### PR TITLE
Fix --debug flag when trying to debug subcommands

### DIFF
--- a/packages/cms-cli/commands/main.js
+++ b/packages/cms-cli/commands/main.js
@@ -1,5 +1,4 @@
 const { version } = require('../package.json');
-const { addLoggerOptions } = require('../lib/commonOpts');
 const { addHelpUsageTracking } = require('../lib/usageTracking');
 
 function configureMainCommand(program) {
@@ -31,7 +30,6 @@ function configureMainCommand(program) {
     .command('secrets', 'manage HubSpot secrets')
     .command('logs', 'get logs for a function');
 
-  addLoggerOptions(program);
   addHelpUsageTracking(program);
 }
 


### PR DESCRIPTION
The main option gets swallowed.

See https://github.com/tj/commander.js/issues/563#issuecomment-520112985

@miketalley