### PR TITLE
Support id in default account

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "prettier:write": "prettier --write 'packages/**/*.{js,json}'",
     "publish-release": "yarn lerna publish --conventional-graduate",
     "publish-prerelease": "yarn lerna publish prerelease --preid beta --dist-tag next",
-    "test": "jest --no-colors",
-    "jest": "jest --watch --no-colors",
+    "test": "jest",
+    "jest": "jest --watch",
     "circular-deps": "yarn madge --circular packages"
   },
   "lint-staged": {

--- a/packages/cms-lib/__tests__/schema.js
+++ b/packages/cms-lib/__tests__/schema.js
@@ -1,4 +1,5 @@
 const { cleanSchema, writeSchemaToDisk, logSchemas } = require('../schema');
+const chalk = require('chalk');
 const basic = require('./fixtures/schema/basic.json');
 const full = require('./fixtures/schema/full.json');
 const { getCwd } = require('@hubspot/cms-lib/path');
@@ -36,6 +37,7 @@ describe('cms-lib/schema', () => {
   describe('logSchemas()', () => {
     it('logs schemas', () => {
       const spy = jest.spyOn(logger, 'log');
+      chalk.level = 0;
       logSchemas([basic]);
       expect(spy.mock.calls[0][0]).toMatchSnapshot();
     });

--- a/packages/cms-lib/lib/__tests__/config.js
+++ b/packages/cms-lib/lib/__tests__/config.js
@@ -124,6 +124,15 @@ describe('lib/config', () => {
     it('returns defaultAccount from config', () => {
       expect(getAccountId()).toEqual(PERSONAL_ACCESS_KEY_CONFIG.accountId);
     });
+
+    it('supports defaultAccount also being an accountId', () => {
+      setConfig({
+        defaultAccount: PERSONAL_ACCESS_KEY_CONFIG.accountId,
+        accounts: ACCOUNTS,
+      });
+
+      expect(getAccountId()).toEqual(PERSONAL_ACCESS_KEY_CONFIG.accountId);
+    });
   });
 
   describe('updateDefaultAccount method', () => {

--- a/packages/cms-lib/lib/config.js
+++ b/packages/cms-lib/lib/config.js
@@ -425,33 +425,20 @@ const getAccountConfig = accountId =>
 /*
  * Returns a accountId from the config if it exists, else returns null
  */
-const getAccountId = nameOrId => {
+const getAccountId = _nameOrId => {
   const config = getAndLoadConfigIfNeeded();
-  let name;
-  let accountId;
-  let account;
 
-  if (!nameOrId) {
-    const defaultAccount = getConfigDefaultAccount(config);
-
-    if (defaultAccount) {
-      name = defaultAccount;
-    }
-  } else {
-    if (typeof nameOrId === 'number') {
-      accountId = nameOrId;
-    } else if (/^\d+$/.test(nameOrId)) {
-      accountId = parseInt(nameOrId, 10);
-    } else {
-      name = nameOrId;
-    }
+  let nameOrId = _nameOrId || getConfigDefaultAccount(config);
+  if (/^\d+$/.test(nameOrId)) {
+    nameOrId = parseInt(nameOrId, 10);
   }
 
   const accounts = getConfigAccounts(config);
-  if (name) {
-    account = accounts.find(p => p.name === name);
-  } else if (accountId) {
-    account = accounts.find(p => [p.accountId, p.portalId].includes(accountId));
+  let account;
+  if (nameOrId) {
+    account = accounts.find(
+      a => a.name === nameOrId || [a.accountId, a.portalId].includes(nameOrId)
+    );
   }
 
   if (account) {


### PR DESCRIPTION
## Description and Context
Will noticed we don't support ids for defaultAccount/defaultPortal.  This adds that functionality

https://hubspot.slack.com/archives/CDW3REULW/p1605016464473800?thread_ts=1604673892.447200&cid=CDW3REULW

## Screenshots
![2020-11-10 09 34 50](https://user-images.githubusercontent.com/5521743/98687778-202ea280-2338-11eb-88c9-3c67db192b8d.gif)

## Who to Notify
@williamspiro 


