### PR TITLE
Updated endpoint used for build/deploy which supports polling and added polling

### DIFF
--- a/packages/cli-lib/api/functions.js
+++ b/packages/cli-lib/api/functions.js
@@ -15,12 +15,18 @@ async function getRoutes(accountId) {
   });
 }
 
-async function buildPackage(portalId, path) {
+async function buildPackage(portalId, folderPath) {
   return http.post(portalId, {
-    uri: `${FUNCTION_API_PATH}/package`,
+    uri: `${FUNCTION_API_PATH}/build`,
     body: {
-      path,
+      folderPath,
     },
+  });
+}
+
+async function pollBuild(portalId, buildId) {
+  return http.get(portalId, {
+    uri: `${FUNCTION_API_PATH}/build/${buildId}/poll`,
   });
 }
 
@@ -37,4 +43,5 @@ module.exports = {
   deletePackage,
   getFunctionByPath,
   getRoutes,
+  pollBuild,
 };

--- a/packages/cli-lib/api/functions.js
+++ b/packages/cli-lib/api/functions.js
@@ -1,6 +1,4 @@
 const http = require('../http');
-const { fetchRawAssetByPath } = require('./designManager');
-
 const FUNCTION_API_PATH = 'cms/v3/functions';
 
 async function getFunctionByPath(accountId, functionPath) {
@@ -30,17 +28,8 @@ async function getBuildStatus(portalId, buildId) {
   });
 }
 
-async function deletePackage(portalId, path) {
-  return fetchRawAssetByPath(portalId, path).then(resp => {
-    return http.delete(portalId, {
-      uri: `${FUNCTION_API_PATH}/package?portalId=${portalId}&rawAssetId=${resp.id}`,
-    });
-  });
-}
-
 module.exports = {
   buildPackage,
-  deletePackage,
   getBuildStatus,
   getFunctionByPath,
   getRoutes,

--- a/packages/cli-lib/api/functions.js
+++ b/packages/cli-lib/api/functions.js
@@ -24,7 +24,7 @@ async function buildPackage(portalId, folderPath) {
   });
 }
 
-async function pollBuild(portalId, buildId) {
+async function getBuildStatus(portalId, buildId) {
   return http.get(portalId, {
     uri: `${FUNCTION_API_PATH}/build/${buildId}/poll`,
   });
@@ -41,7 +41,7 @@ async function deletePackage(portalId, path) {
 module.exports = {
   buildPackage,
   deletePackage,
+  getBuildStatus,
   getFunctionByPath,
   getRoutes,
-  pollBuild,
 };

--- a/packages/cli/commands/functions/deploy.js
+++ b/packages/cli/commands/functions/deploy.js
@@ -21,7 +21,7 @@ const { logger } = require('@hubspot/cli-lib/logger');
 const {
   buildPackage,
   deletePackage,
-  pollBuild,
+  getBuildStatus,
 } = require('@hubspot/cli-lib/api/functions');
 const { validateAccount } = require('../../lib/validation');
 
@@ -34,7 +34,7 @@ const makeSpinner = (actionText, functionPath, accountIdentifier) => {
 const pollBuildStatus = (accountId, buildId) => {
   return new Promise((resolve, reject) => {
     const pollInterval = setInterval(async () => {
-      const pollResp = await pollBuild(accountId, buildId);
+      const pollResp = await getBuildStatus(accountId, buildId);
       const { status } = pollResp;
 
       if (status === 'SUCCESS') {

--- a/packages/cli/commands/functions/deploy.js
+++ b/packages/cli/commands/functions/deploy.js
@@ -43,7 +43,7 @@ const pollBuildStatus = (accountId, buildId) => {
         clearInterval(pollInterval);
         reject(pollResp);
       }
-    }, 1000);
+    }, 5000);
   });
 };
 


### PR DESCRIPTION
## Description and Context
Changed custom serverless build endpoint from `cms/v3/functions/package` to `cms/v3/functions/build` which returns a `buildId`. This is used to poll `cms/v3/functions/build/((id))/poll` for build status.

This update does not change anything visibly or from a flow standpoint, it is done to allow polling to be done instead of having the BE endpoint only respond when the build has completed.

The `--delete` option has also been removed from the `hs functions deploy` command as the backend handles properly deleting associated built packages when serverless function folders are deleted.

## Who to Notify
@bkrainer @gcorne @williamspiro 
