### PR TITLE
Fix label in module creation flow

### DIFF
--- a/packages/cms-cli/commands/create.js
+++ b/packages/cms-cli/commands/create.js
@@ -57,9 +57,9 @@ const PROJECT_REPOSITORIES = {
 const SUPPORTED_ASSET_TYPES = commaSeparatedValues(Object.values(TYPES));
 
 const createModule = (moduleDefinition, name, dest) => {
-  const writeModuleMeta = ({ contentTypes, label, global }, dest) => {
+  const writeModuleMeta = ({ contentTypes, moduleLabel, global }, dest) => {
     const metaData = {
-      label: label,
+      label: moduleLabel,
       css_assets: [],
       external_js: [],
       global: global,


### PR DESCRIPTION
## Description and Context
Fixes #395 

Previously, the `create module` command would prompt for a label value but not correctly set it in the `meta.json` file

## Screenshots
<!-- Provide images of the before and after functionality -->
![image](https://user-images.githubusercontent.com/9009552/103967628-65046900-5130-11eb-9461-2669e26c099c.png)


