### PR TITLE
Build logs are displayed on build completion

### DIFF
--- a/packages/cli/commands/functions/deploy.js
+++ b/packages/cli/commands/functions/deploy.js
@@ -66,6 +66,11 @@ const logBuildOutput = async resp => {
     try {
       https
         .get(resp.cdnUrl, response => {
+          // If the cdnUrl is not found, just display success message
+          if (response.statusCode === 404) {
+            resolve('');
+          }
+
           let data = '';
           response.on('data', chunk => {
             data += chunk;

--- a/packages/cli/commands/functions/deploy.js
+++ b/packages/cli/commands/functions/deploy.js
@@ -129,7 +129,8 @@ exports.handler = async options => {
       logger.error(e.error.message);
     } else if (e.status === 'ERROR') {
       const buildOutput = await logBuildOutput(e);
-      logger.error(`Build error: ${e.errorReason}\n${buildOutput}`);
+      logger.log(buildOutput);
+      logger.error(`Build error: ${e.errorReason}`);
     } else {
       logApiErrorInstance(
         accountId,

--- a/packages/cli/commands/functions/deploy.js
+++ b/packages/cli/commands/functions/deploy.js
@@ -117,8 +117,9 @@ exports.handler = async options => {
     const buildTimeSeconds = (successResp.buildTime / 1000).toFixed(2);
     spinner.stop();
     const buildOutput = await logBuildOutput(successResp);
+    logger.log(buildOutput);
     logger.success(
-      `Successfully built and deployed bundle from package.json for ${functionPath} on account ${accountId} in ${buildTimeSeconds}s. Build output: \n${buildOutput}`
+      `Built and deployed bundle from package.json for ${functionPath} on account ${accountId} in ${buildTimeSeconds}s.`
     );
   } catch (e) {
     spinner && spinner.stop && spinner.stop();


### PR DESCRIPTION
## Description and Context
On `ERROR` and `SUCCESS` of build/deploy, there is a `cdnUrl` property that is attached that links to the log output of the build. This PR fetches this content and displays it for the user when running the `hs functions deploy` command.

## Screenshots
Success output
![image](https://user-images.githubusercontent.com/6472448/104619382-ce6a0780-565b-11eb-8ded-ecbefa59c7bc.png)

Error output
![image](https://user-images.githubusercontent.com/6472448/104619566-05d8b400-565c-11eb-8333-614cb4cd0676.png)


## Who to Notify
@bkrainer @williamspiro 