### PR TITLE
Remove log output payload

### DIFF
--- a/packages/cli-lib/lib/logs.js
+++ b/packages/cli-lib/lib/logs.js
@@ -1,4 +1,3 @@
-const util = require('util');
 const moment = require('moment');
 const chalk = require('chalk');
 const { logger, Styles } = require('../logger');
@@ -24,12 +23,8 @@ const logHandler = {
     return `${formatLogHeader(log)}${compact ? '' : formatError(log)}`;
   },
   SUCCESS: (log, { compact }) => {
-    return `${formatLogHeader(log)}${compact ? '' : formatLogPayloadData(log)}`;
+    return `${formatLogHeader(log)}${compact ? '' : `\n${formatLog(log)}`}`;
   },
-};
-
-const formatLogPayloadData = log => {
-  return `\n${formatPayload(log)}\n${formatLog(log)}`;
 };
 
 const formatLogHeader = log => {
@@ -55,14 +50,6 @@ const formatStackTrace = log => {
 
 const formatTimestamp = log => {
   return `${chalk.whiteBright(moment(log.createdAt).toISOString())}`;
-};
-
-const formatPayload = log => {
-  return util.inspect(log.payload, {
-    colors: true,
-    compact: true,
-    depth: 'Infinity',
-  });
 };
 
 const formatExecutionTime = log => {

--- a/packages/cli-lib/lib/logs.js
+++ b/packages/cli-lib/lib/logs.js
@@ -10,17 +10,15 @@ const LOG_STATUS_COLORS = {
 };
 
 const formatError = log => {
-  return `/n${log.error.type}: ${log.error.message}\n${formatStackTrace(
-    log
-  )}\n`;
+  return `${log.error.type}: ${log.error.message}\n${formatStackTrace(log)}`;
 };
 
 const logHandler = {
   UNHANDLED_ERROR: (log, { compact }) => {
-    return `${formatLogHeader(log)}${compact ? '' : formatError(log)}`;
+    return `${formatLogHeader(log)}${compact ? '' : `\n${formatError(log)}`}`;
   },
   HANDLED_ERROR: (log, { compact }) => {
-    return `${formatLogHeader(log)}${compact ? '' : formatError(log)}`;
+    return `${formatLogHeader(log)}${compact ? '' : `\n${formatError(log)}`}`;
   },
   SUCCESS: (log, { compact }) => {
     return `${formatLogHeader(log)}${compact ? '' : `\n${formatLog(log)}`}`;


### PR DESCRIPTION
## Description and Context
The `payload` property has been removed from the BE code(see PR 176 in the BE repo). The output is being updated to prevent `undefined` from being logged every time because there is no longer `payload` data.

- Also fixed a small visual bug with error output due to `/n` being used instead of `\n`.

## Who to Notify
@bkrainer -- Thanks for your help in tracking this down!