### PR TITLE
Add messaging to use new package

### DIFF
--- a/packages/cms-cli/bin/cli.js
+++ b/packages/cms-cli/bin/cli.js
@@ -8,7 +8,7 @@ const { logger } = require('@hubspot/cms-lib/logger');
 const { logErrorInstance } = require('@hubspot/cms-lib/errorHandlers');
 const { setLogLevel, getCommandName } = require('../lib/commonOpts');
 const { trackHelpUsage } = require('../lib/usageTracking');
-const { version } = require('../package.json');
+const pkg = require('../package.json');
 
 const removeCommand = require('../commands/remove');
 const initCommand = require('../commands/init');
@@ -28,16 +28,15 @@ const listCommand = require('../commands/list');
 const openCommand = require('../commands/open');
 const mvCommand = require('../commands/mv');
 
-// Point update-notifier towards @hubspot/cli
-const pkg = { name: '@hubspot/cli', version };
+const notifier = updateNotifier({ pkg: { ...pkg, name: '@hubspot/cli' } });
 
-const notifier = updateNotifier({ pkg });
+const CLI_UPGRADE_MESSAGE =
+  chalk.bold('The CMS CLI is now the HubSpot CLI') +
+  '\n\nTo upgrade, run:\n\nnpm uninstall -g @hubspot/cms-cli\nand npm install -g @hubspot/cli';
 
 notifier.notify({
   shouldNotifyInNpmScript: true,
-  message:
-    chalk.bold('The CMS CLI is now the HubSpot CLI') +
-    '\n\nTo upgrade, run:\n\nnpm uninstall -g @hubspot/cms-cli\nand npm install -g @hubspot/cli',
+  message: pkg.name === '@hubspot/cms-cli' ? CLI_UPGRADE_MESSAGE : null,
 });
 
 const argv = yargs

--- a/packages/cms-cli/bin/cli.js
+++ b/packages/cms-cli/bin/cli.js
@@ -2,12 +2,13 @@
 
 const yargs = require('yargs');
 const updateNotifier = require('update-notifier');
+const chalk = require('chalk');
 
 const { logger } = require('@hubspot/cms-lib/logger');
 const { logErrorInstance } = require('@hubspot/cms-lib/errorHandlers');
 const { setLogLevel, getCommandName } = require('../lib/commonOpts');
 const { trackHelpUsage } = require('../lib/usageTracking');
-const pkg = require('../package.json');
+const { version } = require('../package.json');
 
 const removeCommand = require('../commands/remove');
 const initCommand = require('../commands/init');
@@ -27,10 +28,16 @@ const listCommand = require('../commands/list');
 const openCommand = require('../commands/open');
 const mvCommand = require('../commands/mv');
 
+// Point update-notifier towards @hubspot/cli
+const pkg = { name: '@hubspot/cli', version };
+
 const notifier = updateNotifier({ pkg });
 
 notifier.notify({
   shouldNotifyInNpmScript: true,
+  message:
+    chalk.bold('The CMS CLI is now the HubSpot CLI') +
+    '\n\nTo upgrade, run:\n\nnpm uninstall -g @hubspot/cms-cli\nand npm install -g @hubspot/cli',
 });
 
 const argv = yargs


### PR DESCRIPTION
## Description and Context
Steers `update-notifier` towards the new package `@hubspot/cli` and adds a custom message with upgrade instructions. Open to feedback on this.

## Screenshots
<!-- Provide images of the before and after functionality -->
![image](https://user-images.githubusercontent.com/9009552/104783195-7dd5d580-5753-11eb-9665-49292cc30886.png)