### PR TITLE
Update serverless-dev-runtime README

### DIFF
--- a/packages/serverless-dev-runtime/README.md
+++ b/packages/serverless-dev-runtime/README.md
@@ -2,34 +2,24 @@
 
 A serverless function development runtime that can be used to test CMS serverless functions. This is intended for use with the [CMS CLI](https://developers.hubspot.com/docs/cms/developer-reference/local-development-cms-cli).
 
+⚠️ **This is a BETA release that uses some HubSpot features that are not available to all customer accounts. Please refer to the HubSpot [Developer Beta Terms](https://legal.hubspot.com/developerbetaterms)** ⚠️
+
 ## Getting started
 
-For more information on using these tools, see [Local Development Tooling: Getting Started](https://designers.hubspot.com/tutorials/getting-started-with-local-development)
-
-### Installation
-
-#### Using `yarn`
-
-```bash
-yarn add @hubspot/cms-cli --dev
-```
-
-#### Using `npm`
-
-```bash
-npm install @hubspot/cms-cli
-```
+For more information on using these tools, see [Local Development Tooling: Getting Started](https://designers.hubspot.com/tutorials/getting-started-with-local-development).
 
 ### Usage
 
-#### CLI Command
-To run the CLI command to test a local serverless function run...
+#### CLI Command (recommended)
+Using the CLI to run serverless functions locally, requires installing [@hubspot/cli](https://www.npmjs.com/package/@hubspot/cms-cli). Once installed, to test your functions run…
+
 ```bash
-hs functions <localDotFunctionsFolderPath>
+hs functions test <folder.functions>
 ```
 
 #### Importing
-To start the server, the `start` method can be imported from the `@hubspot/serverless-dev-runtime` package and run with settings like so...
+
+It also is possible to use the runtime inside your own tooling. To start the server, the `start` method can be imported from the `@hubspot/serverless-dev-runtime` package and run with settings like so...
 
 ```bash
 const { start } = require('@hubspot/serverless-dev-runtime');

--- a/packages/serverless-dev-runtime/package.json
+++ b/packages/serverless-dev-runtime/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "A tool for testing HubSpot CMS serverless functions locally",
   "main": "index.js",
-  "repository": "https://github.com/HubSpot/hubspot-cms-tools",
+  "repository": "https://github.com/HubSpot/hubspot-cli",
   "license": "Apache-2.0",
   "dependencies": {
     "@hubspot/cli-lib": "^2.2.3-beta.3",

--- a/packages/webpack-cms-plugins/README.md
+++ b/packages/webpack-cms-plugins/README.md
@@ -1,6 +1,6 @@
 # `@hubspot/webpack-cms-plugins`
 
-The `@hubspot/webpack-cms-plugins` packages contains plugins designed to make using webpack to compile HubSpot CMS assets more straightforward. Instead of using `webpack-dev-server`, the idea is to use generate assets locally and then upload them to the HubSpot CMS for previewing and testing. The plugin is designed to work together with [@hubspot/cms-cli](https://www.npmjs.com/package/@hubspot/cms-cli).
+The `@hubspot/webpack-cms-plugins` packages contains plugins designed to make using webpack to compile HubSpot CMS assets more straightforward. Instead of using `webpack-dev-server`, the idea is to use generate assets locally and then upload them to the HubSpot CMS for previewing and testing. The plugin is designed to work together with [@hubspot/cli](https://www.npmjs.com/package/@hubspot/cli).
 
 ## Why is this needed?
 


### PR DESCRIPTION
Update to add BETA terms, fix usage, and refer to `@hubspot/cli` instead of `@hubspot/cms-cli`.

@miketalley