### PR TITLE
Remove some sort of debug log statement that is cluttering upload logs

### DIFF
--- a/packages/cli-lib/api/fileMapper.js
+++ b/packages/cli-lib/api/fileMapper.js
@@ -53,7 +53,6 @@ function createFileMapperNodeFromStreamResponse(filePath, response) {
  * @returns {Promise}
  */
 async function upload(accountId, src, dest, options = {}) {
-  console.log('upload: ', fs.createReadStream(path.resolve(getCwd(), src)));
   return http.post(accountId, {
     uri: `${FILE_MAPPER_API_PATH}/upload/${encodeURIComponent(dest)}`,
     formData: {


### PR DESCRIPTION
Looks like this was added via #389 so only needs to go to `master`.