### PR TITLE
enable api-sample type in create command for testing, remove it from …

### DIFF
--- a/packages/cli/commands/create.js
+++ b/packages/cli/commands/create.js
@@ -70,7 +70,9 @@ const PROJECT_REPOSITORIES = {
   [TYPES['api-sample']]: 'sample-apps-list',
 };
 
-const SUPPORTED_ASSET_TYPES = commaSeparatedValues(Object.values(TYPES));
+const SUPPORTED_ASSET_TYPES = commaSeparatedValues(
+  Object.values(TYPES).filter(type => type !== 'api-sample')
+);
 
 const createModule = (moduleDefinition, name, dest) => {
   const writeModuleMeta = ({ contentTypes, moduleLabel, global }, dest) => {
@@ -301,8 +303,6 @@ exports.builder = yargs => {
   yargs.positional('type', {
     describe: 'Type of asset',
     type: 'string',
-    // temporarily disable showing api-sample for users, since it's in beta
-    choices: Object.values(TYPES).filter(type => type !== 'api-sample'),
   });
   yargs.positional('name', {
     describe: 'Name of new asset',


### PR DESCRIPTION

## Description and Context
The reason is that we have a new type of asset called api-sample, but currently it cannot be used within `hs create` command, and since it's in beta, we want to only hide it from `--help` description but leave the ability to test it using cli.

## Screenshots


## TODO

## Who to Notify
