### PR TITLE
Fix filemanager upload bugs

### DIFF
--- a/packages/cms-lib/api/fileManager.js
+++ b/packages/cms-lib/api/fileManager.js
@@ -19,6 +19,8 @@ async function uploadFile(accountId, src, dest) {
 
   if (directory && directory !== '.' && directory !== '/') {
     formData.folderPath = directory;
+  } else {
+    formData.folderPath = '/';
   }
 
   return http.post(accountId, {

--- a/packages/cms-lib/api/fileManager.js
+++ b/packages/cms-lib/api/fileManager.js
@@ -17,7 +17,7 @@ async function uploadFile(accountId, src, dest) {
     }),
   };
 
-  if (directory && directory !== '.' && directory !== '/') {
+  if (directory && directory !== '.') {
     formData.folderPath = directory;
   } else {
     formData.folderPath = '/';


### PR DESCRIPTION
## Description and Context
When uploading files to the root of the file manager, and files within a sub directory will upload ok, but if a file uploads to the root directly, the upload fails.

For example, if you run `hs filemanager upload folder /` you would expect `folder` and all of its contents to be uploaded to the root of the account's file manager. However, files that are direct children of `folder` fail to upload

```
folder
- image.png [FAIL]
- index.html [FAIL]
  subFolder
  - file.txt [UPLOADS]
```

The files v3 api requires that either `folderId` or `folderPath` are set, and in this case we were leaving it empty when a files destination is `/`. This PR changes this and sends `'folderPath: '/' when a folder should be written to the root of the file manager
