### PR TITLE
Make webpack autoupload plugin compatible with webpack 5

### DIFF
--- a/packages/webpack-cms-plugins/HubSpotAutoUploadPlugin.js
+++ b/packages/webpack-cms-plugins/HubSpotAutoUploadPlugin.js
@@ -14,7 +14,7 @@ const {
   setLogLevel,
   setLogger,
 } = require('@hubspot/cli-lib/logger');
-
+const path = require('path');
 setLogLevel(LOG_LEVEL.LOG);
 loadConfig();
 checkAndWarnGitInclusion();
@@ -35,34 +35,29 @@ class HubSpotAutoUploadPlugin {
     setLogger(webpackLogger);
     compiler.hooks.afterEmit.tapPromise(pluginName, async compilation => {
       Object.keys(compilation.assets).forEach(filename => {
-        const asset = compilation.assets[filename];
-        // assets with `emitted = false` haven't changed since the previous compilation
-        if (asset.emitted) {
-          const filepath = asset.existsAt;
+        const outputPath = compilation.getPath(compilation.compiler.outputPath);
+        const filepath = path.join(outputPath, filename);
 
-          if (!this.autoupload || !isAllowedExtension(filepath)) {
-            return;
-          }
-
-          const dest = `${this.dest}/${filename}`;
-          upload(this.accountId, asset.existsAt, dest)
-            .then(() => {
-              webpackLogger.info(
-                `Uploaded ${dest} to account ${this.accountId}`
-              );
-            })
-            .catch(error => {
-              webpackLogger.error(`Uploading ${dest} failed`);
-              logApiUploadErrorInstance(
-                error,
-                new ApiErrorContext({
-                  accountId: this.accountId,
-                  request: dest,
-                  payload: filepath,
-                })
-              );
-            });
+        if (!this.autoupload || !isAllowedExtension(filepath)) {
+          return;
         }
+
+        const dest = `${this.dest}/${filename}`;
+        upload(this.accountId, filepath, dest)
+          .then(() => {
+            webpackLogger.info(`Uploaded ${dest} to account ${this.accountId}`);
+          })
+          .catch(error => {
+            webpackLogger.error(`Uploading ${dest} failed`);
+            logApiUploadErrorInstance(
+              error,
+              new ApiErrorContext({
+                accountId: this.accountId,
+                request: dest,
+                payload: filepath,
+              })
+            );
+          });
       });
     });
   }


### PR DESCRIPTION
## Description and Context
In Webpack 5, a bunch of data was removed from the `afterEmit` callback that this plugin relied on:
- the `emitted` boolean property
- the `existsAt` property

This update removes the dependency on those values and builds the `filepath` manually.

This does require `.getPath()` which is only in webpack >= v4.40. I'm curious if anyone has concerns about supporting earlier versions?
