### PR TITLE
Serverless local testing misc fixes

### DIFF
--- a/packages/serverless-dev-runtime/lib/routes.js
+++ b/packages/serverless-dev-runtime/lib/routes.js
@@ -74,7 +74,7 @@ const addEndpointToApp = endpointData => {
         trackedLogs.push(args);
       };
       const functionExecutionCallback = sendResponseValue => {
-        const { statusCode, body } = sendResponseValue;
+        const { statusCode, body, headers = {} } = sendResponseValue;
         const endTime = Date.now();
         const memoryUsed = process.memoryUsage().heapUsed / 1024 / 1024;
         console.log = originalConsoleLog;
@@ -110,14 +110,17 @@ const addEndpointToApp = endpointData => {
           },
         });
         outputTrackedLogs(trackedLogs);
-        res.status(statusCode).json(body);
+        res
+          .status(statusCode)
+          .set(headers)
+          .send(body);
       };
 
       await main(dataForFunc, functionExecutionCallback);
     } catch (e) {
       console.log = originalConsoleLog;
       logger.error(e);
-      res.status(500).json(e);
+      res.status(500).send(e);
     }
   });
 };

--- a/packages/serverless-dev-runtime/lib/secrets.js
+++ b/packages/serverless-dev-runtime/lib/secrets.js
@@ -28,7 +28,7 @@ const getSecrets = (dotEnvConfig, allowedSecrets) => {
   return secretsDict;
 };
 
-const getMockedDataFromDotEnv = dotEnvConfig => {
+const getMockedDataFromDotEnv = (dotEnvConfig = {}) => {
   let mockedDataDict = {};
 
   Object.keys(MOCK_DATA).forEach(mockValue => {


### PR DESCRIPTION
## Description and Context
MIsc fixes for serverless local testing.

- Error when no `.env` file is provided to a function
- `headers` returned in serverless function response are now properly passed to express response
