### PR TITLE
Start returns promise now to allow await to be used

### DIFF
--- a/packages/serverless-dev-runtime/lib/server.js
+++ b/packages/serverless-dev-runtime/lib/server.js
@@ -183,7 +183,7 @@ const start = async props => {
   if (watch) {
     watchFolder(functionPath, restartServer);
   }
-  startServer();
+  return startServer();
 };
 
 module.exports = {


### PR DESCRIPTION
## Description and Context
The start method within `serverless-dev-runtime` was not returning a value. This PR adds the `return` keyword so it returns the promise.
