### PR TITLE
Added --log-output option to console log payload body for local testing

### DIFF
--- a/packages/cli/commands/functions/test.js
+++ b/packages/cli/commands/functions/test.js
@@ -70,6 +70,11 @@ exports.builder = yargs => {
     type: 'boolean',
     default: true,
   });
+  yargs.option('log-output', {
+    describe: 'output the response body from the serverless function execution',
+    type: 'boolean',
+    default: false,
+  });
 
   yargs.example([
     [

--- a/packages/cli/commands/functions/test.js
+++ b/packages/cli/commands/functions/test.js
@@ -71,7 +71,8 @@ exports.builder = yargs => {
     default: true,
   });
   yargs.option('log-output', {
-    describe: 'output the response body from the serverless function execution',
+    describe:
+      'output the response body from the serverless function execution (It is suggested not to use this in production environments as it can reveal any secure data returned by the function in logs)',
     type: 'boolean',
     default: false,
   });

--- a/packages/serverless-dev-runtime/lib/routes.js
+++ b/packages/serverless-dev-runtime/lib/routes.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const util = require('util');
 const fs = require('fs-extra');
 const { logger } = require('@hubspot/cli-lib/logger');
 const { getFunctionDataContext } = require('./data');
@@ -109,6 +110,15 @@ const addEndpointToApp = endpointData => {
             },
           },
         });
+        if (options.logOutput) {
+          logger.log(
+            util.inspect(body, {
+              colors: true,
+              compact: true,
+              depth: 'Infinity',
+            })
+          );
+        }
         outputTrackedLogs(trackedLogs);
         res
           .status(statusCode)


### PR DESCRIPTION
## Description and Context
The function execution return value is not logged anywhere for easy viewing when running the `hs functions test` command. This PR adds the `--log-output` option that can be used to log this output. The default value is `false` for this option to mimic production.

## Screenshots
![image](https://user-images.githubusercontent.com/6472448/106166610-58d16180-615a-11eb-867d-bd256a41103d.png)

## Who to Notify
@TheWebTech - As discussed in the comments of the getting started doc.