### PR TITLE
Handled exception if log does not contain error value

### DIFF
--- a/packages/cli-lib/lib/logs.js
+++ b/packages/cli-lib/lib/logs.js
@@ -11,9 +11,7 @@ const LOG_STATUS_COLORS = {
 };
 
 const errorHandler = (log, options) => {
-  return `${formatLogHeader(log, options)}${
-    options.compact ? '' : `\n${formatError(log)}`
-  }`;
+  return `${formatLogHeader(log, options)}${formatError(log, options)}`;
 };
 
 const logHandler = {
@@ -33,8 +31,8 @@ const formatSuccess = (log, options) => {
   return `\n${log.log}`;
 };
 
-const formatError = log => {
-  if (!log.error) {
+const formatError = (log, options) => {
+  if (!log.error || options.compact) {
     return '';
   }
 

--- a/packages/cli-lib/lib/logs.js
+++ b/packages/cli-lib/lib/logs.js
@@ -9,26 +9,29 @@ const LOG_STATUS_COLORS = {
   HANDLED_ERROR: Styles.error,
 };
 
-const formatError = log => {
-  return `${log.error.type}: ${log.error.message}\n${formatStackTrace(log)}`;
+const errorHandler = (log, options) => {
+  return `${formatLogHeader(log, options)}${
+    options.compact ? '' : `\n${formatError(log)}`
+  }`;
 };
 
 const logHandler = {
-  UNHANDLED_ERROR: (log, options) => {
-    return `${formatLogHeader(log, options)}${
-      options.compact ? '' : `\n${formatError(log)}`
-    }`;
-  },
-  HANDLED_ERROR: (log, options) => {
-    return `${formatLogHeader(log, options)}${
-      options.compact ? '' : `\n${formatError(log)}`
-    }`;
-  },
+  ERROR: errorHandler,
+  UNHANDLED_ERROR: errorHandler,
+  HANDLED_ERROR: errorHandler,
   SUCCESS: (log, options) => {
     return `${formatLogHeader(log, options)}${
       options.compact ? '' : `\n${log.log}`
     }`;
   },
+};
+
+const formatError = log => {
+  if (!log.error) {
+    return '';
+  }
+
+  return `${log.error.type}: ${log.error.message}\n${formatStackTrace(log)}`;
 };
 
 const formatLogHeader = (log, options) => {

--- a/packages/cli-lib/lib/logs.js
+++ b/packages/cli-lib/lib/logs.js
@@ -5,6 +5,7 @@ const { logger, Styles } = require('../logger');
 const SEPARATOR = ' - ';
 const LOG_STATUS_COLORS = {
   SUCCESS: Styles.success,
+  ERROR: Styles.error,
   UNHANDLED_ERROR: Styles.error,
   HANDLED_ERROR: Styles.error,
 };

--- a/packages/cli-lib/lib/logs.js
+++ b/packages/cli-lib/lib/logs.js
@@ -26,11 +26,11 @@ const logHandler = {
 };
 
 const formatSuccess = (log, options) => {
-  if (!log.log) {
+  if (!log.log || options.compact) {
     return '';
   }
 
-  return options.compact ? '' : `\n${log.log}`;
+  return `\n${log.log}`;
 };
 
 const formatError = log => {

--- a/packages/cli-lib/lib/logs.js
+++ b/packages/cli-lib/lib/logs.js
@@ -21,10 +21,16 @@ const logHandler = {
   UNHANDLED_ERROR: errorHandler,
   HANDLED_ERROR: errorHandler,
   SUCCESS: (log, options) => {
-    return `${formatLogHeader(log, options)}${
-      options.compact ? '' : `\n${log.log}`
-    }`;
+    return `${formatLogHeader(log, options)}${formatSuccess(log, options)}`;
   },
+};
+
+const formatSuccess = (log, options) => {
+  if (!log.log) {
+    return '';
+  }
+
+  return options.compact ? '' : `\n${log.log}`;
 };
 
 const formatError = log => {

--- a/packages/serverless-dev-runtime/lib/logging.js
+++ b/packages/serverless-dev-runtime/lib/logging.js
@@ -8,7 +8,6 @@ const logFunctionExecution = ({
   startTime,
   endTime,
   memoryUsed,
-  logs,
   options,
 }) => {
   const runTime = endTime - startTime;
@@ -16,7 +15,6 @@ const logFunctionExecution = ({
   const roundedMemoryUsed = Math.round(memoryUsed);
   const executionData = {
     executionTime: runTime,
-    log: (logs && logs.length && logs.join('\n')) || '',
     duration: `${roundedRuntime} ms`,
     status,
     createdAt: startTime,


### PR DESCRIPTION
## Description and Context
I ran into an issue where the logging of an error encountered an error if there is no `log.error` value. This PR short circuits and does not try to log `log.error` values if there is no `log.error` property.

## Screenshots
Before
![image](https://user-images.githubusercontent.com/6472448/106207161-4aea0380-618f-11eb-9dbf-50a9b77fdb46.png)

After
![image](https://user-images.githubusercontent.com/6472448/106207487-d82d5800-618f-11eb-9067-e526cba486c4.png)
