### PR TITLE
Serverless empathy fixes

### DIFF
--- a/packages/cli/commands/functions.js
+++ b/packages/cli/commands/functions.js
@@ -5,7 +5,7 @@ const {
 } = require('../lib/commonOpts');
 const list = require('./functions/list');
 const deploy = require('./functions/deploy');
-const offline = require('./functions/offline');
+const server = require('./functions/server');
 
 exports.command = 'functions';
 exports.describe = 'Commands for working with functions';
@@ -21,7 +21,7 @@ exports.builder = yargs => {
       aliases: 'ls',
     })
     .command(deploy)
-    .command(offline)
+    .command(server)
     .demandCommand(1, '');
 
   return yargs;

--- a/packages/cli/commands/functions.js
+++ b/packages/cli/commands/functions.js
@@ -5,7 +5,7 @@ const {
 } = require('../lib/commonOpts');
 const list = require('./functions/list');
 const deploy = require('./functions/deploy');
-const test = require('./functions/test');
+const offline = require('./functions/offline');
 
 exports.command = 'functions';
 exports.describe = 'Commands for working with functions';
@@ -21,7 +21,7 @@ exports.builder = yargs => {
       aliases: 'ls',
     })
     .command(deploy)
-    .command(test)
+    .command(offline)
     .demandCommand(1, '');
 
   return yargs;

--- a/packages/cli/commands/functions/deploy.js
+++ b/packages/cli/commands/functions/deploy.js
@@ -65,7 +65,9 @@ const logBuildOutput = async resp => {
   const { cdnUrl } = resp;
 
   if (!cdnUrl) {
-    logger.debug('Unable to display build output. No cdnUrl was provided.');
+    logger.debug(
+      'Unable to display build output. No build log URL was provided.'
+    );
     return;
   }
 

--- a/packages/cli/commands/functions/deploy.js
+++ b/packages/cli/commands/functions/deploy.js
@@ -62,6 +62,13 @@ const loadAndValidateOptions = async options => {
 };
 
 const logBuildOutput = async resp => {
+  const { cdnUrl } = resp;
+
+  if (!cdnUrl) {
+    logger.debug('Unable to display build output. No cdnUrl was provided.');
+    return;
+  }
+
   return new Promise((resolve, reject) => {
     try {
       https
@@ -76,6 +83,7 @@ const logBuildOutput = async resp => {
             data += chunk;
           });
           response.on('end', () => {
+            logger.log(data);
             resolve(data);
           });
         })
@@ -121,8 +129,7 @@ exports.handler = async options => {
     const successResp = await pollBuildStatus(accountId, buildId);
     const buildTimeSeconds = (successResp.buildTime / 1000).toFixed(2);
     spinner.stop();
-    const buildOutput = await logBuildOutput(successResp);
-    logger.log(buildOutput);
+    await logBuildOutput(successResp);
     logger.success(
       `Built and deployed bundle from package.json for ${functionPath} on account ${accountId} in ${buildTimeSeconds}s.`
     );

--- a/packages/cli/commands/functions/offline.js
+++ b/packages/cli/commands/functions/offline.js
@@ -28,7 +28,7 @@ const loadAndValidateOptions = async options => {
   }
 };
 
-exports.command = 'test <path>';
+exports.command = 'offline <path>';
 exports.describe = false;
 
 exports.handler = async options => {
@@ -40,7 +40,7 @@ exports.handler = async options => {
   trackCommandUsage('functions-test', { functionPath }, accountId);
 
   logger.debug(
-    `Starting test server for .functions folder with path: ${functionPath}`
+    `Starting local test server for .functions folder with path: ${functionPath}`
   );
 
   startTestServer({
@@ -79,7 +79,7 @@ exports.builder = yargs => {
 
   yargs.example([
     [
-      '$0 functions test ./tmp/myFunctionFolder.functions',
+      '$0 functions offline ./tmp/myFunctionFolder.functions',
       'Run a local function test server.',
     ],
   ]);

--- a/packages/cli/commands/functions/server.js
+++ b/packages/cli/commands/functions/server.js
@@ -28,7 +28,7 @@ const loadAndValidateOptions = async options => {
   }
 };
 
-exports.command = 'offline <path>';
+exports.command = 'server <path>';
 exports.describe = false;
 
 exports.handler = async options => {
@@ -79,7 +79,7 @@ exports.builder = yargs => {
 
   yargs.example([
     [
-      '$0 functions offline ./tmp/myFunctionFolder.functions',
+      '$0 functions server ./tmp/myFunctionFolder.functions',
       'Run a local function test server.',
     ],
   ]);

--- a/packages/serverless-dev-runtime/lib/files.js
+++ b/packages/serverless-dev-runtime/lib/files.js
@@ -24,13 +24,22 @@ const installDeps = (functionData, folderPath) => {
 
   return new Promise((resolve, reject) => {
     try {
+      let errorData = '';
       const npmInstallProcess = spawn(npmCmd, ['i'], {
         env: process.env,
         cwd: folderPath,
       });
 
-      npmInstallProcess.on('exit', data => {
-        resolve(data);
+      npmInstallProcess.stderr.on('data', data => {
+        errorData += data;
+      });
+
+      npmInstallProcess.on('exit', code => {
+        if (code) {
+          logger.error(`Unable to install dependencies\n${errorData}`);
+          process.exit();
+        }
+        return resolve(code);
       });
     } catch (e) {
       reject(e);

--- a/packages/serverless-dev-runtime/lib/files.js
+++ b/packages/serverless-dev-runtime/lib/files.js
@@ -5,7 +5,7 @@ const tmp = require('tmp');
 const { logger } = require('@hubspot/cli-lib/logger');
 const defaultFunctionPackageJson = require('./templates/default-function-package.json');
 
-const installDeps = folderPath => {
+const installDeps = (functionData, folderPath) => {
   const npmCmd = os.platform().startsWith('win') ? 'npm.cmd' : 'npm';
   const packageJsonPath = `${folderPath}/package.json`;
   const packageJsonExists = fs.existsSync(packageJsonPath);
@@ -18,7 +18,9 @@ const installDeps = folderPath => {
     );
   }
 
-  logger.debug(`Installing dependencies from ${folderPath}/package.json`);
+  logger.log(
+    `Installing dependencies from ${functionData.srcPath}/package.json`
+  );
 
   return new Promise((resolve, reject) => {
     try {
@@ -53,7 +55,7 @@ const createTemporaryFunction = async functionData => {
     errorOnExist: true,
   });
 
-  await installDeps(tmpDir.name);
+  await installDeps(functionData, tmpDir.name);
 
   return {
     ...functionData,

--- a/packages/serverless-dev-runtime/lib/routes.js
+++ b/packages/serverless-dev-runtime/lib/routes.js
@@ -110,6 +110,7 @@ const addEndpointToApp = endpointData => {
             },
           },
         });
+
         if (options.logOutput) {
           logger.log(
             util.inspect(body, {
@@ -119,9 +120,10 @@ const addEndpointToApp = endpointData => {
             })
           );
         }
+
         outputTrackedLogs(trackedLogs);
         res
-          .status(statusCode || (sendResponseValue && 200))
+          .status(statusCode || 200)
           .set(headers)
           .send(body);
       };

--- a/packages/serverless-dev-runtime/lib/routes.js
+++ b/packages/serverless-dev-runtime/lib/routes.js
@@ -122,10 +122,11 @@ const addEndpointToApp = endpointData => {
         }
 
         outputTrackedLogs(trackedLogs);
-        res
-          .status(statusCode || 200)
-          .set(headers)
-          .send(body);
+
+        if (statusCode) {
+          res.status(statusCode);
+        }
+        res.set(headers).send(body);
       };
 
       await main(dataForFunc, functionExecutionCallback);

--- a/packages/serverless-dev-runtime/lib/routes.js
+++ b/packages/serverless-dev-runtime/lib/routes.js
@@ -121,7 +121,7 @@ const addEndpointToApp = endpointData => {
         }
         outputTrackedLogs(trackedLogs);
         res
-          .status(statusCode)
+          .status(statusCode || (sendResponseValue && 200))
           .set(headers)
           .send(body);
       };

--- a/packages/serverless-dev-runtime/lib/secrets.js
+++ b/packages/serverless-dev-runtime/lib/secrets.js
@@ -19,11 +19,13 @@ const getDotEnvConfig = folderPath => {
 const getSecrets = (dotEnvConfig, allowedSecrets) => {
   let secretsDict = {};
 
-  allowedSecrets.forEach(secret => {
-    if (Object.prototype.hasOwnProperty.call(dotEnvConfig, secret)) {
-      secretsDict[secret] = dotEnvConfig[secret];
-    }
-  });
+  if (dotEnvConfig) {
+    allowedSecrets.forEach(secret => {
+      if (Object.prototype.hasOwnProperty.call(dotEnvConfig, secret)) {
+        secretsDict[secret] = dotEnvConfig[secret];
+      }
+    });
+  }
 
   return secretsDict;
 };


### PR DESCRIPTION
## Description and Context
This fixes several issues that were found during the empathy session on 2/3

_Local Serverless Testing_
- Rename `hs functions test` to `hs functions server` @abelb
- Additional logging when dependencies are being installed @phalaphone 
- Errors during spawned `npm install` process will be logged and interrupt the process @brandenrodgers 
- Status will only be set on `res` If a `statusCode` is provided
- Fixed error when testing locally with no `.env` file, but having specified secrets in `serverless.json`

_Serverless Deploy_
- Additional handling if no `cdnUrl` is provided @bkrainer @gkemp94 