### PR TITLE
Updated hs functions server tracking string

### DIFF
--- a/packages/cli/commands/functions/server.js
+++ b/packages/cli/commands/functions/server.js
@@ -37,7 +37,7 @@ exports.handler = async options => {
   const { path: functionPath } = options;
   const accountId = getAccountId(options);
 
-  trackCommandUsage('functions-test', { functionPath }, accountId);
+  trackCommandUsage('functions-server', { functionPath }, accountId);
 
   logger.debug(
     `Starting local test server for .functions folder with path: ${functionPath}`


### PR DESCRIPTION
## Description and Context
Changed from `functions-test` to `functions-server` to coordinate with change to command