### PR TITLE
Updated watch verification text

### DIFF
--- a/packages/cli-lib/lib/watch.js
+++ b/packages/cli-lib/lib/watch.js
@@ -120,7 +120,9 @@ function watch(accountId, src, dest, { mode, remove, disableInitial, notify }) {
   }
 
   watcher.on('ready', () => {
-    logger.log(`Watcher is ready and watching ${src}. Any changes detected will be automatically uploaded and overwrite the current version in the developer file system.`);
+    logger.log(
+      `Watcher is ready and watching ${src}. Any changes detected will be automatically uploaded and overwrite the current version in the developer file system.`
+    );
   });
 
   watcher.on('add', async filePath => {

--- a/packages/cli-lib/lib/watch.js
+++ b/packages/cli-lib/lib/watch.js
@@ -120,7 +120,7 @@ function watch(accountId, src, dest, { mode, remove, disableInitial, notify }) {
   }
 
   watcher.on('ready', () => {
-    logger.log(`Watcher is ready and watching ${src}`);
+    logger.log(`Watcher is ready and watching ${src}. Any changes detected will be automatically uploaded and overwrite the current version in the developer file system.`);
   });
 
   watcher.on('add', async filePath => {


### PR DESCRIPTION
## Description and Context
Looking at feedback from DevHub Explorer days, it seemed there may be some confusion about how the watch task works. In order to prevent this, we can update the watch task confirmation text to be clearer about what will happen when changes are detected.

## Who to Notify
@TheWebTech 
