### PR TITLE
Rename "path" option to "endpoint" in hs logs command for clarity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Change Log
 ==========
 
 ## 3.0.3
+* Updated help text for hs logs ([#448](https://github.com/HubSpot/hubspot-cli/pull/448))
 * Updated watch text to be more explicit about what it does ([#446](https://github.com/HubSpot/hubspot-cli/pull/446))
 * Added endpoint for VSCode usage tracking ([#443](https://github.com/HubSpot/hubspot-cli/pull/443))
 * International characters are handled in remote HS paths ([#442](https://github.com/HubSpot/hubspot-cli/pull/442))

--- a/packages/cli/commands/logs.js
+++ b/packages/cli/commands/logs.js
@@ -114,13 +114,13 @@ const tailLogs = async ({
   tail(initialAfter);
 };
 
-exports.command = 'logs <path>';
+exports.command = 'logs <endpoint>';
 exports.describe = 'get logs for a function';
 
 exports.handler = async options => {
   loadAndValidateOptions(options);
 
-  const { latest, follow, compact, path: functionPath } = options;
+  const { latest, follow, compact, endpoint: functionPath } = options;
   let logsResp;
   const accountId = getAccountId(options);
 
@@ -165,8 +165,8 @@ exports.handler = async options => {
 };
 
 exports.builder = yargs => {
-  yargs.positional('path', {
-    describe: 'Path to serverless function',
+  yargs.positional('endpoint', {
+    describe: 'Serverless function endpoint',
     type: 'string',
   });
   yargs
@@ -192,6 +192,21 @@ exports.builder = yargs => {
       },
     })
     .conflicts('follow', 'limit');
+
+  yargs.example([
+    [
+      '$0 logs my-endpoint',
+      'Get 5 most recent logs for function residing at /_hcms/api/my-endpoint',
+    ],
+    [
+      '$0 logs my-endpoint --limit=10',
+      'Get 10 most recent logs for function residing at /_hcms/api/my-endpoint',
+    ],
+    [
+      '$0 logs my-endpoint --follow',
+      'Poll for and Output logs for function residing at /_hcms/api/my-endpoint immediately upon new execution',
+    ],
+  ]);
 
   addConfigOptions(yargs, true);
   addAccountOptions(yargs, true);

--- a/packages/cli/commands/logs.js
+++ b/packages/cli/commands/logs.js
@@ -204,7 +204,7 @@ exports.builder = yargs => {
     ],
     [
       '$0 logs my-endpoint --follow',
-      'Poll for and Output logs for function residing at /_hcms/api/my-endpoint immediately upon new execution',
+      'Poll for and output logs for function residing at /_hcms/api/my-endpoint immediately upon new execution',
     ],
   ]);
 


### PR DESCRIPTION
## Description and Context
Updates the `hs logs <path>` format to `hs logs <endpoint>` which more accurately represents what value should be provided. This also adds a few examples to the help text to clarify how the command can be used.
