### PR TITLE
Wrap all serverless function params in arrays

### DIFF
--- a/packages/serverless-dev-runtime/lib/data.js
+++ b/packages/serverless-dev-runtime/lib/data.js
@@ -68,6 +68,26 @@ const getHeaders = req => {
   };
 };
 
+// This purposefully puts each param into an array to mimic the way production
+// does it. This should be updated when production is fixed so params work as
+// expected instead of always being an array.
+// See https://git.hubteam.com/HubSpot/ContentServerlessFunctions/pull/228
+const getRequestQueryParams = req => {
+  console.log('getting Request params!', req.query);
+  const paramsObj = {};
+
+  Object.keys(req.query).forEach(param => {
+    const currentValue = req.query[param];
+    const newValue = Array.isArray(currentValue)
+      ? currentValue
+      : [currentValue];
+
+    paramsObj[param] = newValue;
+  });
+
+  return paramsObj;
+};
+
 const getFunctionDataContext = async (
   req,
   functionPath,
@@ -88,7 +108,7 @@ const getFunctionDataContext = async (
   } = getDotEnvData(functionPath, allowedSecrets);
   const data = {
     secrets,
-    params: req.query,
+    params: getRequestQueryParams(req),
     limits: {
       timeRemaining:
         HUBSPOT_LIMITS_TIME_REMAINING ||

--- a/packages/serverless-dev-runtime/lib/data.js
+++ b/packages/serverless-dev-runtime/lib/data.js
@@ -73,7 +73,6 @@ const getHeaders = req => {
 // expected instead of always being an array.
 // See https://git.hubteam.com/HubSpot/ContentServerlessFunctions/pull/228
 const getRequestQueryParams = req => {
-  console.log('getting Request params!', req.query);
   const paramsObj = {};
 
   Object.keys(req.query).forEach(param => {


### PR DESCRIPTION
## Description and Context
There is a known issue with production where all params are wrapped in an array. Initially, the beta for DesignManager:ServerlessPackages was going to include changes to the backend to fix this. This is being removed(https://git.hubteam.com/HubSpot/ContentServerlessFunctions/pull/228/files). To sync the serverless dev runtime, we are going to hard-code the issue for now until it is resolved on the backend again.

## Who to Notify
@bkrainer @rudifer @ajlaporte @TheWebTech 
