### PR TITLE
Adding initial support for project deploys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ npm-debug.log.*
 *.log
 .DS_Store
 coverage
+.env

--- a/packages/cli-lib/api/fileMapper.js
+++ b/packages/cli-lib/api/fileMapper.js
@@ -263,7 +263,6 @@ async function getDirectoryContentsByPath(portalId, path) {
  * @returns {Promise}
  */
 async function deployProject(portalId, projectPath) {
-  console.log('projectPath: ', projectPath);
   return http.post(portalId, {
     uri: `${FILE_MAPPER_API_PATH}/deploy/${encodeURIComponent(projectPath)}`,
   });

--- a/packages/cli-lib/api/fileMapper.js
+++ b/packages/cli-lib/api/fileMapper.js
@@ -255,9 +255,24 @@ async function getDirectoryContentsByPath(portalId, path) {
   });
 }
 
+/**
+ * Deploy project
+ *
+ * @async
+ * @param {string} projectPath
+ * @returns {Promise}
+ */
+async function deployProject(portalId, projectPath) {
+  console.log('projectPath: ', projectPath);
+  return http.post(portalId, {
+    uri: `${FILE_MAPPER_API_PATH}/deploy/${encodeURIComponent(projectPath)}`,
+  });
+}
+
 module.exports = {
   deleteFile,
   deleteFolder,
+  deployProject,
   download,
   downloadDefault,
   fetchFileStream,

--- a/packages/cli-lib/fileMapper.js
+++ b/packages/cli-lib/fileMapper.js
@@ -390,7 +390,7 @@ async function downloadFile(input) {
  * @returns {Promise<FileMapperNode}
  */
 async function fetchFolderFromApi(input) {
-  const { accountId, src, mode } = input;
+  const { accountId, src, mode, options } = input;
   const { isRoot, isFolder, isHubspot } = getTypeDataFromPath(src);
   if (!isFolder) {
     throw new Error(`Invalid request for folder: "${src}"`);
@@ -399,8 +399,14 @@ async function fetchFolderFromApi(input) {
     const srcPath = isRoot ? '@root' : src;
     const qs = getFileMapperApiQueryFromMode(mode);
     const node = isHubspot
-      ? await downloadDefault(accountId, srcPath, { qs })
-      : await download(accountId, srcPath, { qs });
+      ? await downloadDefault(accountId, srcPath, {
+          qs,
+          environmentId: options.staging ? 2 : 1,
+        })
+      : await download(accountId, srcPath, {
+          qs,
+          environmentId: options.staging ? 2 : 1,
+        });
     logger.log(
       'Fetched "%s" from account %d from the Design Manager successfully',
       src,

--- a/packages/cli-lib/fileMapper.js
+++ b/packages/cli-lib/fileMapper.js
@@ -91,11 +91,18 @@ function useApiBuffer(mode) {
 }
 
 /**
- * @param {Mode} mode
+ * Determines API param based on mode an options
+ *
+ * @typedef {Object} APIOptions
+ * @property {Mode} mode
+ * @property {Object} options
  */
-function getFileMapperApiQueryFromMode(mode) {
+function getFileMapperQueryValues({ mode, options = {} }) {
   return {
-    buffer: useApiBuffer(mode),
+    qs: {
+      buffer: useApiBuffer(mode),
+      environmentId: options.staging ? 2 : 1,
+    },
   };
 }
 
@@ -267,9 +274,12 @@ async function fetchAndWriteFileStream(input, srcPath, filepath) {
   const { accountId } = input;
 
   try {
-    const node = await fetchFileStream(accountId, srcPath, filepath, {
-      qs: getFileMapperApiQueryFromMode(input.mode),
-    });
+    const node = await fetchFileStream(
+      accountId,
+      srcPath,
+      filepath,
+      getFileMapperQueryValues(input)
+    );
     await writeUtimes(input, filepath, node);
   } catch (err) {
     logApiErrorInstance(
@@ -390,23 +400,20 @@ async function downloadFile(input) {
  * @returns {Promise<FileMapperNode}
  */
 async function fetchFolderFromApi(input) {
-  const { accountId, src, mode, options } = input;
+  const { accountId, src } = input;
   const { isRoot, isFolder, isHubspot } = getTypeDataFromPath(src);
   if (!isFolder) {
     throw new Error(`Invalid request for folder: "${src}"`);
   }
   try {
     const srcPath = isRoot ? '@root' : src;
-    const qs = getFileMapperApiQueryFromMode(mode);
     const node = isHubspot
-      ? await downloadDefault(accountId, srcPath, {
-          qs,
-          environmentId: options.staging ? 2 : 1,
-        })
-      : await download(accountId, srcPath, {
-          qs,
-          environmentId: options.staging ? 2 : 1,
-        });
+      ? await downloadDefault(
+          accountId,
+          srcPath,
+          getFileMapperQueryValues(input)
+        )
+      : await download(accountId, srcPath, getFileMapperQueryValues(input));
     logger.log(
       'Fetched "%s" from account %d from the Design Manager successfully',
       src,
@@ -498,7 +505,7 @@ module.exports = {
   isPathToHubspot,
   downloadFileOrFolder,
   recurseFolder,
-  getFileMapperApiQueryFromMode,
+  getFileMapperQueryValues,
   fetchFolderFromApi,
   getTypeDataFromPath,
 };

--- a/packages/cli-lib/lib/__tests__/uploadFolder.js
+++ b/packages/cli-lib/lib/__tests__/uploadFolder.js
@@ -49,7 +49,7 @@ describe('uploadFolder', () => {
 
       uploadedFilesInOrder.forEach((file, index) => {
         expect(upload).nthCalledWith(index + 1, accountId, file, file, {
-          qs: { buffer: false },
+          qs: { buffer: false, environmentId: 1 },
         });
       });
     });

--- a/packages/cli-lib/lib/watch.js
+++ b/packages/cli-lib/lib/watch.js
@@ -11,7 +11,7 @@ const {
 } = require('../errorHandlers');
 const { uploadFolder } = require('./uploadFolder');
 const { shouldIgnoreFile, ignoreFile } = require('../ignoreRules');
-const { getFileMapperApiQueryFromMode } = require('../fileMapper');
+const { getFileMapperQueryValues } = require('../fileMapper');
 const { upload, deleteFile } = require('../api/fileMapper');
 const escapeRegExp = require('./escapeRegExp');
 const { convertToUnixPath, isAllowedExtension } = require('../path');
@@ -21,7 +21,7 @@ const queue = new PQueue({
   concurrency: 10,
 });
 
-function uploadFile(accountId, file, dest, { mode }) {
+function uploadFile(accountId, file, dest, options) {
   if (!isAllowedExtension(file)) {
     logger.debug(`Skipping ${file} due to unsupported extension`);
     return;
@@ -32,9 +32,7 @@ function uploadFile(accountId, file, dest, { mode }) {
   }
 
   logger.debug('Attempting to upload file "%s" to "%s"', file, dest);
-  const apiOptions = {
-    qs: getFileMapperApiQueryFromMode(mode),
-  };
+  const apiOptions = getFileMapperQueryValues(options);
   return queue.add(() => {
     return upload(accountId, file, dest, apiOptions)
       .then(() => {

--- a/packages/cli/bin/cli.js
+++ b/packages/cli/bin/cli.js
@@ -27,6 +27,7 @@ const functionsCommand = require('../commands/functions');
 const listCommand = require('../commands/list');
 const openCommand = require('../commands/open');
 const mvCommand = require('../commands/mv');
+const projectCommand = require('../commands/project');
 
 const notifier = updateNotifier({ pkg: { ...pkg, name: '@hubspot/cli' } });
 
@@ -80,6 +81,7 @@ const argv = yargs
   })
   .command(openCommand)
   .command(mvCommand)
+  .command(projectCommand)
   .help()
   .recommendCommands()
   .demandCommand(1, '')

--- a/packages/cli/bin/cli.js
+++ b/packages/cli/bin/cli.js
@@ -27,7 +27,7 @@ const functionsCommand = require('../commands/functions');
 const listCommand = require('../commands/list');
 const openCommand = require('../commands/open');
 const mvCommand = require('../commands/mv');
-const projectCommand = require('../commands/project');
+const projectsCommand = require('../commands/projects');
 
 const notifier = updateNotifier({ pkg: { ...pkg, name: '@hubspot/cli' } });
 
@@ -81,7 +81,7 @@ const argv = yargs
   })
   .command(openCommand)
   .command(mvCommand)
-  .command(projectCommand)
+  .command(projectsCommand)
   .help()
   .recommendCommands()
   .demandCommand(1, '')

--- a/packages/cli/commands/fetch.js
+++ b/packages/cli/commands/fetch.js
@@ -84,7 +84,7 @@ exports.builder = yargs => {
 
   yargs.options({
     staging: {
-      describe: 'retrieve staged changes for project',
+      describe: 'Retrieve staged changes for project',
       type: 'boolean',
       default: false,
     },

--- a/packages/cli/commands/fetch.js
+++ b/packages/cli/commands/fetch.js
@@ -82,5 +82,13 @@ exports.builder = yargs => {
     type: 'string',
   });
 
+  yargs.options({
+    staging: {
+      describe: 'retrieve staged changes for project',
+      type: 'boolean',
+      default: false,
+    },
+  });
+
   return yargs;
 };

--- a/packages/cli/commands/fetch.js
+++ b/packages/cli/commands/fetch.js
@@ -87,6 +87,7 @@ exports.builder = yargs => {
       describe: 'Retrieve staged changes for project',
       type: 'boolean',
       default: false,
+      hidden: true,
     },
   });
 

--- a/packages/cli/commands/project.js
+++ b/packages/cli/commands/project.js
@@ -1,0 +1,19 @@
+const {
+  addConfigOptions,
+  addAccountOptions,
+  addOverwriteOptions,
+} = require('../lib/commonOpts');
+const deploy = require('./projects/deploy');
+
+exports.command = 'project';
+exports.describe = 'Commands for working with projects';
+
+exports.builder = yargs => {
+  addOverwriteOptions(yargs, true);
+  addConfigOptions(yargs, true);
+  addAccountOptions(yargs, true);
+
+  yargs.command(deploy).demandCommand(1, '');
+
+  return yargs;
+};

--- a/packages/cli/commands/projects.js
+++ b/packages/cli/commands/projects.js
@@ -6,7 +6,7 @@ const {
 const deploy = require('./projects/deploy');
 
 exports.command = 'projects';
-exports.describe = 'Commands for working with projects';
+exports.describe = false; //'Commands for working with projects';
 
 exports.builder = yargs => {
   addOverwriteOptions(yargs, true);

--- a/packages/cli/commands/projects.js
+++ b/packages/cli/commands/projects.js
@@ -5,7 +5,7 @@ const {
 } = require('../lib/commonOpts');
 const deploy = require('./projects/deploy');
 
-exports.command = 'project';
+exports.command = 'projects';
 exports.describe = 'Commands for working with projects';
 
 exports.builder = yargs => {

--- a/packages/cli/commands/projects/deploy.js
+++ b/packages/cli/commands/projects/deploy.js
@@ -1,0 +1,104 @@
+// const ora = require('ora');
+// var https = require('https');
+const {
+  addAccountOptions,
+  addConfigOptions,
+  setLogLevel,
+  getAccountId,
+  addUseEnvironmentOptions,
+} = require('../../lib/commonOpts');
+const { trackCommandUsage } = require('../../lib/usageTracking');
+const { logDebugInfo } = require('../../lib/debugInfo');
+const {
+  loadConfig,
+  validateConfig,
+  checkAndWarnGitInclusion,
+} = require('@hubspot/cli-lib');
+const {
+  logApiErrorInstance,
+  ApiErrorContext,
+} = require('@hubspot/cli-lib/errorHandlers');
+const { logger } = require('@hubspot/cli-lib/logger');
+const { deployProject } = require('@hubspot/cli-lib/api/fileMapper');
+const { validateAccount } = require('../../lib/validation');
+
+// const makeSpinner = (actionText, functionPath, accountIdentifier) => {
+//   return ora(
+//     `${actionText} bundle for '${functionPath}' on account '${accountIdentifier}'.\n`
+//   );
+// };
+
+const loadAndValidateOptions = async options => {
+  setLogLevel(options);
+  logDebugInfo(options);
+  const { config: configPath } = options;
+  loadConfig(configPath, options);
+  checkAndWarnGitInclusion();
+
+  if (!(validateConfig() && (await validateAccount(options)))) {
+    process.exit(1);
+  }
+};
+
+exports.command = 'deploy <path>';
+exports.describe = false;
+
+exports.handler = async options => {
+  loadAndValidateOptions(options);
+
+  const { path: projectPath } = options;
+  const accountId = getAccountId(options);
+
+  trackCommandUsage('project-deploy', { projectPath }, accountId);
+
+  logger.debug(`Deploying project at path: ${projectPath}`);
+
+  try {
+    const deployResp = await deployProject(accountId, projectPath);
+
+    if (deployResp.error) {
+      logger.error(`Deploy error: ${deployResp.error.message}`);
+    }
+
+    logger.success(
+      `Deployed project in ${projectPath} on account ${accountId}.`
+    );
+  } catch (e) {
+    // spinner && spinner.stop && spinner.stop();
+    // if (e.statusCode === 404) {
+    //   logger.error(`Unable to find package.json for function ${functionPath}.`);
+    // } else if (e.statusCode === 400) {
+    //   logger.error(e.error.message);
+    // } else if (e.status === 'ERROR') {
+    //   const buildOutput = await logBuildOutput(e);
+    //   logger.log(buildOutput);
+    //   logger.error(`Build error: ${e.errorReason}`);
+    // } else {
+    logApiErrorInstance(
+      accountId,
+      e,
+      new ApiErrorContext({ accountId, projectPath })
+    );
+    // }
+  }
+};
+
+exports.builder = yargs => {
+  yargs.positional('path', {
+    describe: 'Path to a project folder',
+    type: 'string',
+  });
+
+  yargs.example([
+    [
+      '$0 project deploy myProjectFolder',
+      'Deploy a project within the myProjectFolder folder',
+    ],
+  ]);
+
+  addConfigOptions(yargs, true);
+  addAccountOptions(yargs, true);
+  addUseEnvironmentOptions(yargs, true);
+
+  return yargs;
+};

--- a/packages/cli/commands/projects/deploy.js
+++ b/packages/cli/commands/projects/deploy.js
@@ -64,22 +64,15 @@ exports.handler = async options => {
       `Deployed project in ${projectPath} on account ${accountId}.`
     );
   } catch (e) {
-    // spinner && spinner.stop && spinner.stop();
-    // if (e.statusCode === 404) {
-    //   logger.error(`Unable to find package.json for function ${functionPath}.`);
-    // } else if (e.statusCode === 400) {
-    //   logger.error(e.error.message);
-    // } else if (e.status === 'ERROR') {
-    //   const buildOutput = await logBuildOutput(e);
-    //   logger.log(buildOutput);
-    //   logger.error(`Build error: ${e.errorReason}`);
-    // } else {
-    logApiErrorInstance(
-      accountId,
-      e,
-      new ApiErrorContext({ accountId, projectPath })
-    );
-    // }
+    if (e.statusCode === 400) {
+      logger.error(e.error.message);
+    } else {
+      logApiErrorInstance(
+        accountId,
+        e,
+        new ApiErrorContext({ accountId, projectPath })
+      );
+    }
   }
 };
 

--- a/packages/cli/commands/projects/deploy.js
+++ b/packages/cli/commands/projects/deploy.js
@@ -1,5 +1,3 @@
-// const ora = require('ora');
-// var https = require('https');
 const {
   addAccountOptions,
   addConfigOptions,
@@ -21,12 +19,6 @@ const {
 const { logger } = require('@hubspot/cli-lib/logger');
 const { deployProject } = require('@hubspot/cli-lib/api/fileMapper');
 const { validateAccount } = require('../../lib/validation');
-
-// const makeSpinner = (actionText, functionPath, accountIdentifier) => {
-//   return ora(
-//     `${actionText} bundle for '${functionPath}' on account '${accountIdentifier}'.\n`
-//   );
-// };
 
 const loadAndValidateOptions = async options => {
   setLogLevel(options);

--- a/packages/cli/commands/projects/deploy.js
+++ b/packages/cli/commands/projects/deploy.js
@@ -50,6 +50,7 @@ exports.handler = async options => {
 
     if (deployResp.error) {
       logger.error(`Deploy error: ${deployResp.error.message}`);
+      return;
     }
 
     logger.success(

--- a/packages/cli/commands/projects/deploy.js
+++ b/packages/cli/commands/projects/deploy.js
@@ -49,7 +49,7 @@ exports.handler = async options => {
   const { path: projectPath } = options;
   const accountId = getAccountId(options);
 
-  trackCommandUsage('project-deploy', { projectPath }, accountId);
+  trackCommandUsage('projects-deploy', { projectPath }, accountId);
 
   logger.debug(`Deploying project at path: ${projectPath}`);
 
@@ -84,7 +84,7 @@ exports.builder = yargs => {
 
   yargs.example([
     [
-      '$0 project deploy myProjectFolder',
+      '$0 projects deploy myProjectFolder',
       'Deploy a project within the myProjectFolder folder',
     ],
   ]);

--- a/packages/cli/commands/upload.js
+++ b/packages/cli/commands/upload.js
@@ -7,9 +7,7 @@ const {
   validateConfig,
   checkAndWarnGitInclusion,
 } = require('@hubspot/cli-lib');
-const {
-  getFileMapperApiQueryFromMode,
-} = require('@hubspot/cli-lib/fileMapper');
+const { getFileMapperQueryValues } = require('@hubspot/cli-lib/fileMapper');
 const { upload } = require('@hubspot/cli-lib/api/fileMapper');
 const {
   getCwd,
@@ -104,9 +102,12 @@ exports.handler = async options => {
       return;
     }
 
-    upload(accountId, absoluteSrcPath, normalizedDest, {
-      qs: getFileMapperApiQueryFromMode(mode),
-    })
+    upload(
+      accountId,
+      absoluteSrcPath,
+      normalizedDest,
+      getFileMapperQueryValues({ mode, options })
+    )
       .then(() => {
         logger.success(
           'Uploaded file from "%s" to "%s" in the Design Manager of account %s',


### PR DESCRIPTION
## Description and Context
https://git.hubteam.com/HubSpot/hubspot-cli-issues/issues/285

This PR adds the command `hs project deploy <projectFolderPath>` and adds a `--staging` flag to the `hs fetch` command that will add the param `environmentId=2` to the request (default is `1`).

## Note
- Right now if you deploy and then fetch the `--staging` assets in the project folder, there will be an error output for every file that is live in the project folder. I spoke to @liamrharwood and he let me know there is a known BE issue dealing with fetching a folder as opposed to a file from the `content/filemapper/v1/download/${folderPath}` endpoint. Hopefully this will no longer occur when that bug is fixed, as it looks like we are passing the `environmentId: 2` properly to that endpoint when fetching.

## Who to Notify
@liamrharwood 
