### PR TITLE
Oauth URL broken and runtime error with logErrorInstance

### DIFF
--- a/packages/cli-lib/oauth.js
+++ b/packages/cli-lib/oauth.js
@@ -1,6 +1,7 @@
 const OAuth2Manager = require('./lib/models/OAuth2Manager');
 const { updateAccountConfig, writeConfig } = require('./lib/config');
-const { logger, logErrorInstance } = require('./logger');
+const { logger } = require('./logger');
+const { logErrorInstance } = require('./errorHandlers/standardErrors');
 const { AUTH_METHODS } = require('./lib/constants');
 
 const oauthManagers = new Map();
@@ -35,13 +36,13 @@ const getOauthManager = (accountId, accountConfig) => {
   return oauthManagers.get(accountId);
 };
 
-const addOauthToAccountConfig = (portalId, oauth) => {
+const addOauthToAccountConfig = oauth => {
   logger.log('Updating configuration');
   try {
     updateAccountConfig({
       ...oauth.toObj(),
       authType: AUTH_METHODS.oauth.value,
-      portalId,
+      portalId: oauth.accountId || oauth.portalId,
     });
     writeConfig();
     logger.log('Configuration updated');

--- a/packages/cli-lib/oauth.js
+++ b/packages/cli-lib/oauth.js
@@ -42,7 +42,7 @@ const addOauthToAccountConfig = oauth => {
     updateAccountConfig({
       ...oauth.toObj(),
       authType: AUTH_METHODS.oauth.value,
-      portalId: oauth.accountId || oauth.portalId,
+      portalId: oauth.accountId,
     });
     writeConfig();
     logger.log('Configuration updated');

--- a/packages/cli/commands/init.js
+++ b/packages/cli/commands/init.js
@@ -105,11 +105,12 @@ exports.handler = async options => {
   handleExit(deleteEmptyConfigFile);
 
   try {
-    const { accountId } = await CONFIG_CREATION_FLOWS[authType](env);
+    const { accountId, name } = await CONFIG_CREATION_FLOWS[authType](env);
     const path = getConfigPath();
 
     logger.success(
-      `The config file "${path}" was created using your personal access key for account ${accountId}.`
+      `The config file "${path}" was created using your personal access key for account ${name ||
+        accountId}.`
     );
 
     trackAuthAction('init', authType, TRACKING_STATUS.COMPLETE, accountId);

--- a/packages/cli/lib/oauth.js
+++ b/packages/cli/lib/oauth.js
@@ -13,9 +13,9 @@ const redirectUri = `http://localhost:${PORT}/oauth-callback`;
 
 const buildAuthUrl = oauthManager => {
   return (
-    `${getHubSpotWebsiteOrigin(
-      oauthManager.env
-    )}/oauth/${oauthManager.portalId || oauthManager.accountId}/authorize` +
+    `${getHubSpotWebsiteOrigin(oauthManager.env)}/oauth/${
+      oauthManager.accountId
+    }/authorize` +
     `?client_id=${encodeURIComponent(oauthManager.clientId)}` + // app's client ID
     `&scope=${encodeURIComponent(oauthManager.scopes.join(' '))}` + // scopes being requested by the app
     `&redirect_uri=${encodeURIComponent(redirectUri)}` // where to send the user after the consent page

--- a/packages/cli/lib/oauth.js
+++ b/packages/cli/lib/oauth.js
@@ -79,7 +79,8 @@ const authorize = async oauthManager => {
   });
 };
 
-const setupOauth = (accountId, accountConfig) => {
+const setupOauth = accountConfig => {
+  const accountId = parseInt(accountConfig.portalId, 10);
   const config = getAccountConfig(accountId) || {};
   return new OAuth2Manager(
     {
@@ -91,8 +92,7 @@ const setupOauth = (accountId, accountConfig) => {
 };
 
 const authenticateWithOauth = async configData => {
-  const accountId = parseInt(configData.portalId, 10);
-  const oauthManager = setupOauth(accountId, configData);
+  const oauthManager = setupOauth(configData);
   logger.log('Authorizing');
   await authorize(oauthManager);
   addOauthToAccountConfig(oauthManager);

--- a/packages/cli/lib/oauth.js
+++ b/packages/cli/lib/oauth.js
@@ -13,9 +13,9 @@ const redirectUri = `http://localhost:${PORT}/oauth-callback`;
 
 const buildAuthUrl = oauthManager => {
   return (
-    `${getHubSpotWebsiteOrigin(oauthManager.env)}/oauth/${
-      oauthManager.portalId
-    }/authorize` +
+    `${getHubSpotWebsiteOrigin(
+      oauthManager.env
+    )}/oauth/${oauthManager.portalId || oauthManager.accountId}/authorize` +
     `?client_id=${encodeURIComponent(oauthManager.clientId)}` + // app's client ID
     `&scope=${encodeURIComponent(oauthManager.scopes.join(' '))}` + // scopes being requested by the app
     `&redirect_uri=${encodeURIComponent(redirectUri)}` // where to send the user after the consent page
@@ -95,7 +95,7 @@ const authenticateWithOauth = async configData => {
   const oauthManager = setupOauth(accountId, configData);
   logger.log('Authorizing');
   await authorize(oauthManager);
-  addOauthToAccountConfig(accountId, oauthManager);
+  addOauthToAccountConfig(oauthManager);
 };
 
 module.exports = {


### PR DESCRIPTION
## Description and Context
- `buildAuthUrl` was not obtaining the correct `accountId` because it was looking for `portalId` instead this resulted in `undefined` being used in the URL instead of the `portalId`
- The import of `logErrorInstance` was wrong and causing a runtime error

```
[ERROR] A TypeError has occurred. logErrorInstance is not a function
[DEBUG] Error: TypeError: logErrorInstance is not a function
    at addOauthToAccountConfig (/Users/mtalley/.config/yarn/global/node_modules/@hubspot/cli-lib/oauth.js:50:5)
    at authenticateWithOauth (/Users/mtalley/.config/yarn/global/node_modules/@hubspot/cli/lib/oauth.js:98:3)
    at processTicksAndRejections (node:internal/process/task_queues:94:5)
    at async Object.oauthConfigCreationFlow [as oauth2] (/Users/mtalley/.config/yarn/global/node_modules/@hubspot/cli/commands/init.js:58:3)
    at async Object.exports.handler (/Users/mtalley/.config/yarn/global/node_modules/@hubspot/cli/commands/init.js:108:27) {
  [stack]: 'TypeError: logErrorInstance is not a function\n' +
    '    at addOauthToAccountConfig (/Users/mtalley/.config/yarn/global/node_modules/@hubspot/cli-lib/oauth.js:50:5)\n' +
    '    at authenticateWithOauth (/Users/mtalley/.config/yarn/global/node_modules/@hubspot/cli/lib/oauth.js:98:3)\n' +
    '    at processTicksAndRejections (node:internal/process/task_queues:94:5)\n' +
    '    at async Object.oauthConfigCreationFlow [as oauth2] (/Users/mtalley/.config/yarn/global/node_modules/@hubspot/cli/commands/init.js:58:3)\n' +
    '    at async Object.exports.handler (/Users/mtalley/.config/yarn/global/node_modules/@hubspot/cli/commands/init.js:108:27)',
  [message]: 'logErrorInstance is not a function'
```

## Who to Notify
@alnoorp
