### PR TITLE
Init success message now outputs correct authType

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ npm-debug.log.*
 *.log
 .DS_Store
 coverage
+.env

--- a/packages/cli/commands/init.js
+++ b/packages/cli/commands/init.js
@@ -109,7 +109,7 @@ exports.handler = async options => {
     const path = getConfigPath();
 
     logger.success(
-      `The config file "${path}" was created using ${authType} for account ${name ||
+      `The config file "${path}" was created using "${authType}" for account ${name ||
         accountId}.`
     );
 

--- a/packages/cli/commands/init.js
+++ b/packages/cli/commands/init.js
@@ -109,7 +109,7 @@ exports.handler = async options => {
     const path = getConfigPath();
 
     logger.success(
-      `The config file "${path}" was created using your personal access key for account ${name ||
+      `The config file "${path}" was created using ${authType} for account ${name ||
         accountId}.`
     );
 


### PR DESCRIPTION
## Description and Context
This was previously hard-coded to output "personal access key" even when setting up an "oauth2" auth.