### PR TITLE
Cleanup functions commands a bit

### DIFF
--- a/packages/cli/commands/functions.js
+++ b/packages/cli/commands/functions.js
@@ -1,8 +1,4 @@
-const {
-  addConfigOptions,
-  addAccountOptions,
-  addOverwriteOptions,
-} = require('../lib/commonOpts');
+const { addConfigOptions, addAccountOptions } = require('../lib/commonOpts');
 const list = require('./functions/list');
 const deploy = require('./functions/deploy');
 const server = require('./functions/server');
@@ -11,7 +7,6 @@ exports.command = 'functions';
 exports.describe = 'Commands for working with functions';
 
 exports.builder = yargs => {
-  addOverwriteOptions(yargs, true);
   addConfigOptions(yargs, true);
   addAccountOptions(yargs, true);
 

--- a/packages/cli/commands/functions/deploy.js
+++ b/packages/cli/commands/functions/deploy.js
@@ -1,5 +1,5 @@
 const ora = require('ora');
-var https = require('https');
+const https = require('https');
 const {
   addAccountOptions,
   addConfigOptions,
@@ -149,7 +149,7 @@ exports.handler = async options => {
       logApiErrorInstance(
         accountId,
         e,
-        new ApiErrorContext({ accountId, functionPath })
+        new ApiErrorContext({ accountId, request: functionPath })
       );
     }
   }


### PR DESCRIPTION
## Description and Context

This PR includes some cleanup discovered when working on #462

- Remove unnecessary option
- Use const instead of var
- Fix shape of `ApiErrorContext`

## Who to Notify

@miketalley