### PR TITLE
Allow .graphql file extension

### DIFF
--- a/packages/cli-lib/lib/constants.js
+++ b/packages/cli-lib/lib/constants.js
@@ -19,6 +19,7 @@ const ALLOWED_EXTENSIONS = new Set([
   'ttf',
   'woff',
   'woff2',
+  'graphql',
 ]);
 const HUBL_EXTENSIONS = new Set(['css', 'html', 'js']);
 const MODULE_EXTENSION = 'module';


### PR DESCRIPTION
## Description and Context
We need the ability to add graphQL queries as raw assets to Design Manager files.

