### PR TITLE
Hs open list

### DIFF
--- a/packages/cli/commands/open.js
+++ b/packages/cli/commands/open.js
@@ -36,7 +36,7 @@ exports.handler = async options => {
   if (shortcut === undefined && !list) {
     const choice = await createListPrompt(accountId);
     openLink(accountId, choice.open);
-  } else if (list) {
+  } else if (list || shortcut === 'list') {
     logSiteLinks(accountId);
     return;
   } else {

--- a/packages/cli/commands/open.js
+++ b/packages/cli/commands/open.js
@@ -25,7 +25,8 @@ const createListPrompt = async accountId =>
   ]);
 
 exports.command = 'open [shortcut]';
-exports.describe = 'Quickly open a page to HubSpot in your browser';
+exports.describe =
+  'Open a HubSpot page in your browser. Run ‘hs open list’ to see all available shortcuts.';
 
 exports.handler = async options => {
   const { shortcut, list } = options;


### PR DESCRIPTION
Context - https://hubspot.slack.com/archives/C01GV708YH3/p1618504470018300

Allow user to type `hs open list` to see the list of commands, and update the description