### PR TITLE
Implement new approach for custom object schemas behind a flag

### DIFF
--- a/packages/cli-lib/api/fileTransport.js
+++ b/packages/cli-lib/api/fileTransport.js
@@ -1,0 +1,29 @@
+const fs = require('fs');
+const path = require('path');
+const http = require('../http');
+const { getCwd } = require('../path');
+
+const HUBFILES_API_PATH = '/file-transport/v1/hubfiles';
+
+async function createSchema(accountId, filepath) {
+  return http.post(accountId, {
+    uri: `${HUBFILES_API_PATH}/object-schemas`,
+    formData: {
+      file: fs.createReadStream(path.resolve(getCwd(), filepath)),
+    },
+  });
+}
+
+async function updateSchema(accountId, filepath) {
+  return http.put(accountId, {
+    uri: `${HUBFILES_API_PATH}/object-schemas`,
+    formData: {
+      file: fs.createReadStream(path.resolve(getCwd(), filepath)),
+    },
+  });
+}
+
+module.exports = {
+  createSchema,
+  updateSchema,
+};

--- a/packages/cli-lib/api/fileTransport.js
+++ b/packages/cli-lib/api/fileTransport.js
@@ -23,7 +23,18 @@ async function updateSchema(accountId, filepath) {
   });
 }
 
+async function fetchSchema(accountId, objectName, path) {
+  return http.getOctetStream(
+    accountId,
+    {
+      uri: `${HUBFILES_API_PATH}/object-schemas/${objectName}`,
+    },
+    path
+  );
+}
+
 module.exports = {
   createSchema,
   updateSchema,
+  fetchSchema,
 };

--- a/packages/cli-lib/http.js
+++ b/packages/cli-lib/http.js
@@ -150,9 +150,7 @@ const createGetRequestStream = ({ contentType }) => async (
         },
         json: false,
       });
-      req.on('error', error => {
-        reject(error);
-      });
+      req.on('error', reject);
       req.on('response', res => {
         if (res.statusCode >= 200 && res.statusCode < 300) {
           let filepath = destPath;

--- a/packages/cli-lib/http.js
+++ b/packages/cli-lib/http.js
@@ -157,12 +157,14 @@ const createGetRequestStream = ({ contentType }) => async (
         if (res.statusCode >= 200 && res.statusCode < 300) {
           let filepath = destPath;
 
-          const stat = fs.statSync(destPath);
-          if (stat.isDirectory) {
-            const { parameters } = contentDisposition.parse(
-              res.headers['content-disposition']
-            );
-            filepath = path.join(destPath, parameters.filename);
+          if (fs.existsSync(destPath)) {
+            const stat = fs.statSync(destPath);
+            if (stat.isDirectory) {
+              const { parameters } = contentDisposition.parse(
+                res.headers['content-disposition']
+              );
+              filepath = path.join(destPath, parameters.filename);
+            }
           }
           try {
             fs.ensureFileSync(filepath);

--- a/packages/cli-lib/index.js
+++ b/packages/cli-lib/index.js
@@ -6,11 +6,13 @@ const {
   getAccountId,
   getAccountConfig,
   getEnv,
+
   findConfig,
   loadConfig,
   loadConfigFromEnvironment,
   updateAccountConfig,
   validateConfig,
+  isConfigFlagEnabled,
   isTrackingAllowed,
 } = require('./lib/config');
 const { uploadFolder } = require('./lib/uploadFolder');
@@ -37,6 +39,7 @@ module.exports = {
   uploadFolder,
   validateConfig,
   isTrackingAllowed,
+  isConfigFlagEnabled,
   watch,
   walk,
 };

--- a/packages/cli-lib/lib/config.js
+++ b/packages/cli-lib/lib/config.js
@@ -688,6 +688,16 @@ const loadEnvironmentVariableConfig = () => {
   return setConfig(envConfig);
 };
 
+const isConfigFlagEnabled = flag => {
+  if (!configFileExists() || configFileIsBlank()) {
+    return false;
+  }
+
+  const config = getAndLoadConfigIfNeeded();
+
+  return config[flag] || false;
+};
+
 module.exports = {
   checkAndWarnGitInclusion,
   getAndLoadConfigIfNeeded,
@@ -699,6 +709,7 @@ module.exports = {
   getConfigPath,
   getOrderedAccount,
   getOrderedConfig,
+  isConfigFlagEnabled,
   setConfig,
   setConfigPath,
   loadConfig,

--- a/packages/cli-lib/lib/config.js
+++ b/packages/cli-lib/lib/config.js
@@ -133,7 +133,7 @@ const getOrderedConfig = unorderedConfig => {
     defaultPortal,
     defaultMode,
     httpTimeout,
-    allowsUsageTracking,
+    allowUsageTracking,
     portals,
     ...rest
   } = unorderedConfig;
@@ -142,9 +142,9 @@ const getOrderedConfig = unorderedConfig => {
     ...(defaultPortal && { defaultPortal }),
     defaultMode,
     httpTimeout,
-    allowsUsageTracking,
-    portals: portals.map(getOrderedAccount),
+    allowUsageTracking,
     ...rest,
+    portals: portals.map(getOrderedAccount),
   };
 };
 

--- a/packages/cli-lib/lib/constants.js
+++ b/packages/cli-lib/lib/constants.js
@@ -105,7 +105,12 @@ const GITHUB_RELEASE_TYPES = {
   REPOSITORY: 'repository',
 };
 
+const ConfigFlags = {
+  USE_CUSTOM_OBJECT_HUBFILE: 'useCustomObjectHubfile',
+};
+
 module.exports = {
+  ConfigFlags,
   Mode,
   ENVIRONMENTS,
   ALLOWED_EXTENSIONS,

--- a/packages/cli/commands/customObject/schema/create.js
+++ b/packages/cli/commands/customObject/schema/create.js
@@ -13,10 +13,13 @@ const {
   setLogLevel,
   getAccountId,
 } = require('../../../lib/commonOpts');
-const { getEnv } = require('@hubspot/cli-lib/lib/config');
-const { ENVIRONMENTS } = require('@hubspot/cli-lib/lib/constants');
+const { getEnv, isConfigFlagEnabled } = require('@hubspot/cli-lib/');
+const { ENVIRONMENTS, ConfigFlags } = require('@hubspot/cli-lib/lib/constants');
 const { logDebugInfo } = require('../../../lib/debugInfo');
 const { createSchema } = require('@hubspot/cli-lib/api/schema');
+const {
+  createSchema: createSchemaFromHubFile,
+} = require('@hubspot/cli-lib/api/fileTransport');
 const { getHubSpotWebsiteOrigin } = require('@hubspot/cli-lib/lib/urls');
 
 exports.command = 'create <definition>';
@@ -43,12 +46,16 @@ exports.handler = async options => {
   }
 
   try {
-    const res = await createSchema(accountId, filePath);
-    logger.success(
-      `Schema can be viewed at ${getHubSpotWebsiteOrigin(
-        getEnv() === 'qa' ? ENVIRONMENTS.QA : ENVIRONMENTS.PROD
-      )}/contacts/${accountId}/objects/${res.objectTypeId}`
-    );
+    if (isConfigFlagEnabled(ConfigFlags.USE_CUSTOM_OBJECT_HUBFILE)) {
+      await createSchemaFromHubFile(accountId, filePath);
+    } else {
+      const res = await createSchema(accountId, filePath);
+      logger.success(
+        `Schema can be viewed at ${getHubSpotWebsiteOrigin(
+          getEnv() === 'qa' ? ENVIRONMENTS.QA : ENVIRONMENTS.PROD
+        )}/contacts/${accountId}/objects/${res.objectTypeId}`
+      );
+    }
   } catch (e) {
     logErrorInstance(e, { accountId });
     logger.error(`Schema creation from ${definition} failed`);

--- a/packages/cli/commands/customObject/schema/create.js
+++ b/packages/cli/commands/customObject/schema/create.js
@@ -48,6 +48,7 @@ exports.handler = async options => {
   try {
     if (isConfigFlagEnabled(ConfigFlags.USE_CUSTOM_OBJECT_HUBFILE)) {
       await createSchemaFromHubFile(accountId, filePath);
+      logger.success(`Your schema has been created in acount "${accountId}"`);
     } else {
       const res = await createSchema(accountId, filePath);
       logger.success(

--- a/packages/cli/commands/customObject/schema/fetch.js
+++ b/packages/cli/commands/customObject/schema/fetch.js
@@ -1,16 +1,21 @@
+const path = require('path');
 const {
   loadConfig,
   validateConfig,
   checkAndWarnGitInclusion,
+  isConfigFlagEnabled,
 } = require('@hubspot/cli-lib');
 const { logger } = require('@hubspot/cli-lib/logger');
 const { logErrorInstance } = require('@hubspot/cli-lib/errorHandlers');
+const { ConfigFlags } = require('@hubspot/cli-lib/lib/constants');
+const { downloadSchema, getResolvedPath } = require('@hubspot/cli-lib/schema');
+const { fetchSchema } = require('@hubspot/cli-lib/api/fileTransport');
+const { getCwd } = require('@hubspot/cli-lib/path');
 
 const { validateAccount } = require('../../../lib/validation');
 const { trackCommandUsage } = require('../../../lib/usageTracking');
 const { setLogLevel, getAccountId } = require('../../../lib/commonOpts');
 const { logDebugInfo } = require('../../../lib/debugInfo');
-const { downloadSchema, getResolvedPath } = require('@hubspot/cli-lib/schema');
 
 exports.command = 'fetch <name> [dest]';
 exports.describe = 'Fetch a custom object schema';
@@ -31,8 +36,14 @@ exports.handler = async options => {
   trackCommandUsage('custom-object-schema-fetch', null, accountId);
 
   try {
-    await downloadSchema(accountId, name, dest);
-    logger.success(`Saved schema to ${getResolvedPath(dest, name)}`);
+    if (isConfigFlagEnabled(ConfigFlags.USE_CUSTOM_OBJECT_HUBFILE)) {
+      const fullpath = path.resolve(getCwd(), dest);
+      await fetchSchema(accountId, name, dest);
+      logger.success(`The schema "${name}" has been saved to "${fullpath}"`);
+    } else {
+      await downloadSchema(accountId, name, dest);
+      logger.success(`Saved schema to ${getResolvedPath(dest, name)}`);
+    }
   } catch (e) {
     logErrorInstance(e);
     logger.error(`Unable to fetch ${name}`);
@@ -42,11 +53,11 @@ exports.handler = async options => {
 exports.builder = yargs => {
   yargs.example([
     [
-      '$0 custom-object schema fetch schemaId',
+      '$0 custom-object schema fetch schemaName',
       'Fetch `schemaId` schema and put it in the current working directory',
     ],
     [
-      '$0 custom-object schema fetch schemaId my/folder',
+      '$0 custom-object schema fetch schemaName my/folder',
       'Fetch `schemaId` schema and put it in a directory named my/folder',
     ],
   ]);

--- a/packages/cli/commands/customObject/schema/fetch.js
+++ b/packages/cli/commands/customObject/schema/fetch.js
@@ -38,7 +38,7 @@ exports.handler = async options => {
   try {
     if (isConfigFlagEnabled(ConfigFlags.USE_CUSTOM_OBJECT_HUBFILE)) {
       const fullpath = path.resolve(getCwd(), dest);
-      await fetchSchema(accountId, name, dest);
+      await fetchSchema(accountId, name, fullpath);
       logger.success(`The schema "${name}" has been saved to "${fullpath}"`);
     } else {
       await downloadSchema(accountId, name, dest);

--- a/packages/cli/commands/customObject/schema/update.js
+++ b/packages/cli/commands/customObject/schema/update.js
@@ -13,10 +13,13 @@ const {
   setLogLevel,
   getAccountId,
 } = require('../../../lib/commonOpts');
-const { ENVIRONMENTS } = require('@hubspot/cli-lib/lib/constants');
-const { getEnv } = require('@hubspot/cli-lib/lib/config');
+const { ENVIRONMENTS, ConfigFlags } = require('@hubspot/cli-lib/lib/constants');
+const { getEnv, isConfigFlagEnabled } = require('@hubspot/cli-lib');
 const { logDebugInfo } = require('../../../lib/debugInfo');
 const { updateSchema } = require('@hubspot/cli-lib/api/schema');
+const {
+  updateSchema: updateSchemaFromHubFile,
+} = require('@hubspot/cli-lib/api/fileTransport');
 const { getHubSpotWebsiteOrigin } = require('@hubspot/cli-lib/lib/urls');
 
 exports.command = 'update <name> <definition>';
@@ -43,12 +46,16 @@ exports.handler = async options => {
   }
 
   try {
-    const res = await updateSchema(accountId, name, filePath);
-    logger.success(
-      `Schema can be viewed at ${getHubSpotWebsiteOrigin(
-        getEnv() === 'qa' ? ENVIRONMENTS.QA : ENVIRONMENTS.PROD
-      )}/contacts/${accountId}/objects/${res.objectTypeId}`
-    );
+    if (isConfigFlagEnabled(ConfigFlags.USE_CUSTOM_OBJECT_HUBFILE)) {
+      await updateSchemaFromHubFile(accountId, filePath);
+    } else {
+      const res = await updateSchema(accountId, name, filePath);
+      logger.success(
+        `Schema can be viewed at ${getHubSpotWebsiteOrigin(
+          getEnv() === 'qa' ? ENVIRONMENTS.QA : ENVIRONMENTS.PROD
+        )}/contacts/${accountId}/objects/${res.objectTypeId}`
+      );
+    }
   } catch (e) {
     logErrorInstance(e, { accountId });
     logger.error(`Schema update from ${definition} failed`);

--- a/packages/cli/commands/customObject/schema/update.js
+++ b/packages/cli/commands/customObject/schema/update.js
@@ -48,6 +48,7 @@ exports.handler = async options => {
   try {
     if (isConfigFlagEnabled(ConfigFlags.USE_CUSTOM_OBJECT_HUBFILE)) {
       await updateSchemaFromHubFile(accountId, filePath);
+      logger.success(`Your schema has been updated in acount "${accountId}"`);
     } else {
       const res = await updateSchema(accountId, name, filePath);
       logger.success(


### PR DESCRIPTION
## Description and Context

This PR starts the process of implementing a more robust approach for working with custom object schemas that incorporates property groups and associations.

It introduces a top-level config flag `useCustomObjectHubfile` that is used to determine whether to use the old or new approach.

## TODO

- [x] Implement flow for getting a schema as a file
- [ ] Adjust backend to provide more useful response so we can better log successes
- [ ] Automatically detect the shape of the file when determining what logic branch to use

## Who to Notify
@chrisbaldauf @drewjenkins @brandenrodgers 
