### PR TITLE
Ignore package-lock.json to simplify custom package function uploads

### DIFF
--- a/packages/cli-lib/ignoreRules.js
+++ b/packages/cli-lib/ignoreRules.js
@@ -11,6 +11,7 @@ const ignoreList = [
   '*.log', // Error log for npm
   '*.swp', // Swap file for vim state
   '.env', // Dotenv file
+  'package-lock.json', // Temporary solution to improve serverless beta: https://git.hubteam.com/HubSpot/cms-devex-super-repo/issues/2
 
   // # macOS
   'Icon\\r', // Custom Finder icon: http://superuser.com/questions/298785/icon-file-on-os-x-desktop


### PR DESCRIPTION
## Description and Context
When running `hs upload` for a custom package serverless function containing a `package-lock.json` file an error is encountered.

![image](https://user-images.githubusercontent.com/6472448/116408851-45896d00-a801-11eb-8cf7-0615fecb55c2.png)

## Screenshots
After adding `package-lock.json` to ignore rules
![image](https://user-images.githubusercontent.com/6472448/116408979-65b92c00-a801-11eb-88d6-bd3d7e6f0233.png)

## Who to Notify
@bkrainer 