### PR TITLE
Added endpoint and method to function context to match production context

### DIFF
--- a/packages/serverless-dev-runtime/lib/data.js
+++ b/packages/serverless-dev-runtime/lib/data.js
@@ -118,6 +118,8 @@ const getFunctionDataContext = async (
     },
     body: req.body,
     headers: getHeaders(req),
+    method: req.method,
+    endpoint: req.url,
     accountId: accountId || HUBSPOT_ACCOUNT_ID || MOCK_DATA.HUBSPOT_ACCOUNT_ID,
     contact:
       contact === 'true' || contact === true

--- a/packages/serverless-dev-runtime/lib/data.js
+++ b/packages/serverless-dev-runtime/lib/data.js
@@ -1,7 +1,7 @@
 const fs = require('fs-extra');
 const { logger } = require('@hubspot/cli-lib/logger');
 const { getDotEnvData } = require('./secrets');
-const { MOCK_DATA, MAX_SECRETS } = require('./constants');
+const { MOCK_DATA, MAX_SECRETS, ROUTE_PATH_PREFIX } = require('./constants');
 
 const getValidatedFunctionData = path => {
   // Allow passing serverless folder path with and without .functions extension
@@ -119,7 +119,7 @@ const getFunctionDataContext = async (
     body: req.body,
     headers: getHeaders(req),
     method: req.method,
-    endpoint: req.url,
+    endpoint: req.url.replace(`/${ROUTE_PATH_PREFIX}`, ''),
     accountId: accountId || HUBSPOT_ACCOUNT_ID || MOCK_DATA.HUBSPOT_ACCOUNT_ID,
     contact:
       contact === 'true' || contact === true


### PR DESCRIPTION
## Description and Context
`endpoint` and `method` were added to the production function context, this PR brings the local dev server in sync.

`method` - one of `GET` `POST` `PUT` `PATCH` `DELETE`
`endpoint` - for url `/_hcms/api/myEndpoint` the value will be `myEndpoint`

## Who to Notify
@bkrainer
