### PR TITLE
Added validation error for non-lowercased authType values

### DIFF
--- a/packages/cli/lib/validation.js
+++ b/packages/cli/lib/validation.js
@@ -4,6 +4,12 @@ const {
   loadConfigFromEnvironment,
   Mode,
 } = require('@hubspot/cli-lib');
+const { getConfigPath } = require('@hubspot/cli-lib/lib/config');
+const {
+  API_KEY_AUTH_METHOD,
+  OAUTH_AUTH_METHOD,
+  PERSONAL_ACCESS_KEY_AUTH_METHOD,
+} = require('@hubspot/cli-lib/lib/constants');
 const { getAbsoluteFilePath } = require('@hubspot/cli-lib/path');
 const { getOauthManager } = require('@hubspot/cli-lib/oauth');
 const {
@@ -11,6 +17,7 @@ const {
 } = require('@hubspot/cli-lib/personalAccessKey');
 const { getCwd, getExt } = require('@hubspot/cli-lib/path');
 const { getAccountId, getMode } = require('./commonOpts');
+const { commaSeparatedValues } = require('./text');
 const fs = require('fs');
 const path = require('path');
 
@@ -62,6 +69,18 @@ async function validateAccount(options) {
   }
 
   const { authType, auth, apiKey, personalAccessKey } = accountConfig;
+
+  if (typeof authType === 'string' && authType !== authType.toLowerCase()) {
+    logger.error(
+      `Invalid "authType" value "${authType}" for account "${accountId}" in config file: ${getConfigPath()}. Valid values are ${commaSeparatedValues(
+        [
+          PERSONAL_ACCESS_KEY_AUTH_METHOD,
+          OAUTH_AUTH_METHOD,
+          API_KEY_AUTH_METHOD,
+        ].map(method => method.value)
+      )}.`
+    );
+  }
 
   if (authType === 'oauth2') {
     if (typeof auth !== 'object') {


### PR DESCRIPTION
## Description and Context
Fixes #83 

When manually editing the config file and using non-lowercased values for `authType`, it is unclear why things are not working. Only an error:
```
[ERROR] The accountId 8245999 is missing authentication configuration
```
is displayed, which is not very helpful for pinpointing the problem.

This PR adds validation to check for this and display a more helpful error message.

Do we want to allow invalid values (non-lowercased) to be used also? I think having the more helpful error may be sufficient. What are your thoughts @gcorne ?

## Screenshots
![image](https://user-images.githubusercontent.com/6472448/116597310-7a75ec80-a8f3-11eb-8a85-1366abd8aef8.png)
