### PR TITLE
Allow .EOT files

### DIFF
--- a/packages/cli-lib/lib/constants.js
+++ b/packages/cli-lib/lib/constants.js
@@ -16,6 +16,7 @@ const ALLOWED_EXTENSIONS = new Set([
   'gif',
   'map',
   'svg',
+  'eot',
   'ttf',
   'woff',
   'woff2',


### PR DESCRIPTION
## Description and Context
Adds support for `.eot` now that the API supports them

Fixes #399 
