### PR TITLE
Improved error messaging when running hs auth with no config

### DIFF
--- a/packages/cli-lib/lib/config.js
+++ b/packages/cli-lib/lib/config.js
@@ -58,7 +58,7 @@ const getConfigAccountId = config => {
 const validateConfig = () => {
   const config = getConfig();
   if (!config) {
-    logger.error('config is not defined');
+    logger.error('No config was found');
     return false;
   }
   const accounts = getConfigAccounts();

--- a/packages/cli/commands/auth.js
+++ b/packages/cli/commands/auth.js
@@ -18,6 +18,7 @@ const {
   updateAccountConfig,
   accountNameExistsInConfig,
   writeConfig,
+  getConfigPath,
 } = require('@hubspot/cli-lib/lib/config');
 const {
   promptUser,
@@ -73,14 +74,16 @@ exports.handler = async options => {
   setLogLevel(options);
   logDebugInfo(options);
 
+  if (!getConfigPath()) {
+    logger.error(
+      'No config file was found. To create a new config file, use the "hs init" command.'
+    );
+    process.exit(1);
+  }
+
   const env = qa ? ENVIRONMENTS.QA : ENVIRONMENTS.PROD;
   loadConfig(configPath);
   checkAndWarnGitInclusion();
-
-  if (!validateConfig()) {
-    logger.info('To create a new config file, use the "hs init" command.');
-    process.exit(1);
-  }
 
   trackCommandUsage('auth');
 

--- a/packages/cli/commands/auth.js
+++ b/packages/cli/commands/auth.js
@@ -1,8 +1,4 @@
-const {
-  loadConfig,
-  validateConfig,
-  checkAndWarnGitInclusion,
-} = require('@hubspot/cli-lib');
+const { loadConfig, checkAndWarnGitInclusion } = require('@hubspot/cli-lib');
 const { logger } = require('@hubspot/cli-lib/logger');
 const {
   OAUTH_AUTH_METHOD,


### PR DESCRIPTION
## Description and Context
Currently, the error messaging when using `hs auth` with no config is not clean
![image](https://user-images.githubusercontent.com/6472448/116606711-1c4f0680-a8ff-11eb-9ed5-7d06c6c121b3.png)

This PR improves the error messaging to be clear
![image](https://user-images.githubusercontent.com/6472448/116606599-f88bc080-a8fe-11eb-8ab0-93cdb94f14ec.png)