### PR TITLE
Change console error message to reflect correct property "defaultAccount" to "defaultPortal"

### DIFF
--- a/packages/cli/lib/validation.js
+++ b/packages/cli/lib/validation.js
@@ -50,7 +50,7 @@ async function validateAccount(options) {
       );
     } else {
       logger.error(
-        'An account needs to be supplied either via "--account" or through setting a "defaultAccount"'
+        'An account needs to be supplied either via "--account" or through setting a "defaultPortal"'
       );
     }
     return false;


### PR DESCRIPTION
## Description and Context
CLI messaging refers to defaultAccount - but the YAML property is actually defaultPortal
