### PR TITLE
 Add ability to retrieve and tail app function logs

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,3 @@
-// Chalk can cause snapshots to with its styling, just disable the color instead
-process.env.FORCE_COLOR = 0;
-
 module.exports = {
   testEnvironment: 'node',
   projects: ['<rootDir>/packages/*'],

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "lerna": "^4.0.0",
     "lint-staged": "^8.1.4",
     "madge": "^4.0.1",
-    "mock-stdin": "1.0.0",
     "prettier": "^1.19.1"
   },
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "lerna": "^4.0.0",
     "lint-staged": "^8.1.4",
     "madge": "^4.0.1",
+    "mock-stdin": "1.0.0",
     "prettier": "^1.19.1"
   },
   "workspaces": [

--- a/packages/cli-lib/__tests__/__snapshots__/schema.js.snap
+++ b/packages/cli-lib/__tests__/__snapshots__/schema.js.snap
@@ -198,7 +198,7 @@ Array [
 
 exports[`cli-lib/schema logSchemas() logs schemas 1`] = `
 "╔════════╤════════╤══════════════╗
-║ [1mLabel[22m  │ [1mName[22m   │ [1mobjectTypeId[22m ║
+║ Label  │ Name   │ objectTypeId ║
 ║ Schema │ schema │ 2-123        ║
 ╚════════╧════════╧══════════════╝
 "

--- a/packages/cli-lib/__tests__/__snapshots__/schema.js.snap
+++ b/packages/cli-lib/__tests__/__snapshots__/schema.js.snap
@@ -1,5 +1,28 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`cli-lib/schema cleanSchema() cleans a basic schema 1`] = `
+Object {
+  "associatedObjects": null,
+  "labels": Object {
+    "plural": "Schemas",
+    "singular": "Schema",
+  },
+  "name": "schema",
+  "primaryDisplayProperty": "name",
+  "properties": Array [
+    Object {
+      "description": "Name Field",
+      "fieldType": "text",
+      "label": "Name",
+      "name": "name",
+      "type": "string",
+    },
+  ],
+  "requiredProperties": Array [],
+  "searchableProperties": Array [],
+}
+`;
+
 exports[`cli-lib/schema cleanSchema() cleans a full schema 1`] = `
 Object {
   "associatedObjects": undefined,
@@ -175,8 +198,8 @@ Array [
 
 exports[`cli-lib/schema logSchemas() logs schemas 1`] = `
 "╔════════╤════════╤══════════════╗
-║ Label  │ Name   │ objectTypeId ║
-║ Schema │ schema │              ║
+║ [1mLabel[22m  │ [1mName[22m   │ [1mobjectTypeId[22m ║
+║ Schema │ schema │ 2-123        ║
 ╚════════╧════════╧══════════════╝
 "
 `;

--- a/packages/cli-lib/__tests__/fixtures/schema/basic.json
+++ b/packages/cli-lib/__tests__/fixtures/schema/basic.json
@@ -4,6 +4,7 @@
   "requiredProperties": [],
   "searchableProperties": [],
   "primaryDisplayProperty": "name",
+  "objectTypeId": "2-123",
   "properties": [
     {
       "name": "name",

--- a/packages/cli-lib/__tests__/schema.js
+++ b/packages/cli-lib/__tests__/schema.js
@@ -10,7 +10,7 @@ const multiple = require('./fixtures/schema/multiple.json');
 describe('cli-lib/schema', () => {
   describe('cleanSchema()', () => {
     it('cleans a basic schema', () => {
-      expect(cleanSchema(basic)).toEqual(basic);
+      expect(cleanSchema(basic)).toMatchSnapshot();
     });
 
     it('cleans a full schema', () => {

--- a/packages/cli-lib/__tests__/schema.js
+++ b/packages/cli-lib/__tests__/schema.js
@@ -1,5 +1,6 @@
 const fs = require('fs-extra');
 const path = require('path');
+const chalk = require('chalk');
 const { cleanSchema, writeSchemaToDisk, logSchemas } = require('../schema');
 const { logger } = require('../logger');
 const { getCwd } = require('../path');
@@ -8,6 +9,13 @@ const full = require('./fixtures/schema/full.json');
 const multiple = require('./fixtures/schema/multiple.json');
 
 describe('cli-lib/schema', () => {
+  const originalChalkLevel = chalk.level;
+  beforeEach(() => {
+    chalk.level = 0;
+  });
+  afterEach(() => {
+    chalk.level = originalChalkLevel;
+  });
   describe('cleanSchema()', () => {
     it('cleans a basic schema', () => {
       expect(cleanSchema(basic)).toMatchSnapshot();

--- a/packages/cli-lib/api/functions.js
+++ b/packages/cli-lib/api/functions.js
@@ -28,7 +28,30 @@ async function getBuildStatus(portalId, buildId) {
   });
 }
 
+async function getAppFunctionLogs(
+  accountId,
+  functionName,
+  appPath,
+  query = {}
+) {
+  const { limit = 5 } = query;
+
+  return http.get(accountId, {
+    uri: `${FUNCTION_API_PATH}/app-function/logs/${functionName}`,
+    query: { ...query, limit, appPath },
+  });
+}
+
+async function getLatestAppFunctionLogs(accountId, functionName, appPath) {
+  return http.get(accountId, {
+    uri: `${FUNCTION_API_PATH}/app-function/logs/${functionName}/latest`,
+    query: { appPath },
+  });
+}
+
 module.exports = {
+  getAppFunctionLogs,
+  getLatestAppFunctionLogs,
   buildPackage,
   getBuildStatus,
   getFunctionByPath,

--- a/packages/cli/commands/logs.js
+++ b/packages/cli/commands/logs.js
@@ -1,5 +1,3 @@
-const readline = require('readline');
-const ora = require('ora');
 const {
   addAccountOptions,
   addConfigOptions,
@@ -25,33 +23,8 @@ const {
   getFunctionLogs,
   getLatestFunctionLog,
 } = require('@hubspot/cli-lib/api/results');
-const { base64EncodeString } = require('@hubspot/cli-lib/lib/encoding');
 const { validateAccount } = require('../lib/validation');
-
-const TAIL_DELAY = 5000;
-
-const makeSpinner = (functionPath, accountId) => {
-  return ora(
-    `Waiting for log entries for '${functionPath}' on account '${accountId}'.\n`
-  );
-};
-
-const makeTailCall = (accountId, functionId) => {
-  return async after => {
-    const latestLog = await getFunctionLogs(accountId, functionId, { after });
-    return latestLog;
-  };
-};
-
-const handleKeypressToExit = exit => {
-  readline.emitKeypressEvents(process.stdin);
-  process.stdin.setRawMode(true);
-  process.stdin.on('keypress', (str, key) => {
-    if (key && ((key.ctrl && key.name == 'c') || key.name === 'escape')) {
-      exit();
-    }
-  });
-};
+const { tailLogs } = require('../lib/serverlessLogs');
 
 const loadAndValidateOptions = async options => {
   setLogLevel(options);
@@ -65,56 +38,7 @@ const loadAndValidateOptions = async options => {
   }
 };
 
-const tailLogs = async ({
-  functionId,
-  functionPath,
-  accountId,
-  accountName,
-  compact,
-}) => {
-  const tailCall = makeTailCall(accountId, functionId);
-  const spinner = makeSpinner(functionPath, accountName || accountId);
-  let initialAfter;
-
-  spinner.start();
-
-  try {
-    const latestLog = await getLatestFunctionLog(accountId, functionId);
-    initialAfter = base64EncodeString(latestLog.id);
-  } catch (e) {
-    // A 404 means no latest log exists(never executed)
-    if (e.statusCode !== 404) {
-      await logServerlessFunctionApiErrorInstance(
-        accountId,
-        e,
-        new ApiErrorContext({ accountId, functionPath })
-      );
-    }
-  }
-
-  const tail = async after => {
-    const latestLog = await tailCall(after);
-
-    if (latestLog.results.length) {
-      spinner.clear();
-      outputLogs(latestLog, {
-        compact,
-      });
-    }
-
-    setTimeout(() => {
-      tail(latestLog.paging.next.after);
-    }, TAIL_DELAY);
-  };
-
-  handleKeypressToExit(() => {
-    spinner.stop();
-    process.exit();
-  });
-  tail(initialAfter);
-};
-
-exports.command = 'logs <endpoint>';
+exports.command = 'logs [endpoint]';
 exports.describe = 'get logs for a function';
 
 exports.handler = async options => {

--- a/packages/cli/lib/__tests__/serverlessLogs.js
+++ b/packages/cli/lib/__tests__/serverlessLogs.js
@@ -1,0 +1,67 @@
+const mockStdIn = require('mock-stdin');
+const { tailLogs } = require('../serverlessLogs');
+
+jest.mock('@hubspot/cli-lib/lib/logs');
+
+jest.useFakeTimers();
+
+describe('@hubspot/cli/lib/serverlessLogs', () => {
+  describe('tailLogs()', () => {
+    let stdinMock;
+
+    beforeEach(() => {
+      jest.spyOn(process, 'exit').mockImplementation(() => {});
+      stdinMock = mockStdIn.stdin();
+    });
+
+    afterEach(() => {
+      jest.clearAllTimers();
+      stdinMock.restore();
+    });
+
+    it('calls tailCall() to get the next results', async () => {
+      const accountId = 123;
+      const compact = false;
+      const spinner = {
+        start: jest.fn(),
+        stop: jest.fn(),
+        clear: jest.fn(),
+      };
+
+      const fetchLatest = jest.fn(() => {
+        return Promise.resolve({
+          id: '1234',
+          executionTime: 510,
+          log: 'Log message',
+          error: null,
+          status: 'SUCCESS',
+          createdAt: 1620232011451,
+          memory: '70/128 MB',
+          duration: '53.40 ms',
+        });
+      });
+      const tailCall = jest.fn(() => {
+        return Promise.resolve({
+          results: [],
+          paging: {
+            next: {
+              after: 'somehash',
+            },
+          },
+        });
+      });
+
+      await tailLogs({
+        accountId,
+        compact,
+        spinner,
+        fetchLatest,
+        tailCall,
+      });
+      jest.runOnlyPendingTimers();
+
+      expect(fetchLatest).toHaveBeenCalled();
+      expect(tailCall).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/packages/cli/lib/serverlessLogs.js
+++ b/packages/cli/lib/serverlessLogs.js
@@ -1,10 +1,4 @@
 const readline = require('readline');
-const ora = require('ora');
-
-const {
-  getFunctionLogs,
-  getLatestFunctionLog,
-} = require('@hubspot/cli-lib/api/results');
 
 const { outputLogs } = require('@hubspot/cli-lib/lib/logs');
 const {
@@ -14,19 +8,6 @@ const {
 const { base64EncodeString } = require('@hubspot/cli-lib/lib/encoding');
 
 const TAIL_DELAY = 5000;
-
-const makeSpinner = (functionPath, accountId) => {
-  return ora(
-    `Waiting for log entries for '${functionPath}' on account '${accountId}'.\n`
-  );
-};
-
-const makeTailCall = (accountId, functionId) => {
-  return async after => {
-    const latestLog = await getFunctionLogs(accountId, functionId, { after });
-    return latestLog;
-  };
-};
 
 const handleKeypressToExit = exit => {
   readline.emitKeypressEvents(process.stdin);
@@ -39,20 +20,18 @@ const handleKeypressToExit = exit => {
 };
 
 const tailLogs = async ({
-  functionId,
-  functionPath,
   accountId,
-  accountName,
   compact,
+  spinner,
+  fetchLatest,
+  tailCall,
 }) => {
-  const tailCall = makeTailCall(accountId, functionId);
-  const spinner = makeSpinner(functionPath, accountName || accountId);
   let initialAfter;
 
   spinner.start();
 
   try {
-    const latestLog = await getLatestFunctionLog(accountId, functionId);
+    const latestLog = await fetchLatest();
     initialAfter = base64EncodeString(latestLog.id);
   } catch (e) {
     // A 404 means no latest log exists(never executed)
@@ -60,7 +39,7 @@ const tailLogs = async ({
       await logServerlessFunctionApiErrorInstance(
         accountId,
         e,
-        new ApiErrorContext({ accountId, functionPath })
+        new ApiErrorContext({ accountId })
       );
     }
   }

--- a/packages/cli/lib/serverlessLogs.js
+++ b/packages/cli/lib/serverlessLogs.js
@@ -1,0 +1,92 @@
+const readline = require('readline');
+const ora = require('ora');
+
+const {
+  getFunctionLogs,
+  getLatestFunctionLog,
+} = require('@hubspot/cli-lib/api/results');
+
+const { outputLogs } = require('@hubspot/cli-lib/lib/logs');
+const {
+  logServerlessFunctionApiErrorInstance,
+  ApiErrorContext,
+} = require('@hubspot/cli-lib/errorHandlers');
+const { base64EncodeString } = require('@hubspot/cli-lib/lib/encoding');
+
+const TAIL_DELAY = 5000;
+
+const makeSpinner = (functionPath, accountId) => {
+  return ora(
+    `Waiting for log entries for '${functionPath}' on account '${accountId}'.\n`
+  );
+};
+
+const makeTailCall = (accountId, functionId) => {
+  return async after => {
+    const latestLog = await getFunctionLogs(accountId, functionId, { after });
+    return latestLog;
+  };
+};
+
+const handleKeypressToExit = exit => {
+  readline.emitKeypressEvents(process.stdin);
+  process.stdin.setRawMode(true);
+  process.stdin.on('keypress', (str, key) => {
+    if (key && ((key.ctrl && key.name == 'c') || key.name === 'escape')) {
+      exit();
+    }
+  });
+};
+
+const tailLogs = async ({
+  functionId,
+  functionPath,
+  accountId,
+  accountName,
+  compact,
+}) => {
+  const tailCall = makeTailCall(accountId, functionId);
+  const spinner = makeSpinner(functionPath, accountName || accountId);
+  let initialAfter;
+
+  spinner.start();
+
+  try {
+    const latestLog = await getLatestFunctionLog(accountId, functionId);
+    initialAfter = base64EncodeString(latestLog.id);
+  } catch (e) {
+    // A 404 means no latest log exists(never executed)
+    if (e.statusCode !== 404) {
+      await logServerlessFunctionApiErrorInstance(
+        accountId,
+        e,
+        new ApiErrorContext({ accountId, functionPath })
+      );
+    }
+  }
+
+  const tail = async after => {
+    const latestLog = await tailCall(after);
+
+    if (latestLog.results.length) {
+      spinner.clear();
+      outputLogs(latestLog, {
+        compact,
+      });
+    }
+
+    setTimeout(() => {
+      tail(latestLog.paging.next.after);
+    }, TAIL_DELAY);
+  };
+
+  handleKeypressToExit(() => {
+    spinner.stop();
+    process.exit();
+  });
+  tail(initialAfter);
+};
+
+module.exports = {
+  tailLogs,
+};

--- a/packages/cli/lib/serverlessLogs.js
+++ b/packages/cli/lib/serverlessLogs.js
@@ -63,7 +63,7 @@ const tailLogs = async ({
     spinner.stop();
     process.exit();
   });
-  tail(initialAfter);
+  await tail(initialAfter);
 };
 
 module.exports = {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -21,6 +21,9 @@
     "update-notifier": "3.0.1",
     "yargs": "15.4.1"
   },
+  "devDependencies": {
+    "mock-stdin": "^1.0.0"
+  },
   "engines": {
     "node": ">=10"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6430,7 +6430,7 @@ mkdirp@^1.0.3, mkdirp@^1.0.4:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
-mock-stdin@1.0.0:
+mock-stdin@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/mock-stdin/-/mock-stdin-1.0.0.tgz#efcfaf4b18077e14541742fd758b9cae4e5365ea"
   integrity sha512-tukRdb9Beu27t6dN+XztSRHq9J0B/CoAOySGzHfn8UTfmqipA5yNT/sDUEyYdAV3Hpka6Wx6kOMxuObdOex60Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,19 +2,19 @@
 # yarn lockfile v1
 
 
-"@babel/code-frame@7.12.11", "@babel/code-frame@^7.10.4":
-  version "7.12.11"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.11.tgz#f4ad435aa263db935b8f10f2c552d23fb716a63f"
-  integrity sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==
-  dependencies:
-    "@babel/highlight" "^7.10.4"
-
 "@babel/code-frame@^7.0.0":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.13.tgz#dcfc826beef65e75c50e21d3837d7d95798dd658"
   integrity sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==
   dependencies:
     "@babel/highlight" "^7.12.13"
+
+"@babel/code-frame@^7.10.4":
+  version "7.12.11"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.11.tgz#f4ad435aa263db935b8f10f2c552d23fb716a63f"
+  integrity sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==
+  dependencies:
+    "@babel/highlight" "^7.10.4"
 
 "@babel/core@^7.1.0", "@babel/core@^7.7.5":
   version "7.12.10"
@@ -296,21 +296,6 @@
   dependencies:
     exec-sh "^0.3.2"
     minimist "^1.2.0"
-
-"@eslint/eslintrc@^0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.4.0.tgz#99cc0a0584d72f1df38b900fb062ba995f395547"
-  integrity sha512-2ZPCc+uNbjV5ERJr+aKSPRwZgKd2z11x0EgLvb1PURmUrn9QNRXFqje0Ldq454PfAVyaJYyrDvvIKSFP4NnBog==
-  dependencies:
-    ajv "^6.12.4"
-    debug "^4.1.1"
-    espree "^7.3.0"
-    globals "^12.1.0"
-    ignore "^4.0.6"
-    import-fresh "^3.2.1"
-    js-yaml "^3.13.1"
-    minimatch "^3.0.4"
-    strip-json-comments "^3.1.1"
 
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
@@ -1572,11 +1557,6 @@ acorn-jsx@^5.2.0:
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.2.0.tgz#4c66069173d6fdd68ed85239fc256226182b2ebe"
   integrity sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==
 
-acorn-jsx@^5.3.1:
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.1.tgz#fc8661e11b7ac1539c47dbfea2e72b3af34d267b"
-  integrity sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==
-
 acorn-walk@^7.1.1:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.2.0.tgz#0de889a601203909b0fbe07b8938dc21d2e967bc"
@@ -1586,11 +1566,6 @@ acorn@^7.1.1:
   version "7.4.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.0.tgz#e1ad486e6c54501634c6c397c5c121daa383607c"
   integrity sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==
-
-acorn@^7.4.0:
-  version "7.4.1"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
-  integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
 add-stream@^1.0.0:
   version "1.0.0"
@@ -1657,11 +1632,6 @@ ansi-align@^3.0.0:
   integrity sha512-ZpClVKqXN3RGBmKibdfWzqCY4lnjEuoNzU5T0oEFpfd/z5qJHVarukridD4juLO2FXMiwUQxr9WqQtaYa8XRYw==
   dependencies:
     string-width "^3.0.0"
-
-ansi-colors@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.1.tgz#cbb9ae256bf750af1eab344f229aa27fe94ba348"
-  integrity sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==
 
 ansi-escapes@^3.0.0, ansi-escapes@^3.2.0:
   version "3.2.0"
@@ -2795,7 +2765,7 @@ cross-spawn@^6.0.0, cross-spawn@^6.0.5:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
+cross-spawn@^7.0.0, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
@@ -2947,7 +2917,7 @@ deep-extend@^0.6.0:
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
   integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
-deep-is@^0.1.3, deep-is@~0.1.3:
+deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
@@ -3307,13 +3277,6 @@ enhanced-resolve@^5.3.2:
     graceful-fs "^4.2.4"
     tapable "^2.2.0"
 
-enquirer@^2.3.5:
-  version "2.3.6"
-  resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.3.6.tgz#2a7fe5dd634a1e4125a975ec994ff5456dc3734d"
-  integrity sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==
-  dependencies:
-    ansi-colors "^4.1.1"
-
 env-paths@^2.2.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-2.2.1.tgz#420399d416ce1fbe9bc0a07c62fa68d67fd0f8f2"
@@ -3407,14 +3370,6 @@ eslint-scope@^5.0.0:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint-scope@^5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
-  integrity sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==
-  dependencies:
-    esrecurse "^4.3.0"
-    estraverse "^4.1.1"
-
 eslint-utils@^1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.4.3.tgz#74fec7c54d0776b6f67e0251040b5806564e981f"
@@ -3422,14 +3377,7 @@ eslint-utils@^1.4.3:
   dependencies:
     eslint-visitor-keys "^1.1.0"
 
-eslint-utils@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-2.1.0.tgz#d2de5e03424e707dc10c74068ddedae708741b27"
-  integrity sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==
-  dependencies:
-    eslint-visitor-keys "^1.1.0"
-
-eslint-visitor-keys@^1.1.0, eslint-visitor-keys@^1.3.0:
+eslint-visitor-keys@^1.1.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz#30ebd1ef7c2fdff01c3a4f151044af25fab0523e"
   integrity sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==
@@ -3482,49 +3430,6 @@ eslint@^6.5.1:
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
 
-eslint@^7.23.0:
-  version "7.24.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.24.0.tgz#2e44fa62d93892bfdb100521f17345ba54b8513a"
-  integrity sha512-k9gaHeHiFmGCDQ2rEfvULlSLruz6tgfA8DEn+rY9/oYPFFTlz55mM/Q/Rij1b2Y42jwZiK3lXvNTw6w6TXzcKQ==
-  dependencies:
-    "@babel/code-frame" "7.12.11"
-    "@eslint/eslintrc" "^0.4.0"
-    ajv "^6.10.0"
-    chalk "^4.0.0"
-    cross-spawn "^7.0.2"
-    debug "^4.0.1"
-    doctrine "^3.0.0"
-    enquirer "^2.3.5"
-    eslint-scope "^5.1.1"
-    eslint-utils "^2.1.0"
-    eslint-visitor-keys "^2.0.0"
-    espree "^7.3.1"
-    esquery "^1.4.0"
-    esutils "^2.0.2"
-    file-entry-cache "^6.0.1"
-    functional-red-black-tree "^1.0.1"
-    glob-parent "^5.0.0"
-    globals "^13.6.0"
-    ignore "^4.0.6"
-    import-fresh "^3.0.0"
-    imurmurhash "^0.1.4"
-    is-glob "^4.0.0"
-    js-yaml "^3.13.1"
-    json-stable-stringify-without-jsonify "^1.0.1"
-    levn "^0.4.1"
-    lodash "^4.17.21"
-    minimatch "^3.0.4"
-    natural-compare "^1.4.0"
-    optionator "^0.9.1"
-    progress "^2.0.0"
-    regexpp "^3.1.0"
-    semver "^7.2.1"
-    strip-ansi "^6.0.0"
-    strip-json-comments "^3.1.0"
-    table "^6.0.4"
-    text-table "^0.2.0"
-    v8-compile-cache "^2.0.3"
-
 espree@^6.1.2:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/espree/-/espree-6.2.1.tgz#77fc72e1fd744a2052c20f38a5b575832e82734a"
@@ -3533,15 +3438,6 @@ espree@^6.1.2:
     acorn "^7.1.1"
     acorn-jsx "^5.2.0"
     eslint-visitor-keys "^1.1.0"
-
-espree@^7.3.0, espree@^7.3.1:
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-7.3.1.tgz#f2df330b752c6f55019f8bd89b7660039c1bbbb6"
-  integrity sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==
-  dependencies:
-    acorn "^7.4.0"
-    acorn-jsx "^5.3.1"
-    eslint-visitor-keys "^1.3.0"
 
 esprima@4.0.1, esprima@^4.0.0, esprima@^4.0.1:
   version "4.0.1"
@@ -3555,13 +3451,6 @@ esquery@^1.0.1:
   dependencies:
     estraverse "^5.1.0"
 
-esquery@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.4.0.tgz#2148ffc38b82e8c7057dfed48425b3e61f0f24a5"
-  integrity sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==
-  dependencies:
-    estraverse "^5.1.0"
-
 esrecurse@^4.1.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.2.1.tgz#007a3b9fdbc2b3bb87e4879ea19c92fdbd3942cf"
@@ -3569,19 +3458,12 @@ esrecurse@^4.1.0:
   dependencies:
     estraverse "^4.1.0"
 
-esrecurse@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.3.0.tgz#7ad7964d679abb28bee72cec63758b1c5d2c9921"
-  integrity sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==
-  dependencies:
-    estraverse "^5.2.0"
-
 estraverse@^4.1.0, estraverse@^4.1.1, estraverse@^4.2.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
   integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
 
-estraverse@^5.1.0, estraverse@^5.2.0:
+estraverse@^5.1.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.2.0.tgz#307df42547e6cc7324d3cf03c155d5cdb8c53880"
   integrity sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==
@@ -3820,7 +3702,7 @@ fast-json-stable-stringify@^2.0.0:
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
 
-fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
+fast-levenshtein@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
@@ -3874,13 +3756,6 @@ file-entry-cache@^5.0.1:
   integrity sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==
   dependencies:
     flat-cache "^2.0.1"
-
-file-entry-cache@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-6.0.1.tgz#211b2dd9659cb0394b073e7323ac3c933d522027"
-  integrity sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==
-  dependencies:
-    flat-cache "^3.0.4"
 
 filing-cabinet@^3.0.0:
   version "3.0.0"
@@ -3985,23 +3860,10 @@ flat-cache@^2.0.1:
     rimraf "2.6.3"
     write "1.0.3"
 
-flat-cache@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-3.0.4.tgz#61b0338302b2fe9f957dcc32fc2a87f1c3048b11"
-  integrity sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==
-  dependencies:
-    flatted "^3.1.0"
-    rimraf "^3.0.2"
-
 flatted@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
-
-flatted@^3.1.0:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.1.1.tgz#c4b489e80096d9df1dfc97c79871aea7c617c469"
-  integrity sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==
 
 flatten@^1.0.2:
   version "1.0.3"
@@ -4357,13 +4219,6 @@ globals@^12.1.0:
   integrity sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==
   dependencies:
     type-fest "^0.8.1"
-
-globals@^13.6.0:
-  version "13.8.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-13.8.0.tgz#3e20f504810ce87a8d72e55aecf8435b50f4c1b3"
-  integrity sha512-rHtdA6+PDBIjeEvA91rpqzEvk/k3/i7EeNQiryiWuJH0Hw9cpyJMAt2jtbAwUaRdhD+573X4vWw6IcjKPasi9Q==
-  dependencies:
-    type-fest "^0.20.2"
 
 globby@^11.0.1:
   version "11.0.2"
@@ -5936,14 +5791,6 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-levn@^0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/levn/-/levn-0.4.1.tgz#ae4562c007473b932a6200d403268dd2fffc6ade"
-  integrity sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==
-  dependencies:
-    prelude-ls "^1.2.1"
-    type-check "~0.4.0"
-
 libnpmaccess@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/libnpmaccess/-/libnpmaccess-4.0.1.tgz#17e842e03bef759854adf6eb6c2ede32e782639f"
@@ -6133,7 +5980,7 @@ lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
 
-lodash@^4.17.12, lodash@^4.17.15, lodash@^4.17.21:
+lodash@^4.17.12, lodash@^4.17.15:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -6582,6 +6429,11 @@ mkdirp@^1.0.3, mkdirp@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
+
+mock-stdin@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/mock-stdin/-/mock-stdin-1.0.0.tgz#efcfaf4b18077e14541742fd758b9cae4e5365ea"
+  integrity sha512-tukRdb9Beu27t6dN+XztSRHq9J0B/CoAOySGzHfn8UTfmqipA5yNT/sDUEyYdAV3Hpka6Wx6kOMxuObdOex60Q==
 
 modify-values@^1.0.0:
   version "1.0.1"
@@ -7054,18 +6906,6 @@ optionator@^0.8.1, optionator@^0.8.3:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
     word-wrap "~1.2.3"
-
-optionator@^0.9.1:
-  version "0.9.1"
-  resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.9.1.tgz#4f236a6373dae0566a6d43e1326674f50c291499"
-  integrity sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==
-  dependencies:
-    deep-is "^0.1.3"
-    fast-levenshtein "^2.0.6"
-    levn "^0.4.1"
-    prelude-ls "^1.2.1"
-    type-check "^0.4.0"
-    word-wrap "^1.2.3"
 
 ora@^4.0.3:
   version "4.1.1"
@@ -7547,11 +7387,6 @@ precinct@^7.0.0:
     module-definition "^3.3.1"
     node-source-walk "^4.2.0"
 
-prelude-ls@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
-  integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
-
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
@@ -7946,11 +7781,6 @@ regexpp@^2.0.1:
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-2.0.1.tgz#8d19d31cf632482b589049f8281f93dbcba4d07f"
   integrity sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==
 
-regexpp@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.1.0.tgz#206d0ad0a5648cffbdb8ae46438f3dc51c9f78e2"
-  integrity sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==
-
 registry-auth-token@^4.0.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/registry-auth-token/-/registry-auth-token-4.2.0.tgz#1d37dffda72bbecd0f581e4715540213a65eb7da"
@@ -8303,7 +8133,7 @@ semver@^6.0.0, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-semver@^7.1.1, semver@^7.1.3, semver@^7.2.1, semver@^7.3.4:
+semver@^7.1.1, semver@^7.1.3, semver@^7.3.4:
   version "7.3.5"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
   integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
@@ -8857,7 +8687,7 @@ strip-indent@^3.0.0:
   dependencies:
     min-indent "^1.0.0"
 
-strip-json-comments@^3.0.1, strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
+strip-json-comments@^3.0.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
@@ -9212,13 +9042,6 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
   integrity sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
 
-type-check@^0.4.0, type-check@~0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.4.0.tgz#07b8203bfa7056c0657050e3ccd2c37730bab8f1"
-  integrity sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==
-  dependencies:
-    prelude-ls "^1.2.1"
-
 type-check@~0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
@@ -9240,11 +9063,6 @@ type-fest@^0.18.0:
   version "0.18.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.18.1.tgz#db4bc151a4a2cf4eebf9add5db75508db6cc841f"
   integrity sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==
-
-type-fest@^0.20.2:
-  version "0.20.2"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
-  integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
 
 type-fest@^0.3.0:
   version "0.3.1"
@@ -9625,7 +9443,7 @@ widest-line@^2.0.0:
   dependencies:
     string-width "^2.1.1"
 
-word-wrap@^1.2.3, word-wrap@~1.2.3:
+word-wrap@~1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==


### PR DESCRIPTION
## Description and Context

This PR adds support for accessing serverless app function logs through expanding the `hs logs` command. The new options will remain undocumented for now.

An example of the format is `hs logs --appFunction=weatherCard --app=/hello-world-app`

## TODO

- [ ] See if `yargs` supports having option work as both a positional and option. If so, add `--endpoint` so that there is symmetry
- [x] Add some unit test coverage

## Who to Notify
@miketalley
