### PR TITLE
Fix typo in check

### DIFF
--- a/packages/cli-lib/http.js
+++ b/packages/cli-lib/http.js
@@ -157,7 +157,7 @@ const createGetRequestStream = ({ contentType }) => async (
 
           if (fs.existsSync(destPath)) {
             const stat = fs.statSync(destPath);
-            if (stat.isDirectory) {
+            if (stat.isDirectory()) {
               const { parameters } = contentDisposition.parse(
                 res.headers['content-disposition']
               );


### PR DESCRIPTION
@drewjenkins pointed out that there was a mistake in the logic to determine if a path is a directory. This fixes it.