### PR TITLE
Updated endpoint for deploying serverless functions

### DIFF
--- a/packages/cli-lib/api/functions.js
+++ b/packages/cli-lib/api/functions.js
@@ -15,7 +15,10 @@ async function getRoutes(accountId) {
 
 async function buildPackage(portalId, folderPath) {
   return http.post(portalId, {
-    uri: `${FUNCTION_API_PATH}/build`,
+    uri: `${FUNCTION_API_PATH}/build/async`,
+    headers: {
+      Accept: 'text/plain',
+    },
     body: {
       folderPath,
     },


### PR DESCRIPTION
## Description and Context
The update to add serverless deployment menus within the DesignManager UI requires updating the response value of the endpoint to be `text/plain`. When updating the endpoint to return that type, it breaks the CLI command that uses it.

There was an update to the endpoint with a new path of `/build/async` that returns `text/plain`. This work updates the CLI to utilize that new endpoint.

## Who to Notify
@bkrainer 
