### PR TITLE
Set output width to 80% of terminal width

### DIFF
--- a/packages/cli/bin/cli.js
+++ b/packages/cli/bin/cli.js
@@ -50,7 +50,6 @@ const getTerminalWidth = () => {
 };
 
 const argv = yargs
-
   .usage('Tools for working with HubSpot')
   .middleware([setLogLevel])
   .exitProcess(false)

--- a/packages/cli/bin/cli.js
+++ b/packages/cli/bin/cli.js
@@ -88,6 +88,7 @@ const argv = yargs
   .recommendCommands()
   .demandCommand(1, '')
   .completion()
+  .wrap(yargs.terminalWidth() * 0.8)
   .strict().argv;
 
 if (argv.help) {

--- a/packages/cli/bin/cli.js
+++ b/packages/cli/bin/cli.js
@@ -41,7 +41,16 @@ notifier.notify({
   message: pkg.name === '@hubspot/cms-cli' ? CLI_UPGRADE_MESSAGE : null,
 });
 
+const getTerminalWidth = () => {
+  const width = yargs.terminalWidth();
+
+  if (width >= 100) return width * 0.9;
+
+  return width;
+};
+
 const argv = yargs
+
   .usage('Tools for working with HubSpot')
   .middleware([setLogLevel])
   .exitProcess(false)
@@ -88,7 +97,7 @@ const argv = yargs
   .recommendCommands()
   .demandCommand(1, '')
   .completion()
-  .wrap(yargs.terminalWidth() * 0.8)
+  .wrap(getTerminalWidth())
   .strict().argv;
 
 if (argv.help) {


### PR DESCRIPTION
## Description and Context
Before the width of the output was hardcoded to a width that was pretty short.  It made some of our descriptions hard to read because there was a lot of text wrapping.  This makes the width dynamic to the width of your terminal.

## Screenshots
Before
![image](https://user-images.githubusercontent.com/5521743/117836031-5a74f000-b246-11eb-84d2-2867154291a1.png)

After
![image](https://user-images.githubusercontent.com/5521743/117835987-50eb8800-b246-11eb-844a-d50ed99eb037.png)


## TODO
Does 80% seem good? Should we go wider?