### PR TITLE
Provide more context when an app deploy fails

### DIFF
--- a/packages/cli/commands/app/deploy.js
+++ b/packages/cli/commands/app/deploy.js
@@ -39,11 +39,11 @@ const logServerlessBuildFailures = async errorDetails => {
   const folderPaths = errorDetails.context.folderPath;
   const buildLogUrls = errorDetails.context.serverlessBuildLogUrl;
   for (let i = 0; i < buildLogUrls.length; i++) {
-    logger.log(`Building serverless functions in "${folderPaths[i]}"`);
+    logger.log(`Building serverless functions in "${folderPaths[i]}":`);
     await outputBuildLog(buildLogUrls[i]);
   }
   logger.error(
-    'Your app failed to build and deploy due a problem building the serverless functions'
+    'Your app failed to build and deploy due to a problem building the serverless functions.'
   );
 };
 

--- a/packages/cli/commands/functions/deploy.js
+++ b/packages/cli/commands/functions/deploy.js
@@ -107,8 +107,7 @@ exports.handler = async options => {
     } else if (e.statusCode === 400) {
       logger.error(e.error.message);
     } else if (e.status === 'ERROR') {
-      const buildOutput = await outputBuildLog(e.cdnUrl);
-      logger.log(buildOutput);
+      await outputBuildLog(e.cdnUrl);
       logger.error(`Build error: ${e.errorReason}`);
     } else {
       logApiErrorInstance(

--- a/packages/cli/commands/functions/deploy.js
+++ b/packages/cli/commands/functions/deploy.js
@@ -1,5 +1,4 @@
 const ora = require('ora');
-const https = require('https');
 const {
   addAccountOptions,
   addConfigOptions,
@@ -25,6 +24,7 @@ const {
   getBuildStatus,
 } = require('@hubspot/cli-lib/api/functions');
 const { validateAccount } = require('../../lib/validation');
+const { outputBuildLog } = require('../../lib/serverlessLogs');
 
 const makeSpinner = (actionText, functionPath, accountIdentifier) => {
   return ora(
@@ -59,41 +59,6 @@ const loadAndValidateOptions = async options => {
   if (!(validateConfig() && (await validateAccount(options)))) {
     process.exit(1);
   }
-};
-
-const logBuildOutput = async resp => {
-  const { cdnUrl } = resp;
-
-  if (!cdnUrl) {
-    logger.debug(
-      'Unable to display build output. No build log URL was provided.'
-    );
-    return;
-  }
-
-  return new Promise((resolve, reject) => {
-    try {
-      https
-        .get(resp.cdnUrl, response => {
-          // If the cdnUrl is not found, just display success message
-          if (response.statusCode === 404) {
-            resolve('');
-          }
-
-          let data = '';
-          response.on('data', chunk => {
-            data += chunk;
-          });
-          response.on('end', () => {
-            logger.log(data);
-            resolve(data);
-          });
-        })
-        .on('error', reject);
-    } catch (e) {
-      reject(e);
-    }
-  });
 };
 
 exports.command = 'deploy <path>';
@@ -131,7 +96,7 @@ exports.handler = async options => {
     const successResp = await pollBuildStatus(accountId, buildId);
     const buildTimeSeconds = (successResp.buildTime / 1000).toFixed(2);
     spinner.stop();
-    await logBuildOutput(successResp);
+    await outputBuildLog(successResp.cdnUrl);
     logger.success(
       `Built and deployed bundle from package.json for ${functionPath} on account ${accountId} in ${buildTimeSeconds}s.`
     );
@@ -142,7 +107,7 @@ exports.handler = async options => {
     } else if (e.statusCode === 400) {
       logger.error(e.error.message);
     } else if (e.status === 'ERROR') {
-      const buildOutput = await logBuildOutput(e);
+      const buildOutput = await outputBuildLog(e.cdnUrl);
       logger.log(buildOutput);
       logger.error(`Build error: ${e.errorReason}`);
     } else {

--- a/packages/cli/lib/serverlessLogs.js
+++ b/packages/cli/lib/serverlessLogs.js
@@ -1,5 +1,7 @@
+const https = require('https');
 const readline = require('readline');
 
+const { logger } = require('@hubspot/cli-lib/logger');
 const { outputLogs } = require('@hubspot/cli-lib/lib/logs');
 const {
   logServerlessFunctionApiErrorInstance,
@@ -82,6 +84,39 @@ const tailLogs = async ({
   await tail(initialAfter);
 };
 
+const outputBuildLog = async buildLogUrl => {
+  if (!buildLogUrl) {
+    logger.debug(
+      'Unable to display build output. No build log URL was provided.'
+    );
+    return;
+  }
+
+  return new Promise((resolve, reject) => {
+    try {
+      https
+        .get(buildLogUrl, response => {
+          if (response.statusCode === 404) {
+            resolve('');
+          }
+
+          let data = '';
+          response.on('data', chunk => {
+            data += chunk;
+          });
+          response.on('end', () => {
+            logger.log(data);
+            resolve(data);
+          });
+        })
+        .on('error', reject);
+    } catch (e) {
+      reject(e);
+    }
+  });
+};
+
 module.exports = {
+  outputBuildLog,
   tailLogs,
 };

--- a/packages/cli/lib/serverlessLogs.js
+++ b/packages/cli/lib/serverlessLogs.js
@@ -92,7 +92,7 @@ const outputBuildLog = async buildLogUrl => {
     return;
   }
 
-  return new Promise((resolve, reject) => {
+  return new Promise(resolve => {
     try {
       https
         .get(buildLogUrl, response => {
@@ -109,9 +109,12 @@ const outputBuildLog = async buildLogUrl => {
             resolve(data);
           });
         })
-        .on('error', reject);
+        .on('error', () => {
+          logger.error('The build log could not be retrieved.');
+        });
     } catch (e) {
-      reject(e);
+      logger.error('The build log could not be retrieved.');
+      resolve('');
     }
   });
 };


### PR DESCRIPTION
## Description and Context

When an app build/deploy fails, we need to provide more context to the developer about why it failed so that they can resolve it.

This also includes a fix for the build log being output twice when there is a build failure when running `hs functions deploy`.

## Screenshots

Before:
![image](https://user-images.githubusercontent.com/266036/118291760-f18bb300-b4a5-11eb-99e6-082e5b2b2584.png)

After:
![image](https://user-images.githubusercontent.com/266036/118292091-45969780-b4a6-11eb-8c47-384e1ae8c8bc.png)

## Who to Notify
@miketalley
