### PR TITLE
resolves #502 by providing better error messaging.

### DIFF
--- a/packages/cli/commands/create.js
+++ b/packages/cli/commands/create.js
@@ -152,7 +152,7 @@ exports.handler = async options => {
 
   if (assetType === 'global-partial') {
     logger.error(
-      `The asset type ${assetType} has been deprecated. Please choose the "template" asset and select "global partial".`
+      `The CLI command for asset type ${assetType} has been deprecated in an effort to make it easier to know what asset types can be created. Run the "hs create template" command instead. Then when prompted select "global partial".`
     );
     return;
   }


### PR DESCRIPTION
## Description and Context
resolves #502. Old error messaging was confusing and made it seem global partials were deprecated. We were actually just deprecating the command in favor of a different command.
`[ERROR] The asset type global-partial has been deprecated. Please choose the "template" asset and select "global partial".`


I think it's also worth evaluating if 
https://github.com/HubSpot/hubspot-cli/blob/98ebf65eb741b4b5319e8be73a09e0b84f19e8d3/packages/cli/commands/create.js#L162 
could cause confusion as well. After all the error is just that the CLI doesn't support the asset type in the command. Doesn't mean it's not supported period.
## TODO

I would appreciate a review of this PR, it should be fine but I haven't worked on the CLI directly yet.

## Who to Notify
<!-- /cc those you wish to know about the PR -->
