### PR TITLE
Granular template checks for marketplace theme validation

### DIFF
--- a/packages/cli-lib/__tests__/templates.js
+++ b/packages/cli-lib/__tests__/templates.js
@@ -1,8 +1,4 @@
-const fs = require('fs');
-
-const { isCodedFile } = require('../templates');
-
-jest.mock('fs');
+const { getAnnotationValue, isCodedFile } = require('../templates');
 
 const makeAnnotation = (options = {}) => {
   let result = '<!--\n';
@@ -16,7 +12,7 @@ const makeAnnotation = (options = {}) => {
 
 describe('cli-lib/templates', () => {
   describe('isCodedFile()', () => {
-    it('should return falseinvalid input', () => {
+    it('should return false for invalid input', () => {
       expect(isCodedFile()).toBe(false);
       expect(isCodedFile(null)).toBe(false);
       expect(isCodedFile(1)).toBe(false);
@@ -25,20 +21,19 @@ describe('cli-lib/templates', () => {
       expect(isCodedFile('folder.module/module.html')).toBe(false);
     });
     it('should return true for templates', () => {
-      // Without isAvailableForNewContent
-      fs.readFileSync.mockReturnValue(makeAnnotation({ templateType: 'page' }));
+      expect(isCodedFile('folder/template.html')).toBe(true);
+    });
+  });
 
-      expect(isCodedFile('folder.module/template.html')).toBe(true);
+  describe('getAnnotationValue()', () => {
+    it('returns the annotation value', () => {
+      const annotations = makeAnnotation({
+        isAvailableForNewContent: 'true',
+        templateType: 'page',
+      });
 
-      // With isAvailableForNewContent
-      fs.readFileSync.mockReturnValue(
-        makeAnnotation({
-          isAvailableForNewContent: 'true',
-          templateType: 'page',
-        })
-      );
-
-      expect(isCodedFile('folder.module/template.html')).toBe(true);
+      const value = getAnnotationValue(annotations, 'templateType');
+      expect(value).toEqual('page');
     });
   });
 });

--- a/packages/cli-lib/__tests__/templates.js
+++ b/packages/cli-lib/__tests__/templates.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 
-const { isTemplate } = require('../templates');
+const { isCodedFile } = require('../templates');
 
 jest.mock('fs');
 
@@ -15,39 +15,20 @@ const makeAnnotation = (options = {}) => {
 };
 
 describe('cli-lib/templates', () => {
-  describe('isTemplate()', () => {
+  describe('isCodedFile()', () => {
     it('should return falseinvalid input', () => {
-      expect(isTemplate()).toBe(false);
-      expect(isTemplate(null)).toBe(false);
-      expect(isTemplate(1)).toBe(false);
+      expect(isCodedFile()).toBe(false);
+      expect(isCodedFile(null)).toBe(false);
+      expect(isCodedFile(1)).toBe(false);
     });
     it('should return false for modules', () => {
-      expect(isTemplate('folder.module/module.html')).toBe(false);
-    });
-    it('should return false for partials', () => {
-      // Standard partials
-      fs.readFileSync.mockReturnValue(
-        makeAnnotation({ isAvailableForNewContent: 'false' })
-      );
-      expect(isTemplate('folder.module/partial.html')).toBe(false);
-
-      // Global partials
-      fs.readFileSync.mockReturnValue(
-        makeAnnotation({ templateType: 'global_partial' })
-      );
-
-      expect(isTemplate('folder.module/partial.html')).toBe(false);
-    });
-    it('should return false for templateType none', () => {
-      fs.readFileSync.mockReturnValue(makeAnnotation({ templateType: 'none' }));
-
-      expect(isTemplate('folder.module/template.html')).toBe(false);
+      expect(isCodedFile('folder.module/module.html')).toBe(false);
     });
     it('should return true for templates', () => {
       // Without isAvailableForNewContent
       fs.readFileSync.mockReturnValue(makeAnnotation({ templateType: 'page' }));
 
-      expect(isTemplate('folder.module/template.html')).toBe(true);
+      expect(isCodedFile('folder.module/template.html')).toBe(true);
 
       // With isAvailableForNewContent
       fs.readFileSync.mockReturnValue(
@@ -57,7 +38,7 @@ describe('cli-lib/templates', () => {
         })
       );
 
-      expect(isTemplate('folder.module/template.html')).toBe(true);
+      expect(isCodedFile('folder.module/template.html')).toBe(true);
     });
   });
 });

--- a/packages/cli-lib/templates.js
+++ b/packages/cli-lib/templates.js
@@ -36,24 +36,8 @@ const getAnnotationValue = (annotations, key) => {
 /*
  * Returns true if:
  * .html extension (ignoring module.html)
- * isAvailableForNewContent is null or true
  */
-const isCodedFile = filePath => {
-  if (TEMPLATE_EXTENSION_REGEX.test(filePath)) {
-    const annotations = getFileAnnotations(filePath);
-    if (!annotations.length) {
-      return false;
-    }
-
-    const isAvailableForNewContent = getAnnotationValue(
-      annotations,
-      ANNOTATION_KEYS.isAvailableForNewContent
-    );
-
-    return isAvailableForNewContent !== 'false';
-  }
-  return false;
-};
+const isCodedFile = filePath => TEMPLATE_EXTENSION_REGEX.test(filePath);
 
 module.exports = {
   ANNOTATION_KEYS,

--- a/packages/cli-lib/templates.js
+++ b/packages/cli-lib/templates.js
@@ -37,28 +37,20 @@ const getAnnotationValue = (annotations, key) => {
  * Returns true if:
  * .html extension (ignoring module.html)
  * isAvailableForNewContent is null or true
- * templateType is NOT 'global_partial' or 'none'
  */
-const isTemplate = filePath => {
+const isCodedFile = filePath => {
   if (TEMPLATE_EXTENSION_REGEX.test(filePath)) {
     const annotations = getFileAnnotations(filePath);
     if (!annotations.length) {
       return false;
     }
 
-    const templateType = getAnnotationValue(
-      annotations,
-      ANNOTATION_KEYS.templateType
-    );
     const isAvailableForNewContent = getAnnotationValue(
       annotations,
       ANNOTATION_KEYS.isAvailableForNewContent
     );
 
-    return (
-      isAvailableForNewContent !== 'false' &&
-      !['global_partial', 'none'].includes(templateType)
-    );
+    return isAvailableForNewContent !== 'false';
   }
   return false;
 };
@@ -67,5 +59,5 @@ module.exports = {
   ANNOTATION_KEYS,
   getAnnotationValue,
   getFileAnnotations,
-  isTemplate,
+  isCodedFile,
 };

--- a/packages/cli/commands/marketplaceValidate/validateTheme.js
+++ b/packages/cli/commands/marketplaceValidate/validateTheme.js
@@ -13,6 +13,7 @@ const { walk } = require('@hubspot/cli-lib');
 const {
   addConfigOptions,
   addAccountOptions,
+  addUseEnvironmentOptions,
   setLogLevel,
   getAccountId,
 } = require('../../lib/commonOpts');
@@ -78,6 +79,8 @@ exports.handler = async options => {
 exports.builder = yargs => {
   addConfigOptions(yargs, true);
   addAccountOptions(yargs, true);
+  addUseEnvironmentOptions(yargs, true);
+
   yargs.options({
     json: {
       describe: 'Output raw json data',

--- a/packages/cli/commands/watch.js
+++ b/packages/cli/commands/watch.js
@@ -81,9 +81,12 @@ exports.handler = async options => {
     logger.info(
       `The "watch" command no longer uploads the watched directory when started. The directory "${src}" was not uploaded.`
     );
-    logger.info(
-      'To upload the directory run "hs upload" beforehand or add the "--initial-upload" option when running "hs watch".'
-    );
+
+    if (!initialUpload) {
+      logger.info(
+        'To upload the directory run "hs upload" beforehand or add the "--initial-upload" option when running "hs watch".'
+      );
+    }
   }
 
   trackCommandUsage('watch', { mode }, accountId);

--- a/packages/cli/lib/validators/__tests__/ModuleValidator.js
+++ b/packages/cli/lib/validators/__tests__/ModuleValidator.js
@@ -1,31 +1,19 @@
 const fs = require('fs');
 const ModuleValidator = require('../marketplaceValidators/theme/ModuleValidator');
 const { VALIDATION_RESULT } = require('../constants');
+const { generateModulesList, makeFindError } = require('./validatorTestUtils');
 
 jest.mock('fs');
 
 const MODULE_LIMIT = 50;
 
-const makeFilesList = numFiles => {
-  const files = [];
-  for (let i = 0; i < numFiles; i++) {
-    const base = `module-${i}.module`;
-    files.push(`${base}/meta.json`);
-    files.push(`${base}/fields.json`);
-    files.push(`${base}/module.html`);
-    files.push(`${base}/module.js`);
-  }
-  return files;
-};
-
-const findError = (errors, errorKey) =>
-  errors.find(error => error.key === `module.${errorKey}`);
+const findError = makeFindError('module');
 
 describe('validators/marketplaceValidators/theme/ModuleValidator', () => {
   it('returns error if module limit is exceeded', async () => {
     const validationErrors = ModuleValidator.validate(
       'dirName',
-      makeFilesList(MODULE_LIMIT + 1)
+      generateModulesList(MODULE_LIMIT + 1)
     );
     const limitError = findError(validationErrors, 'limitExceeded');
     expect(limitError).toBeDefined();
@@ -35,7 +23,7 @@ describe('validators/marketplaceValidators/theme/ModuleValidator', () => {
   it('returns no limit error if module limit is not exceeded', async () => {
     const validationErrors = ModuleValidator.validate(
       'dirName',
-      makeFilesList(MODULE_LIMIT)
+      generateModulesList(MODULE_LIMIT)
     );
     const limitError = findError(validationErrors, 'limitExceeded');
     expect(limitError).not.toBeDefined();

--- a/packages/cli/lib/validators/__tests__/TemplateValidator.js
+++ b/packages/cli/lib/validators/__tests__/TemplateValidator.js
@@ -3,19 +3,15 @@ const templates = require('@hubspot/cli-lib/templates');
 
 const TemplateValidator = require('../marketplaceValidators/theme/TemplateValidator');
 const { VALIDATION_RESULT } = require('../constants');
+const {
+  generateTemplatesList,
+  makeFindError,
+} = require('./validatorTestUtils');
 
 jest.mock('fs');
 jest.mock('@hubspot/cli-lib/templates');
 
 const TEMPLATE_LIMIT = 50;
-
-const makeFilesList = numFiles => {
-  const files = [];
-  for (let i = 0; i < numFiles; i++) {
-    files.push(`file-${i}.html`);
-  }
-  return files;
-};
 
 const mockGetAnnotationValue = (templateType, rest) => {
   templates.getAnnotationValue.mockImplementation((x, key) => {
@@ -26,8 +22,7 @@ const mockGetAnnotationValue = (templateType, rest) => {
   });
 };
 
-const findError = (errors, errorKey) =>
-  errors.find(error => error.key === `template.${errorKey}`);
+const findError = makeFindError('template');
 
 describe('validators/marketplaceValidators/theme/TemplateValidator', () => {
   beforeEach(() => {
@@ -39,7 +34,7 @@ describe('validators/marketplaceValidators/theme/TemplateValidator', () => {
 
     const validationErrors = TemplateValidator.validate(
       'dirName',
-      makeFilesList(TEMPLATE_LIMIT + 1)
+      generateTemplatesList(TEMPLATE_LIMIT + 1)
     );
     const limitError = findError(validationErrors, 'limitExceeded');
     expect(limitError).toBeDefined();
@@ -51,7 +46,7 @@ describe('validators/marketplaceValidators/theme/TemplateValidator', () => {
 
     const validationErrors = TemplateValidator.validate(
       'dirName',
-      makeFilesList(TEMPLATE_LIMIT)
+      generateTemplatesList(TEMPLATE_LIMIT)
     );
     const limitError = findError(validationErrors, 'limitExceeded');
     expect(limitError).not.toBeDefined();

--- a/packages/cli/lib/validators/__tests__/TemplateValidator.js
+++ b/packages/cli/lib/validators/__tests__/TemplateValidator.js
@@ -74,7 +74,18 @@ describe('validators/marketplaceValidators/theme/TemplateValidator', () => {
     expect(validationErrors.length).toBe(1);
   });
 
-  it('returns no error if templateType is not found', async () => {
+  it('returns error if template type is unknown', async () => {
+    fs.readFileSync.mockReturnValue('mock');
+    mockGetAnnotationValue('unknown-type', 'value');
+
+    const validationErrors = TemplateValidator.validate('dirName', [
+      'template.html',
+    ]);
+
+    expect(validationErrors.length).toBe(1);
+  });
+
+  it('returns error if template type is not found', async () => {
     fs.readFileSync.mockReturnValue('mock');
     mockGetAnnotationValue(null, 'value');
 
@@ -82,7 +93,7 @@ describe('validators/marketplaceValidators/theme/TemplateValidator', () => {
       'template.html',
     ]);
 
-    expect(validationErrors.length).toBe(0);
+    expect(validationErrors.length).toBe(1);
   });
 
   it('returns no error if template annotation has label and screenshotPath', async () => {

--- a/packages/cli/lib/validators/__tests__/validatorTestUtils.js
+++ b/packages/cli/lib/validators/__tests__/validatorTestUtils.js
@@ -1,0 +1,31 @@
+//HACK so we can keep this util file next to the tests that use it
+test.skip('skip', () => null);
+
+const makeFindError = baseKey => (errors, errorKey) =>
+  errors.find(error => error.key === `${baseKey}.${errorKey}`);
+
+const generateModulesList = numFiles => {
+  const files = [];
+  for (let i = 0; i < numFiles; i++) {
+    const base = `module-${i}.module`;
+    files.push(`${base}/meta.json`);
+    files.push(`${base}/fields.json`);
+    files.push(`${base}/module.html`);
+    files.push(`${base}/module.js`);
+  }
+  return files;
+};
+
+const generateTemplatesList = numFiles => {
+  const files = [];
+  for (let i = 0; i < numFiles; i++) {
+    files.push(`template-${i}.html`);
+  }
+  return files;
+};
+
+module.exports = {
+  generateModulesList,
+  generateTemplatesList,
+  makeFindError,
+};

--- a/packages/cli/lib/validators/marketplaceValidators/theme/TemplateValidator.js
+++ b/packages/cli/lib/validators/marketplaceValidators/theme/TemplateValidator.js
@@ -10,6 +10,7 @@ const BaseValidator = require('../BaseValidator');
 const { logger } = require('@hubspot/cli-lib/logger');
 
 const TEMPLATE_LIMIT = 50;
+const TEMPLATE_COUNT_IGNORE_LIST = ['global_partial', 'none'];
 const VALIDATIONS_BY_TYPE = {
   page: { allowed: true, label: true, screenshot: true },
   starter_landing_pages: { allowed: false },
@@ -102,8 +103,8 @@ class TemplateValidator extends BaseValidator {
             ANNOTATION_KEYS.screenshotPath
           );
 
-          // Exclude global partials and templates with type of none in count
-          if (!['global_partial', 'none'].includes(templateType)) {
+          // Ignore global partials and templates with type of none in count
+          if (!TEMPLATE_COUNT_IGNORE_LIST.includes(templateType)) {
             templateCount++;
           }
 

--- a/packages/cli/lib/validators/marketplaceValidators/theme/TemplateValidator.js
+++ b/packages/cli/lib/validators/marketplaceValidators/theme/TemplateValidator.js
@@ -4,11 +4,52 @@ const {
   ANNOTATION_KEYS,
   getAnnotationValue,
   getFileAnnotations,
-  isTemplate,
+  isCodedFile,
 } = require('@hubspot/cli-lib/templates');
 const BaseValidator = require('../BaseValidator');
+const { logger } = require('@hubspot/cli-lib/logger');
 
 const TEMPLATE_LIMIT = 50;
+const VALIDATIONS_BY_TYPE = {
+  page: { allowed: true, label: true, screenshot: true },
+  starter_landing_pages: { allowed: false },
+  email: { allowed: false },
+  blog: { allowed: false },
+  none: { allowed: true, label: false, screenshot: false },
+  error_page: { allowed: true, label: true, screenshot: false },
+  password_prompt_page: { allowed: true, label: true, screenshot: false },
+  email_subscriptions_preferences_page: {
+    allowed: true,
+    label: true,
+    screenshot: false,
+  },
+  email_backup_unsubscribe_page: {
+    allowed: true,
+    label: true,
+    screenshot: false,
+  },
+  email_subscriptions_confirmation_page: {
+    allowed: true,
+    label: true,
+    screenshot: false,
+  },
+  search_results_page: { allowed: true, label: true, screenshot: false },
+  membership_login_page: { allowed: true, label: true, screenshot: false },
+  membership_register_page: { allowed: true, label: true, screenshot: false },
+  membership_reset_page: { allowed: true, label: true, screenshot: false },
+  membership_reset_request_page: {
+    allowed: true,
+    label: true,
+    screenshot: false,
+  },
+  membership_email_page: { allowed: true, label: true, screenshot: false },
+  global_partial: { allowed: true, label: true, screenshot: false },
+  knowledge_article: { allowed: false },
+  drag_drop_email: { allowed: false },
+  proposal: { allowed: false },
+  blog_listing: { allowed: true, label: true, screenshot: true },
+  blog_post: { allowed: true, label: true, screenshot: true },
+};
 
 class TemplateValidator extends BaseValidator {
   constructor(options) {
@@ -19,6 +60,11 @@ class TemplateValidator extends BaseValidator {
         key: 'limitExceeded',
         getCopy: ({ limit, total }) =>
           `Cannot exceed ${limit} templates in your theme (found ${total})`,
+      },
+      INVALID_TEMPLATE_TYPE: {
+        key: 'invalidTemplateType',
+        getCopy: ({ templatePath, templateType }) =>
+          `Cannot have template type ${templateType} for ${templatePath}`,
       },
       MISSING_LABEL: {
         key: 'missingLabel',
@@ -35,44 +81,75 @@ class TemplateValidator extends BaseValidator {
 
   // Validates:
   // - Theme does not contain more than TEMPLATE_LIMIT templates
-  // - All templates have a "label" annotation
+  // - All templates have valid template types
+  // - All templates that require a label have a "label" annotation
+  // - All templates that require a screenshot have a "screenshotPath" annotation
   validate(absoluteThemePath, files) {
     let validationErrors = [];
-    const templates = files.filter(isTemplate);
-    const numTemplates = templates.length;
+    let templateCount = 0;
 
-    if (numTemplates > TEMPLATE_LIMIT) {
+    files.forEach(filePath => {
+      if (isCodedFile(filePath)) {
+        const annotations = getFileAnnotations(filePath);
+        const templateType = getAnnotationValue(
+          annotations,
+          ANNOTATION_KEYS.templateType
+        );
+        const label = getAnnotationValue(annotations, ANNOTATION_KEYS.label);
+        const sreenshotPath = getAnnotationValue(
+          annotations,
+          ANNOTATION_KEYS.screenshotPath
+        );
+
+        // Exclude global partials and templates with type of none in count
+        if (!['global_partial', 'none'].includes(templateType)) {
+          templateCount++;
+        }
+
+        const validations = VALIDATIONS_BY_TYPE[templateType];
+
+        if (validations) {
+          if (!validations.allowed) {
+            validationErrors.push(
+              this.getError(this.errors.INVALID_TEMPLATE_TYPE, {
+                templatePath: path.relative(absoluteThemePath, filePath),
+                templateType,
+              })
+            );
+          }
+          if (validations.label && !label) {
+            validationErrors.push(
+              this.getError(this.errors.MISSING_LABEL, {
+                templatePath: path.relative(absoluteThemePath, filePath),
+              })
+            );
+          }
+          if (validations.screenshot && !sreenshotPath) {
+            validationErrors.push(
+              this.getError(this.errors.MISSING_SCREENSHOT_PATH, {
+                templatePath: path.relative(absoluteThemePath, filePath),
+              })
+            );
+          }
+        } else {
+          logger.debug(
+            `Unrecognized template type "${templateType}" in ${path.relative(
+              absoluteThemePath,
+              filePath
+            )}`
+          );
+        }
+      }
+    });
+
+    if (templateCount > TEMPLATE_LIMIT) {
       validationErrors.push(
         this.getError(this.errors.LIMIT_EXCEEDED, {
           limit: TEMPLATE_LIMIT,
-          total: numTemplates,
+          total: templateCount,
         })
       );
     }
-
-    templates.forEach(templatePath => {
-      const annotations = getFileAnnotations(templatePath);
-      const label = getAnnotationValue(annotations, ANNOTATION_KEYS.label);
-      const sreenshotPath = getAnnotationValue(
-        annotations,
-        ANNOTATION_KEYS.screenshotPath
-      );
-
-      if (!label) {
-        validationErrors.push(
-          this.getError(this.errors.MISSING_LABEL, {
-            templatePath: path.relative(absoluteThemePath, templatePath),
-          })
-        );
-      }
-      if (!sreenshotPath) {
-        validationErrors.push(
-          this.getError(this.errors.MISSING_SCREENSHOT_PATH, {
-            templatePath: path.relative(absoluteThemePath, templatePath),
-          })
-        );
-      }
-    });
 
     return validationErrors;
   }

--- a/packages/cli/lib/validators/marketplaceValidators/theme/TemplateValidator.js
+++ b/packages/cli/lib/validators/marketplaceValidators/theme/TemplateValidator.js
@@ -95,45 +95,54 @@ class TemplateValidator extends BaseValidator {
           annotations,
           ANNOTATION_KEYS.templateType
         );
-        const label = getAnnotationValue(annotations, ANNOTATION_KEYS.label);
-        const sreenshotPath = getAnnotationValue(
-          annotations,
-          ANNOTATION_KEYS.screenshotPath
-        );
+        if (templateType) {
+          const label = getAnnotationValue(annotations, ANNOTATION_KEYS.label);
+          const screenshotPath = getAnnotationValue(
+            annotations,
+            ANNOTATION_KEYS.screenshotPath
+          );
 
-        // Exclude global partials and templates with type of none in count
-        if (!['global_partial', 'none'].includes(templateType)) {
-          templateCount++;
-        }
-
-        const validations = VALIDATIONS_BY_TYPE[templateType];
-
-        if (validations) {
-          if (!validations.allowed) {
-            validationErrors.push(
-              this.getError(this.errors.INVALID_TEMPLATE_TYPE, {
-                templatePath: path.relative(absoluteThemePath, filePath),
-                templateType,
-              })
-            );
+          // Exclude global partials and templates with type of none in count
+          if (!['global_partial', 'none'].includes(templateType)) {
+            templateCount++;
           }
-          if (validations.label && !label) {
-            validationErrors.push(
-              this.getError(this.errors.MISSING_LABEL, {
-                templatePath: path.relative(absoluteThemePath, filePath),
-              })
-            );
-          }
-          if (validations.screenshot && !sreenshotPath) {
-            validationErrors.push(
-              this.getError(this.errors.MISSING_SCREENSHOT_PATH, {
-                templatePath: path.relative(absoluteThemePath, filePath),
-              })
+
+          const validations = VALIDATIONS_BY_TYPE[templateType];
+
+          if (validations) {
+            if (!validations.allowed) {
+              validationErrors.push(
+                this.getError(this.errors.INVALID_TEMPLATE_TYPE, {
+                  templatePath: path.relative(absoluteThemePath, filePath),
+                  templateType,
+                })
+              );
+            }
+            if (validations.label && !label) {
+              validationErrors.push(
+                this.getError(this.errors.MISSING_LABEL, {
+                  templatePath: path.relative(absoluteThemePath, filePath),
+                })
+              );
+            }
+            if (validations.screenshot && !screenshotPath) {
+              validationErrors.push(
+                this.getError(this.errors.MISSING_SCREENSHOT_PATH, {
+                  templatePath: path.relative(absoluteThemePath, filePath),
+                })
+              );
+            }
+          } else {
+            logger.debug(
+              `Unrecognized template type "${templateType}" in ${path.relative(
+                absoluteThemePath,
+                filePath
+              )}`
             );
           }
         } else {
           logger.debug(
-            `Unrecognized template type "${templateType}" in ${path.relative(
+            `No template type found for ${path.relative(
               absoluteThemePath,
               filePath
             )}`


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
Using this PR as the base just to split up the work into separate PR's to make it more reviewable.

This adds more accurate template checking to the theme validation command. Now we're correctly checking for label and screenshot annotations depending on the template type. 

## Screenshots
<!-- Provide images of the before and after functionality -->
![image](https://user-images.githubusercontent.com/6654014/120016244-58cf5a00-bfb2-11eb-86bb-5eeab78dbb9a.png)

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->
- [x] Add unit tests for the new template checks
- [ ] This still needs more testing. I ran it against a marketplace theme and it seems to work, but there are a lot of edge cases that I could be missing.
## Who to Notify
<!-- /cc those you wish to know about the PR -->
cc/ @KatzMitch 