### PR TITLE
Fixing bugs in the WIP theme marketplace validation command

### DIFF
--- a/packages/cli-lib/api/marketplace.js
+++ b/packages/cli-lib/api/marketplace.js
@@ -1,0 +1,21 @@
+const http = require('../http');
+
+const MARKETPLACE_API_PATH = 'product/marketplace/v2/template/dependencies';
+
+/**
+ * @async
+ * @param {number} accountId
+ * @param {string} sourceCode
+ * @param {object} hublValidationOptions
+ * @returns {Promise}
+ */
+async function fetchDependencies(accountId, sourceCode) {
+  return http.post(accountId, {
+    uri: MARKETPLACE_API_PATH,
+    body: { template_source: sourceCode },
+  });
+}
+
+module.exports = {
+  fetchDependencies,
+};

--- a/packages/cli-lib/modules.js
+++ b/packages/cli-lib/modules.js
@@ -47,7 +47,7 @@ const isModuleFolder = pathInput => {
  * @returns {boolean}
  * @throws {TypeError}
  */
-const isModuleFolderChild = pathInput => {
+const isModuleFolderChild = (pathInput, ignoreLocales = false) => {
   throwInvalidPathInput(pathInput);
   let pathParts = [];
   if (pathInput.isLocal) {
@@ -58,6 +58,10 @@ const isModuleFolderChild = pathInput => {
   const { length } = pathParts;
   // Not a child path?
   if (length <= 1) return false;
+  // Check if we should ignore this file
+  if (ignoreLocales && pathParts.find(part => part === '_locales')) {
+    return false;
+  }
   // Check if any parent folders are module folders.
   return pathParts
     .slice(0, length - 1)

--- a/packages/cli-lib/validate.js
+++ b/packages/cli-lib/validate.js
@@ -47,9 +47,6 @@ async function lint(accountId, filepath, callback) {
 const getErrorsFromHublValidationObject = validation =>
   (validation && validation.meta && validation.meta.template_errors) || [];
 
-const getDepsFromHublValidationObject = validation =>
-  (validation && validation.meta && validation.meta.all_dependencies) || {};
-
 function printHublValidationError(err) {
   const { severity, message, lineno, startPosition } = err;
   const method = severity === 'FATAL' ? 'error' : 'warn';
@@ -75,7 +72,6 @@ function printHublValidationResult({ file, validation }) {
 }
 
 module.exports = {
-  getDepsFromHublValidationObject,
   lint,
   printHublValidationResult,
 };

--- a/packages/cli/lib/validators/__tests__/DependencyValidator.js
+++ b/packages/cli/lib/validators/__tests__/DependencyValidator.js
@@ -40,7 +40,6 @@ describe('validators/marketplaceValidators/theme/DependencyValidator', () => {
     it('returns true if dep is external to the provided absolute path', () => {
       const absoluteFilePath = `${THEME_PATH}/file.js`;
       const relativeDepPath = '../external/dep/path/file2.js';
-      console.log('TESTER: ', DependencyValidator._absoluteThemePath);
       const isExternal = DependencyValidator.isExternalDep(
         absoluteFilePath,
         relativeDepPath

--- a/packages/cli/lib/validators/__tests__/DependencyValidator.js
+++ b/packages/cli/lib/validators/__tests__/DependencyValidator.js
@@ -3,6 +3,7 @@ const validate = require('@hubspot/cli-lib/api/validate');
 
 const DependencyValidator = require('../marketplaceValidators/theme/DependencyValidator');
 const { VALIDATION_RESULT } = require('../constants');
+const { THEME_PATH } = require('./validatorTestUtils');
 
 jest.mock('fs-extra');
 jest.mock('@hubspot/cli-lib/api/validate');
@@ -29,13 +30,15 @@ const getMockValidationResult = customPath => {
 };
 
 describe('validators/marketplaceValidators/theme/DependencyValidator', () => {
+  beforeEach(() => {
+    DependencyValidator.setThemePath(THEME_PATH);
+  });
+
   describe('isExternalDep', () => {
     it('returns true if dep is external to provided absolute path', () => {
-      const absoluteThemePath = `/path/to/theme`;
       const absoluteFilePath = '/path/to/theme/file.js';
       const relativeDepPath = '../external/dep/path';
       const isExternal = DependencyValidator.isExternalDep(
-        absoluteThemePath,
         absoluteFilePath,
         relativeDepPath
       );
@@ -43,11 +46,9 @@ describe('validators/marketplaceValidators/theme/DependencyValidator', () => {
     });
 
     it('returns false if dep is not external to provided absolute path', () => {
-      const absoluteThemePath = `/path/to/theme`;
       const absoluteFilePath = '/path/to/theme/file.js';
       const relativeDepPath = './internal/dep/path';
       const isExternal = DependencyValidator.isExternalDep(
-        absoluteThemePath,
         absoluteFilePath,
         relativeDepPath
       );
@@ -64,8 +65,8 @@ describe('validators/marketplaceValidators/theme/DependencyValidator', () => {
       validate.validateHubl.mockReturnValue(
         getMockValidationResult('/absolute/file-3.js')
       );
-      const validationErrors = await DependencyValidator.validate('/dirName', [
-        '/dirName/template.html',
+      const validationErrors = await DependencyValidator.validate([
+        `${THEME_PATH}/template.html`,
       ]);
 
       expect(validationErrors.length).toBe(1);
@@ -76,8 +77,8 @@ describe('validators/marketplaceValidators/theme/DependencyValidator', () => {
       validate.validateHubl.mockReturnValue(
         getMockValidationResult('../../external/file-3.js')
       );
-      const validationErrors = await DependencyValidator.validate('/dirName', [
-        '/dirName/template.html',
+      const validationErrors = await DependencyValidator.validate([
+        `${THEME_PATH}/template.html`,
       ]);
 
       expect(validationErrors.length).toBe(1);
@@ -86,8 +87,8 @@ describe('validators/marketplaceValidators/theme/DependencyValidator', () => {
 
     it('returns no errors if paths are relative and internal', async () => {
       validate.validateHubl.mockReturnValue(getMockValidationResult());
-      const validationErrors = await DependencyValidator.validate('/dirName', [
-        '/dirName/template.html',
+      const validationErrors = await DependencyValidator.validate([
+        `${THEME_PATH}/template.html`,
       ]);
 
       expect(validationErrors.length).toBe(0);

--- a/packages/cli/lib/validators/__tests__/ModuleValidator.js
+++ b/packages/cli/lib/validators/__tests__/ModuleValidator.js
@@ -1,7 +1,11 @@
 const fs = require('fs');
 const ModuleValidator = require('../marketplaceValidators/theme/ModuleValidator');
 const { VALIDATION_RESULT } = require('../constants');
-const { generateModulesList, makeFindError } = require('./validatorTestUtils');
+const {
+  generateModulesList,
+  makeFindError,
+  THEME_PATH,
+} = require('./validatorTestUtils');
 
 jest.mock('fs');
 
@@ -10,19 +14,21 @@ const MODULE_LIMIT = 50;
 const findError = makeFindError('module');
 
 describe('validators/marketplaceValidators/theme/ModuleValidator', () => {
+  beforeEach(() => {
+    ModuleValidator.setThemePath(THEME_PATH);
+  });
+
   it('returns error if module limit is exceeded', async () => {
     const validationErrors = ModuleValidator.validate(
-      'dirName',
       generateModulesList(MODULE_LIMIT + 1)
     );
     const limitError = findError(validationErrors, 'limitExceeded');
     expect(limitError).toBeDefined();
-    expect(validationErrors[0].result).toBe(VALIDATION_RESULT.FATAL);
+    expect(limitError.result).toBe(VALIDATION_RESULT.FATAL);
   });
 
   it('returns no limit error if module limit is not exceeded', async () => {
     const validationErrors = ModuleValidator.validate(
-      'dirName',
       generateModulesList(MODULE_LIMIT)
     );
     const limitError = findError(validationErrors, 'limitExceeded');
@@ -30,7 +36,7 @@ describe('validators/marketplaceValidators/theme/ModuleValidator', () => {
   });
 
   it('returns error if no module meta.json file exists', async () => {
-    const validationErrors = ModuleValidator.validate('dirName', [
+    const validationErrors = ModuleValidator.validate([
       'module.module/module.html',
     ]);
     expect(validationErrors.length).toBe(1);
@@ -40,7 +46,7 @@ describe('validators/marketplaceValidators/theme/ModuleValidator', () => {
   it('returns error if module meta.json file has invalid json', async () => {
     fs.readFileSync.mockReturnValue('{} bad json }');
 
-    const validationErrors = ModuleValidator.validate('dirName', [
+    const validationErrors = ModuleValidator.validate([
       'module.module/meta.json',
     ]);
     expect(validationErrors.length).toBe(1);
@@ -50,7 +56,7 @@ describe('validators/marketplaceValidators/theme/ModuleValidator', () => {
   it('returns error if module meta.json file is missing a label field', async () => {
     fs.readFileSync.mockReturnValue('{ "icon": "woo" }');
 
-    const validationErrors = ModuleValidator.validate('dirName', [
+    const validationErrors = ModuleValidator.validate([
       'module.module/meta.json',
     ]);
     expect(validationErrors.length).toBe(1);
@@ -60,7 +66,7 @@ describe('validators/marketplaceValidators/theme/ModuleValidator', () => {
   it('returns error if module meta.json file is missing an icon field', async () => {
     fs.readFileSync.mockReturnValue('{ "label": "yay" }');
 
-    const validationErrors = ModuleValidator.validate('dirName', [
+    const validationErrors = ModuleValidator.validate([
       'module.module/meta.json',
     ]);
     expect(validationErrors.length).toBe(1);
@@ -70,7 +76,7 @@ describe('validators/marketplaceValidators/theme/ModuleValidator', () => {
   it('returns no error if module meta.json file exists and has all required fields', async () => {
     fs.readFileSync.mockReturnValue('{ "label": "yay", "icon": "woo" }');
 
-    const validationErrors = ModuleValidator.validate('dirName', [
+    const validationErrors = ModuleValidator.validate([
       'module.module/meta.json',
     ]);
     expect(validationErrors.length).toBe(0);

--- a/packages/cli/lib/validators/__tests__/TemplateValidator.js
+++ b/packages/cli/lib/validators/__tests__/TemplateValidator.js
@@ -6,6 +6,7 @@ const { VALIDATION_RESULT } = require('../constants');
 const {
   generateTemplatesList,
   makeFindError,
+  THEME_PATH,
 } = require('./validatorTestUtils');
 
 jest.mock('fs');
@@ -26,6 +27,7 @@ const findError = makeFindError('template');
 
 describe('validators/marketplaceValidators/theme/TemplateValidator', () => {
   beforeEach(() => {
+    TemplateValidator.setThemePath(THEME_PATH);
     templates.isCodedFile.mockReturnValue(true);
   });
 
@@ -33,7 +35,6 @@ describe('validators/marketplaceValidators/theme/TemplateValidator', () => {
     mockGetAnnotationValue('page');
 
     const validationErrors = TemplateValidator.validate(
-      'dirName',
       generateTemplatesList(TEMPLATE_LIMIT + 1)
     );
     const limitError = findError(validationErrors, 'limitExceeded');
@@ -45,7 +46,6 @@ describe('validators/marketplaceValidators/theme/TemplateValidator', () => {
     mockGetAnnotationValue('page');
 
     const validationErrors = TemplateValidator.validate(
-      'dirName',
       generateTemplatesList(TEMPLATE_LIMIT)
     );
     const limitError = findError(validationErrors, 'limitExceeded');
@@ -56,9 +56,7 @@ describe('validators/marketplaceValidators/theme/TemplateValidator', () => {
     fs.readFileSync.mockReturnValue('mock');
     mockGetAnnotationValue('page');
 
-    const validationErrors = TemplateValidator.validate('dirName', [
-      'template.html',
-    ]);
+    const validationErrors = TemplateValidator.validate(['template.html']);
     expect(validationErrors.length).toBe(2);
     expect(validationErrors[0].result).toBe(VALIDATION_RESULT.FATAL);
   });
@@ -67,9 +65,7 @@ describe('validators/marketplaceValidators/theme/TemplateValidator', () => {
     fs.readFileSync.mockReturnValue('mock');
     mockGetAnnotationValue('starter_landing_pages', 'value');
 
-    const validationErrors = TemplateValidator.validate('dirName', [
-      'template.html',
-    ]);
+    const validationErrors = TemplateValidator.validate(['template.html']);
 
     expect(validationErrors.length).toBe(1);
   });
@@ -78,9 +74,7 @@ describe('validators/marketplaceValidators/theme/TemplateValidator', () => {
     fs.readFileSync.mockReturnValue('mock');
     mockGetAnnotationValue('unknown-type', 'value');
 
-    const validationErrors = TemplateValidator.validate('dirName', [
-      'template.html',
-    ]);
+    const validationErrors = TemplateValidator.validate(['template.html']);
 
     expect(validationErrors.length).toBe(1);
   });
@@ -89,9 +83,7 @@ describe('validators/marketplaceValidators/theme/TemplateValidator', () => {
     fs.readFileSync.mockReturnValue('mock');
     mockGetAnnotationValue(null, 'value');
 
-    const validationErrors = TemplateValidator.validate('dirName', [
-      'template.html',
-    ]);
+    const validationErrors = TemplateValidator.validate(['template.html']);
 
     expect(validationErrors.length).toBe(1);
   });
@@ -100,9 +92,7 @@ describe('validators/marketplaceValidators/theme/TemplateValidator', () => {
     fs.readFileSync.mockReturnValue('mock');
     mockGetAnnotationValue('page', 'value');
 
-    const validationErrors = TemplateValidator.validate('dirName', [
-      'template.html',
-    ]);
+    const validationErrors = TemplateValidator.validate(['template.html']);
 
     expect(validationErrors.length).toBe(0);
   });

--- a/packages/cli/lib/validators/__tests__/ThemeValdiator.js
+++ b/packages/cli/lib/validators/__tests__/ThemeValdiator.js
@@ -3,15 +3,18 @@ const path = require('path');
 
 const ThemeValidator = require('../../validators/marketplaceValidators/theme/ThemeValidator');
 const { VALIDATION_RESULT } = require('../../validators/constants');
+const { THEME_PATH } = require('./validatorTestUtils');
 
 jest.mock('fs');
 jest.mock('path');
 
 describe('validators/marketplaceValidators/theme/ThemeValidator', () => {
+  beforeEach(() => {
+    ThemeValidator.setThemePath(THEME_PATH);
+  });
+
   it('returns error if no theme.json file exists', async () => {
-    const validationErrors = ThemeValidator.validate('dirName', [
-      'someFile.html',
-    ]);
+    const validationErrors = ThemeValidator.validate(['someFile.html']);
     expect(validationErrors.length).toBe(1);
     expect(validationErrors[0].result).toBe(VALIDATION_RESULT.FATAL);
   });
@@ -19,7 +22,7 @@ describe('validators/marketplaceValidators/theme/ThemeValidator', () => {
   it('returns error if theme.json file has invalid json', async () => {
     fs.readFileSync.mockReturnValue('{} bad json }');
 
-    const validationErrors = ThemeValidator.validate('dirName', ['theme.json']);
+    const validationErrors = ThemeValidator.validate(['theme.json']);
     expect(validationErrors.length).toBe(1);
     expect(validationErrors[0].result).toBe(VALIDATION_RESULT.FATAL);
   });
@@ -27,7 +30,7 @@ describe('validators/marketplaceValidators/theme/ThemeValidator', () => {
   it('returns error if theme.json file is missing a label field', async () => {
     fs.readFileSync.mockReturnValue('{ "screenshot_path": "./relative/path" }');
 
-    const validationErrors = ThemeValidator.validate('dirName', ['theme.json']);
+    const validationErrors = ThemeValidator.validate(['theme.json']);
     expect(validationErrors.length).toBe(1);
     expect(validationErrors[0].result).toBe(VALIDATION_RESULT.FATAL);
   });
@@ -37,7 +40,7 @@ describe('validators/marketplaceValidators/theme/ThemeValidator', () => {
       '{ "label": "yay", "screenshot_path": "/absolute/path" }'
     );
 
-    const validationErrors = ThemeValidator.validate('dirName', ['theme.json']);
+    const validationErrors = ThemeValidator.validate(['theme.json']);
     expect(validationErrors.length).toBe(1);
     expect(validationErrors[0].result).toBe(VALIDATION_RESULT.FATAL);
   });
@@ -49,7 +52,7 @@ describe('validators/marketplaceValidators/theme/ThemeValidator', () => {
     path.relative.mockReturnValue('theme.json');
     fs.existsSync.mockReturnValue(false);
 
-    const validationErrors = ThemeValidator.validate('dirName', ['theme.json']);
+    const validationErrors = ThemeValidator.validate(['theme.json']);
     expect(validationErrors.length).toBe(1);
     expect(validationErrors[0].result).toBe(VALIDATION_RESULT.FATAL);
   });
@@ -61,7 +64,7 @@ describe('validators/marketplaceValidators/theme/ThemeValidator', () => {
     path.relative.mockReturnValue('theme.json');
     fs.existsSync.mockReturnValue(true);
 
-    const validationErrors = ThemeValidator.validate('dirName', ['theme.json']);
+    const validationErrors = ThemeValidator.validate(['theme.json']);
     expect(validationErrors.length).toBe(0);
   });
 });

--- a/packages/cli/lib/validators/__tests__/validatorTestUtils.js
+++ b/packages/cli/lib/validators/__tests__/validatorTestUtils.js
@@ -1,6 +1,8 @@
 //HACK so we can keep this util file next to the tests that use it
 test.skip('skip', () => null);
 
+const THEME_PATH = '/path/to/a/theme';
+
 const makeFindError = baseKey => (errors, errorKey) =>
   errors.find(error => error.key === `${baseKey}.${errorKey}`);
 
@@ -28,4 +30,5 @@ module.exports = {
   generateModulesList,
   generateTemplatesList,
   makeFindError,
+  THEME_PATH,
 };

--- a/packages/cli/lib/validators/applyValidators.js
+++ b/packages/cli/lib/validators/applyValidators.js
@@ -1,7 +1,10 @@
-async function applyValidators(validators, ...args) {
+async function applyValidators(validators, absoluteThemePath, ...args) {
   return Promise.all(
     validators.map(async Validator => {
+      Validator.setThemePath(absoluteThemePath);
       const validationResult = await Validator.validate(...args);
+      Validator.clearThemePath();
+
       if (!validationResult.length) {
         // Return a success obj so we can log the successes
         return [Validator.getSuccess()];

--- a/packages/cli/lib/validators/logValidatorResults.js
+++ b/packages/cli/lib/validators/logValidatorResults.js
@@ -22,7 +22,8 @@ function logResultsAsJson(results) {
     success,
     results: resultObj,
   };
-  return logger.log(JSON.stringify(result));
+  // Use stdout here b/c console.log will truncate long strings
+  process.stdout.write(JSON.stringify(result) + '\n');
 }
 
 function logValidatorResults(results, { logAsJson = false } = {}) {

--- a/packages/cli/lib/validators/marketplaceValidators/BaseValidator.js
+++ b/packages/cli/lib/validators/marketplaceValidators/BaseValidator.js
@@ -1,9 +1,25 @@
+const path = require('path');
+
 const { VALIDATION_RESULT } = require('../constants');
 
 class BaseValidator {
   constructor({ name, key }) {
     this.name = name;
     this.key = key;
+  }
+
+  clearThemePath() {
+    this._absoluteThemePath = null;
+  }
+
+  setThemePath(path) {
+    this._absoluteThemePath = path;
+  }
+
+  getRelativePath(filePath) {
+    return this._absoluteThemePath
+      ? path.relative(this._absoluteThemePath, filePath)
+      : filePath;
   }
 
   getSuccess() {
@@ -14,13 +30,19 @@ class BaseValidator {
     };
   }
 
-  getError(errorObj, copyPlaceholders = {}) {
+  getError(errorObj, file, extraCopyPlaceholders = {}) {
+    const relativeFilePath = file ? this.getRelativePath(file) : null;
+    const copyPlaceholders = {
+      file: relativeFilePath,
+      ...extraCopyPlaceholders,
+    };
     return {
       validatorKey: this.key,
       validatorName: this.name,
       error: errorObj.getCopy(copyPlaceholders),
       result: errorObj.severity || VALIDATION_RESULT.FATAL,
       key: `${this.key}.${errorObj.key}`,
+      file: relativeFilePath,
     };
   }
 }

--- a/packages/cli/lib/validators/marketplaceValidators/theme/DependencyValidator.js
+++ b/packages/cli/lib/validators/marketplaceValidators/theme/DependencyValidator.js
@@ -89,10 +89,13 @@ class DependencyValidator extends BaseValidator {
   isExternalDep(file, relativeDepPath) {
     // Get dir of file that references the dep
     const { dir } = path.parse(file);
+    console.log('1: ', dir);
     // Use dir to get the dep's absolute path
     const absoluteDepPath = path.resolve(dir, relativeDepPath);
+    console.log('2: ', absoluteDepPath);
     // Get relative path to dep using theme absolute path and dep absolute path
     const relativePath = this.getRelativePath(absoluteDepPath);
+    console.log('3: ', relativePath);
     // Check that dep is not within the theme
     return relativePath && relativePath.startsWith('..');
   }

--- a/packages/cli/lib/validators/marketplaceValidators/theme/DependencyValidator.js
+++ b/packages/cli/lib/validators/marketplaceValidators/theme/DependencyValidator.js
@@ -1,11 +1,12 @@
 const fs = require('fs-extra');
 const path = require('path');
 
-const { HUBL_EXTENSIONS } = require('@hubspot/cli-lib/lib/constants');
-const { validateHubl } = require('@hubspot/cli-lib/api/validate');
+const { logger } = require('@hubspot/cli-lib/logger');
 const {
-  getDepsFromHublValidationObject,
-} = require('@hubspot/cli-lib/validate');
+  HUBL_EXTENSIONS,
+  HUBSPOT_FOLDER,
+} = require('@hubspot/cli-lib/lib/constants');
+const { fetchDependencies } = require('@hubspot/cli-lib/api/marketplace');
 const { getExt, isRelativePath } = require('@hubspot/cli-lib/path');
 
 const BaseValidator = require('../BaseValidator');
@@ -38,16 +39,24 @@ class DependencyValidator extends BaseValidator {
     };
   }
 
-  // HACK We parse paths from rendering errors because the renderer won't
-  // include paths in the all_dependencies object if it can't locate the asset
-  getPathsFromRenderingErrors(validation) {
-    return validation.renderingErrors
+  // HACK We parse paths from rendering errors because the endpoint won't
+  // include paths in the allDependencies object if it can't locate the asset
+  getPathsFromRenderingErrors(renderingErrors = []) {
+    return renderingErrors
       .filter(
         renderingError =>
           MISSING_ASSET_CATEGORY_TYPES.includes(renderingError.category) &&
           renderingError.categoryErrors.path
       )
       .map(renderingError => renderingError.categoryErrors.path);
+  }
+
+  failedToFetchDependencies(err, file, validationErrors) {
+    logger.debug(`Failed to fetch dependencies for ${file}: `, err.error);
+
+    validationErrors.push(
+      this.getError(this.errors.FAILED_TO_FETCH_DEPS, file)
+    );
   }
 
   async getAllDependenciesByFile(files, accountId, validationErrors) {
@@ -60,23 +69,16 @@ class DependencyValidator extends BaseValidator {
           if (!(source && source.trim())) {
             return { file, deps };
           }
-          const validation = await validateHubl(accountId, source).catch(
+          const file_deps = await fetchDependencies(accountId, source).catch(
             err => {
-              validationErrors.push({
-                ...this.getError(this.errors.FAILED_TO_FETCH_DEPS, {
-                  file,
-                }),
-                meta: {
-                  error: err && err.error ? err.error.policyName : 'unknown',
-                },
-              });
+              this.failedToFetchDependencies(err, file, validationErrors);
               return null;
             }
           );
-          if (validation) {
-            deps = getDepsFromHublValidationObject(validation);
+          if (file_deps) {
+            deps = file_deps.allDependencies || {};
             deps.RENDERING_ERROR_PATHS = this.getPathsFromRenderingErrors(
-              validation
+              file_deps.renderingErrors
             );
           }
           return { file, deps };
@@ -84,13 +86,13 @@ class DependencyValidator extends BaseValidator {
     );
   }
 
-  isExternalDep(absoluteThemePath, file, relativeDepPath) {
+  isExternalDep(file, relativeDepPath) {
     // Get dir of file that references the dep
     const { dir } = path.parse(file);
     // Use dir to get the dep's absolute path
     const absoluteDepPath = path.resolve(dir, relativeDepPath);
     // Get relative path to dep using theme absolute path and dep absolute path
-    const relativePath = path.relative(absoluteThemePath, absoluteDepPath);
+    const relativePath = this.getRelativePath(absoluteDepPath);
     // Check that dep is not within the theme
     return relativePath && relativePath.startsWith('..');
   }
@@ -98,7 +100,7 @@ class DependencyValidator extends BaseValidator {
   // Validates:
   // - Theme does not contain external dependencies
   // - All paths are either @hubspot or relative
-  async validate(absoluteThemePath, files, accountId) {
+  async validate(files, accountId) {
     let validationErrors = [];
 
     const dependencyGroups = await this.getAllDependenciesByFile(
@@ -113,30 +115,27 @@ class DependencyValidator extends BaseValidator {
         const depList = deps[key];
         depList.forEach(dependency => {
           // Ignore:
-          // '0' - The BE will return '0' when no deps are found
-          // '@' - Hubspot modules
-          if (dependency !== '0' && !dependency.startsWith('@')) {
+          // - The BE will return '0' when no deps are found
+          // - Hubspot modules
+          if (dependency !== '0' && !dependency.startsWith(HUBSPOT_FOLDER)) {
             if (!isRelativePath(dependency)) {
-              validationErrors.push({
-                ...this.getError(this.errors.ABSOLUTE_DEPENDENCY_PATH, {
-                  file: path.relative(absoluteThemePath, file),
+              validationErrors.push(
+                this.getError(this.errors.ABSOLUTE_DEPENDENCY_PATH, file, {
                   path: dependency,
-                }),
-              });
-            } else if (
-              this.isExternalDep(absoluteThemePath, file, dependency)
-            ) {
-              validationErrors.push({
-                ...this.getError(this.errors.EXTERNAL_DEPENDENCY, {
-                  file: path.relative(absoluteThemePath, file),
+                })
+              );
+            } else if (this.isExternalDep(file, dependency)) {
+              validationErrors.push(
+                this.getError(this.errors.EXTERNAL_DEPENDENCY, file, {
                   path: dependency,
-                }),
-              });
+                })
+              );
             }
           }
         });
       });
     });
+
     return validationErrors;
   }
 }

--- a/packages/cli/lib/validators/marketplaceValidators/theme/DependencyValidator.js
+++ b/packages/cli/lib/validators/marketplaceValidators/theme/DependencyValidator.js
@@ -89,13 +89,10 @@ class DependencyValidator extends BaseValidator {
   isExternalDep(file, relativeDepPath) {
     // Get dir of file that references the dep
     const { dir } = path.parse(file);
-    console.log('1: ', dir);
     // Use dir to get the dep's absolute path
     const absoluteDepPath = path.resolve(dir, relativeDepPath);
-    console.log('2: ', absoluteDepPath);
     // Get relative path to dep using theme absolute path and dep absolute path
     const relativePath = this.getRelativePath(absoluteDepPath);
-    console.log('3: ', relativePath);
     // Check that dep is not within the theme
     return relativePath && relativePath.startsWith('..');
   }

--- a/packages/cli/lib/validators/marketplaceValidators/theme/ModuleValidator.js
+++ b/packages/cli/lib/validators/marketplaceValidators/theme/ModuleValidator.js
@@ -18,23 +18,21 @@ class ModuleValidator extends BaseValidator {
       },
       MISSING_META_JSON: {
         key: 'missingMetaJSON',
-        getCopy: ({ modulePath }) =>
-          `Missing a meta.json file for ${modulePath}`,
+        getCopy: ({ file }) => `Missing a meta.json file for ${file}`,
       },
       INVALID_META_JSON: {
         key: 'invalidMetaJSON',
-        getCopy: ({ modulePath }) =>
-          `Invalid json in meta.json file for ${modulePath}`,
+        getCopy: ({ file }) => `Invalid json in meta.json file for ${file}`,
       },
       MISSING_LABEL: {
         key: 'missingLabel',
-        getCopy: ({ modulePath }) =>
-          `The meta.json file is missing a "label" field for ${modulePath}`,
+        getCopy: ({ file }) =>
+          `The meta.json file is missing a "label" field for ${file}`,
       },
       MISSING_ICON: {
         key: 'missingIcon',
-        getCopy: ({ modulePath }) =>
-          `The meta.json file is missing an "icon" field for ${modulePath}`,
+        getCopy: ({ file }) =>
+          `The meta.json file is missing an "icon" field for ${file}`,
       },
     };
   }
@@ -60,14 +58,14 @@ class ModuleValidator extends BaseValidator {
   // - Each module meta.json file contains valid json
   // - Each module meta.json file has a "label" field
   // - Each module meta.json file has an "icon" field
-  validate(absoluteThemePath, files) {
+  validate(files) {
     let validationErrors = [];
     const uniqueModules = this.getUniqueModulesFromFiles(files);
     const numModules = Object.keys(uniqueModules).length;
 
     if (numModules > MODULE_LIMIT) {
       validationErrors.push(
-        this.getError(this.errors.LIMIT_EXCEEDED, {
+        this.getError(this.errors.LIMIT_EXCEEDED, null, {
           limit: MODULE_LIMIT,
           total: numModules,
         })
@@ -76,43 +74,31 @@ class ModuleValidator extends BaseValidator {
 
     Object.keys(uniqueModules).forEach(modulePath => {
       const metaJSONFile = uniqueModules[modulePath]['meta.json'];
-      const relativePath = path.relative(absoluteThemePath, modulePath);
 
       if (!metaJSONFile) {
         validationErrors.push(
-          this.getError(this.errors.MISSING_META_JSON, {
-            modulePath: relativePath,
-          })
+          this.getError(this.errors.MISSING_META_JSON, modulePath)
         );
       } else {
         let metaJSON;
         try {
           metaJSON = JSON.parse(fs.readFileSync(metaJSONFile));
         } catch (err) {
-          validationErrors.push({
-            ...this.getError(this.errors.INVALID_META_JSON, {
-              modulePath: relativePath,
-            }),
-            meta: { file: metaJSONFile },
-          });
+          validationErrors.push(
+            this.getError(this.errors.INVALID_META_JSON, modulePath)
+          );
         }
 
         if (metaJSON) {
           if (!metaJSON.label) {
-            validationErrors.push({
-              ...this.getError(this.errors.MISSING_LABEL, {
-                modulePath: relativePath,
-              }),
-              meta: { file: metaJSONFile },
-            });
+            validationErrors.push(
+              this.getError(this.errors.MISSING_LABEL, modulePath)
+            );
           }
           if (!metaJSON.icon) {
-            validationErrors.push({
-              ...this.getError(this.errors.MISSING_ICON, {
-                modulePath: relativePath,
-              }),
-              meta: { file: metaJSONFile },
-            });
+            validationErrors.push(
+              this.getError(this.errors.MISSING_ICON, modulePath)
+            );
           }
         }
       }

--- a/packages/cli/lib/validators/marketplaceValidators/theme/ModuleValidator.js
+++ b/packages/cli/lib/validators/marketplaceValidators/theme/ModuleValidator.js
@@ -43,7 +43,7 @@ class ModuleValidator extends BaseValidator {
     const uniqueModules = {};
 
     files.forEach(file => {
-      if (isModuleFolderChild({ isLocal: true, path: file })) {
+      if (isModuleFolderChild({ isLocal: true, path: file }, true)) {
         const { base, dir } = path.parse(file);
         if (!uniqueModules[dir]) {
           uniqueModules[dir] = {};

--- a/packages/cli/lib/validators/marketplaceValidators/theme/TemplateValidator.js
+++ b/packages/cli/lib/validators/marketplaceValidators/theme/TemplateValidator.js
@@ -1,5 +1,3 @@
-const path = require('path');
-
 const {
   ANNOTATION_KEYS,
   getAnnotationValue,
@@ -63,28 +61,25 @@ class TemplateValidator extends BaseValidator {
       },
       MISSING_TEMPLATE_TYPE: {
         key: 'missingTemplateType',
-        getCopy: ({ templatePath }) =>
-          `Missing template type for ${templatePath}`,
+        getCopy: ({ file }) => `Missing template type for ${file}`,
       },
       UNKNOWN_TEMPLATE_TYPE: {
         key: 'unknownTemplateType',
-        getCopy: ({ templatePath, templateType }) =>
-          `Unknown template type ${templateType} for ${templatePath}`,
+        getCopy: ({ file, templateType }) =>
+          `Unknown template type ${templateType} for ${file}`,
       },
       RESTRICTED_TEMPLATE_TYPE: {
         key: 'restrictedTemplateType',
-        getCopy: ({ templatePath, templateType }) =>
-          `Cannot have template type ${templateType} for ${templatePath}`,
+        getCopy: ({ file, templateType }) =>
+          `Cannot have template type ${templateType} for ${file}`,
       },
       MISSING_LABEL: {
         key: 'missingLabel',
-        getCopy: ({ templatePath }) =>
-          `Missing a "label" annotation in ${templatePath}`,
+        getCopy: ({ file }) => `Missing a "label" annotation in ${file}`,
       },
       MISSING_SCREENSHOT_PATH: {
         key: 'missingScreenshotPath',
-        getCopy: ({ templatePath }) =>
-          `The screenshotPath is missing in ${templatePath}`,
+        getCopy: ({ file }) => `The screenshotPath is missing in ${file}`,
       },
     };
   }
@@ -94,13 +89,13 @@ class TemplateValidator extends BaseValidator {
   // - All templates have valid template types
   // - All templates that require a label have a "label" annotation
   // - All templates that require a screenshot have a "screenshotPath" annotation
-  validate(absoluteThemePath, files) {
+  validate(files) {
     let validationErrors = [];
     let templateCount = 0;
 
-    files.forEach(filePath => {
-      if (isCodedFile(filePath)) {
-        const annotations = getFileAnnotations(filePath);
+    files.forEach(file => {
+      if (isCodedFile(file)) {
+        const annotations = getFileAnnotations(file);
         const isAvailableForNewContent = getAnnotationValue(
           annotations,
           ANNOTATION_KEYS.isAvailableForNewContent
@@ -131,39 +126,29 @@ class TemplateValidator extends BaseValidator {
             if (validations) {
               if (!validations.allowed) {
                 validationErrors.push(
-                  this.getError(this.errors.RESTRICTED_TEMPLATE_TYPE, {
-                    templatePath: path.relative(absoluteThemePath, filePath),
+                  this.getError(this.errors.RESTRICTED_TEMPLATE_TYPE, file, {
                     templateType,
                   })
                 );
               }
               if (validations.label && !label) {
                 validationErrors.push(
-                  this.getError(this.errors.MISSING_LABEL, {
-                    templatePath: path.relative(absoluteThemePath, filePath),
-                  })
+                  this.getError(this.errors.MISSING_LABEL, file)
                 );
               }
               if (validations.screenshot && !screenshotPath) {
                 validationErrors.push(
-                  this.getError(this.errors.MISSING_SCREENSHOT_PATH, {
-                    templatePath: path.relative(absoluteThemePath, filePath),
-                  })
+                  this.getError(this.errors.MISSING_SCREENSHOT_PATH, file)
                 );
               }
             } else {
               validationErrors.push(
-                this.getError(this.errors.UNKNOWN_TEMPLATE_TYPE, {
-                  templatePath: path.relative(absoluteThemePath, filePath),
-                  templateType,
-                })
+                this.getError(this.errors.UNKNOWN_TEMPLATE_TYPE, file)
               );
             }
           } else {
             validationErrors.push(
-              this.getError(this.errors.MISSING_TEMPLATE_TYPE, {
-                templatePath: path.relative(absoluteThemePath, filePath),
-              })
+              this.getError(this.errors.MISSING_TEMPLATE_TYPE, file)
             );
           }
         }
@@ -172,7 +157,7 @@ class TemplateValidator extends BaseValidator {
 
     if (templateCount > TEMPLATE_LIMIT) {
       validationErrors.push(
-        this.getError(this.errors.LIMIT_EXCEEDED, {
+        this.getError(this.errors.LIMIT_EXCEEDED, null, {
           limit: TEMPLATE_LIMIT,
           total: templateCount,
         })

--- a/packages/cli/lib/validators/marketplaceValidators/theme/ThemeValidator.js
+++ b/packages/cli/lib/validators/marketplaceValidators/theme/ThemeValidator.js
@@ -44,11 +44,11 @@ class ThemeValidator extends BaseValidator {
   // - theme.json file contains valid json
   // - theme.json file has a "label" field
   // - theme.json file has a relative path for "screenshot" field that resolves
-  validate(absoluteThemePath, files) {
+  validate(files) {
     let validationErrors = [];
     const themeJSONFile = files.find(filePath => {
       // Check for theme.json at the theme root
-      const fileName = path.relative(absoluteThemePath, filePath);
+      const fileName = this.getRelativePath(filePath);
       return fileName === 'theme.json';
     });
 
@@ -60,39 +60,34 @@ class ThemeValidator extends BaseValidator {
       try {
         themeJSON = JSON.parse(fs.readFileSync(themeJSONFile));
       } catch (err) {
-        validationErrors.push({
-          ...this.getError(this.errors.INVALID_THEME_JSON),
-          meta: { file: themeJSONFile },
-        });
+        validationErrors.push(
+          this.getError(this.errors.INVALID_THEME_JSON, themeJSONFile)
+        );
       }
 
       if (themeJSON) {
         if (!themeJSON.label) {
-          validationErrors.push({
-            ...this.getError(this.errors.MISSING_LABEL),
-            meta: { file: themeJSONFile },
-          });
+          validationErrors.push(
+            this.getError(this.errors.MISSING_LABEL, themeJSONFile)
+          );
         }
         if (!themeJSON.screenshot_path) {
-          validationErrors.push({
-            ...this.getError(this.errors.MISSING_SCREENSHOT_PATH),
-            meta: { file: themeJSONFile },
-          });
+          validationErrors.push(
+            this.getError(this.errors.MISSING_SCREENSHOT_PATH, themeJSONFile)
+          );
         } else if (!isRelativePath(themeJSON.screenshot_path)) {
-          validationErrors.push({
-            ...this.getError(this.errors.ABSOLUTE_SCREENSHOT_PATH),
-            meta: { file: themeJSONFile },
-          });
+          validationErrors.push(
+            this.getError(this.errors.ABSOLUTE_SCREENSHOT_PATH, themeJSONFile)
+          );
         } else {
           const absoluteScreenshotPath = path.resolve(
-            absoluteThemePath,
+            this._absoluteThemePath,
             themeJSON.screenshot_path
           );
           if (!fs.existsSync(absoluteScreenshotPath)) {
-            validationErrors.push({
-              ...this.getError(this.errors.MISSING_SCREENSHOT),
-              meta: { file: themeJSONFile },
-            });
+            validationErrors.push(
+              this.getError(this.errors.MISSING_SCREENSHOT, themeJSONFile)
+            );
           }
         }
       }


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
This fixes three bugs:
- Very long outputs were getting truncated. This is b/c I was using console.log to output the json result. I switched over to `process.stdout.write` which seems to work better.
- It's possible to hit the rate limit and we were not handling that gracefully. I added a new error type for when the validate request fails. It's called `failedDepFetch` (open to better naming and/or error handling suggestions here).
- We were incorrectly validating against files in the `_locales` folders for modules. I'm now ignoring files in those folders.

## Screenshots
<!-- Provide images of the before and after functionality -->

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
cc/ @KatzMitch