### PR TITLE
updated Autoupload plugin README to support Webpack 5 and fix --env vars

### DIFF
--- a/packages/webpack-cms-plugins/README.md
+++ b/packages/webpack-cms-plugins/README.md
@@ -48,13 +48,15 @@ module.exports = ({ account, autoupload }) => ({
       src: 'dist',
       dest: 'my-project',
     }),
-    new CopyWebpackPlugin([
-      { from: 'src/images', to: 'images' },
-      { from: 'src/templates', to: 'templates' },
-    ]),
+    new CopyWebpackPlugin({
+      patterns: [
+        { from: 'src/images', to: 'images' },
+        { from: 'src/templates', to: 'templates' },
+      ]
+    }),
   ],
 });
 ```
 
-3. Run `webpack --watch --env.account 123 --env.autoupload` to compile your project and automatically upload assets. Replace `123` with your unique Hub ID.
+3. Run `webpack --watch --env account 123 --env autoupload` to compile your project and automatically upload assets. Replace `123` with your unique Hub ID.
 


### PR DESCRIPTION
## Description and Context
The setup for the latest version of `copy-webpack-plugin` requires paths to live inside of a `patterns` array. Documentation here: https://www.npmjs.com/package/copy-webpack-plugin

Also, passing environment vars to webpack doesn't work with the dot notation. The script should be `webpack --watch --env account 123 --env autoupload`. Documentation here: https://webpack.js.org/guides/environment-variables/

As a side note, the Hubspot.config.yml file always provides the account so that part isn't really needed (might be better to manage that all in one place—can the autoupload option be moved there?) 

## Who to Notify
@TheWebTech 
