### PR TITLE
Marketplace theme validation command: using new dep endpoint

### DIFF
--- a/packages/cli-lib/api/marketplace.js
+++ b/packages/cli-lib/api/marketplace.js
@@ -1,6 +1,6 @@
 const http = require('../http');
 
-const MARKETPLACE_API_PATH = 'product/marketplace/v2/template/dependencies';
+const MARKETPLACE_API_PATH = 'product/marketplace/v2/template/render';
 
 /**
  * @async

--- a/packages/cli/lib/validators/__tests__/DependencyValidator.js
+++ b/packages/cli/lib/validators/__tests__/DependencyValidator.js
@@ -8,22 +8,10 @@ const { THEME_PATH } = require('./validatorTestUtils');
 jest.mock('fs-extra');
 jest.mock('@hubspot/cli-lib/api/marketplace');
 
-const getMockValidationResult = customPath => {
+const getMockDependencyResult = (customPaths = []) => {
   const result = {
-    renderingErrors: [
-      {
-        category: 'MODULE_NOT_FOUND',
-        categoryErrors: { path: './relative/file-1.js' },
-      },
-    ],
-    allDependencies: {
-      EXTERNAL_DEPENDENCIES: ['0'],
-      OTHER_DEPS: ['./relative/file-2.js'],
-    },
+    dependencies: ['./relative/file-2.js', ...customPaths],
   };
-  if (customPath) {
-    result.allDependencies.OTHER_DEPS.push(customPath);
-  }
   return Promise.resolve(result);
 };
 
@@ -65,7 +53,7 @@ describe('validators/marketplaceValidators/theme/DependencyValidator', () => {
 
     it('returns error if any referenced path is absolute', async () => {
       marketplace.fetchDependencies.mockReturnValue(
-        getMockValidationResult('/absolute/file-3.js')
+        getMockDependencyResult(['/absolute/file-3.js'])
       );
       const validationErrors = await DependencyValidator.validate([
         `${THEME_PATH}/template.html`,
@@ -77,7 +65,7 @@ describe('validators/marketplaceValidators/theme/DependencyValidator', () => {
 
     it('returns error if any referenced path is external to the theme', async () => {
       marketplace.fetchDependencies.mockReturnValue(
-        getMockValidationResult('../../external/file-3.js')
+        getMockDependencyResult(['../../external/file-3.js'])
       );
       const validationErrors = await DependencyValidator.validate([
         `${THEME_PATH}/template.html`,
@@ -88,7 +76,7 @@ describe('validators/marketplaceValidators/theme/DependencyValidator', () => {
     });
 
     it('returns no errors if paths are relative and internal', async () => {
-      marketplace.fetchDependencies.mockReturnValue(getMockValidationResult());
+      marketplace.fetchDependencies.mockReturnValue(getMockDependencyResult());
       const validationErrors = await DependencyValidator.validate([
         `${THEME_PATH}/template.html`,
       ]);

--- a/packages/cli/lib/validators/marketplaceValidators/theme/ModuleValidator.js
+++ b/packages/cli/lib/validators/marketplaceValidators/theme/ModuleValidator.js
@@ -30,12 +30,12 @@ class ModuleValidator extends BaseValidator {
       MISSING_LABEL: {
         key: 'missingLabel',
         getCopy: ({ filePath }) =>
-          `Missing required field for ${filePath}. The meta.json file is missing the "label" field`,
+          `Missing required property for ${filePath}. The meta.json file is missing the "label" property`,
       },
       MISSING_ICON: {
         key: 'missingIcon',
         getCopy: ({ filePath }) =>
-          `Missing required field for ${filePath}. The meta.json file is missing the "icon" field`,
+          `Missing required property for ${filePath}. The meta.json file is missing the "icon" property`,
       },
     };
   }

--- a/packages/cli/lib/validators/marketplaceValidators/theme/TemplateValidator.js
+++ b/packages/cli/lib/validators/marketplaceValidators/theme/TemplateValidator.js
@@ -63,7 +63,7 @@ class TemplateValidator extends BaseValidator {
       MISSING_TEMPLATE_TYPE: {
         key: 'missingTemplateType',
         getCopy: ({ filePath }) =>
-          `Missing required field for ${filePath}. The template is missing the "templateType" field`,
+          `Missing required property for ${filePath}. The template is missing the "templateType" property`,
       },
       UNKNOWN_TEMPLATE_TYPE: {
         key: 'unknownTemplateType',
@@ -78,12 +78,12 @@ class TemplateValidator extends BaseValidator {
       MISSING_LABEL: {
         key: 'missingLabel',
         getCopy: ({ filePath }) =>
-          `Missing required field for ${filePath}. The template is missing the "label" field`,
+          `Missing required property for ${filePath}. The template is missing the "label" property`,
       },
       MISSING_SCREENSHOT_PATH: {
         key: 'missingScreenshotPath',
         getCopy: ({ filePath }) =>
-          `Missing required field for ${filePath}. The template is missing the "screenshotPath" field`,
+          `Missing required property for ${filePath}. The template is missing the "screenshotPath" property`,
       },
     };
   }


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
Switching over the marketplace theme validation command to use the new dependency endpoint. This returns all the deps in one single list. It also keeps the relative paths relative, which is important for our checks.

## Screenshots
<!-- Provide images of the before and after functionality -->

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
cc/ @KatzMitch 