### PR TITLE
Use full file path in context, not relative

### DIFF
--- a/packages/cli/lib/validators/marketplaceValidators/BaseValidator.js
+++ b/packages/cli/lib/validators/marketplaceValidators/BaseValidator.js
@@ -31,9 +31,8 @@ class BaseValidator {
   }
 
   getError(errorObj, file, extraContext = {}) {
-    const relativeFilePath = file ? this.getRelativePath(file) : null;
     const context = {
-      filePath: relativeFilePath,
+      filePath: filePath,
       ...extraContext,
     };
     return {

--- a/packages/cli/lib/validators/marketplaceValidators/BaseValidator.js
+++ b/packages/cli/lib/validators/marketplaceValidators/BaseValidator.js
@@ -32,7 +32,7 @@ class BaseValidator {
 
   getError(errorObj, file, extraContext = {}) {
     const context = {
-      filePath: filePath,
+      filePath: file,
       ...extraContext,
     };
     return {


### PR DESCRIPTION
## Description and Context
This PR updates the CLI response object's `context.filePath` field to be the absolute path in the file system, not the relative path to the theme root

## Screenshots
n/a

## TODO
I need to test this in our system - I think this will work and use the relative path to the working directory in Docker, but I do need to make sure it doesn't use the absolute path on the machine running this on our BE

## Who to Notify
