### PR TITLE
Surface warnings for upload/watch

### DIFF
--- a/packages/cli-lib/errorHandlers.js
+++ b/packages/cli-lib/errorHandlers.js
@@ -11,6 +11,7 @@ const {
   ApiErrorContext,
   logApiErrorInstance,
   logApiUploadErrorInstance,
+  logApiUploadWarnings,
   logServerlessFunctionApiErrorInstance,
   parseValidationErrors,
 } = require('./errorHandlers/apiErrors');
@@ -24,6 +25,7 @@ module.exports = {
   logErrorInstance,
   logApiErrorInstance,
   logApiUploadErrorInstance,
+  logApiUploadWarnings,
   logFileSystemErrorInstance,
   logServerlessFunctionApiErrorInstance,
 };

--- a/packages/cli-lib/errorHandlers/apiErrors.js
+++ b/packages/cli-lib/errorHandlers/apiErrors.js
@@ -200,6 +200,22 @@ function logApiUploadErrorInstance(error, context) {
   logApiErrorInstance(error, context);
 }
 
+/**
+ * Logs a message for a warning resulting from filemapper API upload.
+ *
+ * @param {Object} resp
+ */
+function logApiUploadWarnings(resp, context) {
+  if (resp && resp.warnings && resp.warnings.length) {
+    resp.warnings.forEach(warning => {
+      if (warning.message) {
+        logger.warn(warning.message);
+      }
+      debugErrorAndContext(warning, context);
+    });
+  }
+}
+
 async function verifyAccessKeyAndUserAccess(accountId, scopeGroup) {
   const accountConfig = getAccountConfig(accountId);
   const { authType } = accountConfig;
@@ -267,5 +283,6 @@ module.exports = {
   parseValidationErrors,
   logApiErrorInstance,
   logApiUploadErrorInstance,
+  logApiUploadWarnings,
   logServerlessFunctionApiErrorInstance,
 };

--- a/packages/cli-lib/errorHandlers/apiErrors.js
+++ b/packages/cli-lib/errorHandlers/apiErrors.js
@@ -1,3 +1,4 @@
+const path = require('path');
 const { logger } = require('../logger');
 const { getAccountConfig } = require('../lib/config');
 const {
@@ -207,10 +208,9 @@ function logApiUploadErrorInstance(error, context) {
  */
 function logApiUploadWarnings(resp, context) {
   if (resp && resp.warnings && resp.warnings.length) {
+    const { base } = path.parse(resp.path);
     resp.warnings.forEach(warning => {
-      if (warning.message) {
-        logger.warn(warning.message);
-      }
+      logger.warn(`"${base}" - ${warning.message}`);
       debugErrorAndContext(warning, context);
     });
   }

--- a/packages/cli-lib/errorHandlers/apiErrors.js
+++ b/packages/cli-lib/errorHandlers/apiErrors.js
@@ -208,7 +208,7 @@ function logApiUploadErrorInstance(error, context) {
  */
 function logApiUploadWarnings(resp, context) {
   if (resp && resp.warnings && resp.warnings.length) {
-    const { base } = path.parse(resp.path);
+    const base = path.basename(resp.path);
     resp.warnings.forEach(warning => {
       logger.warn(`"${base}" - ${warning.message}`);
       debugErrorAndContext(warning, context);

--- a/packages/cli-lib/errorHandlers/standardErrors.js
+++ b/packages/cli-lib/errorHandlers/standardErrors.js
@@ -30,10 +30,14 @@ function debugErrorAndContext(error, context) {
       response: response.body,
       headers: response.headers,
     });
+  } else if (error.severity === 'WARNING') {
+    logger.debug('WARNING: %o', error);
   } else {
     logger.debug('Error: %o', error);
   }
-  logger.debug('Context: %o', context);
+  if (context) {
+    logger.debug('Context: %o', context);
+  }
 }
 
 /**

--- a/packages/cli-lib/lib/uploadFolder.js
+++ b/packages/cli-lib/lib/uploadFolder.js
@@ -16,6 +16,7 @@ const {
 const {
   ApiErrorContext,
   logApiUploadErrorInstance,
+  logApiUploadWarnings,
   isFatalError,
 } = require('../errorHandlers');
 
@@ -82,7 +83,9 @@ async function uploadFolder(accountId, src, dest, options) {
     return async () => {
       logger.debug('Attempting to upload file "%s" to "%s"', file, destPath);
       try {
-        await upload(accountId, file, destPath, apiOptions);
+        await upload(accountId, file, destPath, apiOptions).then(resp => {
+          logApiUploadWarnings(resp);
+        });
         logger.log('Uploaded file "%s" to "%s"', file, destPath);
       } catch (error) {
         if (isFatalError(error)) {

--- a/packages/cli-lib/lib/uploadFolder.js
+++ b/packages/cli-lib/lib/uploadFolder.js
@@ -83,14 +83,13 @@ async function uploadFolder(accountId, src, dest, options) {
     return async () => {
       logger.debug('Attempting to upload file "%s" to "%s"', file, destPath);
       try {
-        await upload(accountId, file, destPath, apiOptions).then(resp => {
-          const errorContext = new ApiErrorContext({
-            accountId,
-            request: destPath,
-            payload: src,
-          });
-          logApiUploadWarnings(resp, errorContext);
+        const resp = await upload(accountId, file, destPath, apiOptions);
+        const errorContext = new ApiErrorContext({
+          accountId,
+          request: destPath,
+          payload: src,
         });
+        logApiUploadWarnings(resp, errorContext);
         logger.log('Uploaded file "%s" to "%s"', file, destPath);
       } catch (error) {
         if (isFatalError(error)) {

--- a/packages/cli-lib/lib/uploadFolder.js
+++ b/packages/cli-lib/lib/uploadFolder.js
@@ -84,7 +84,12 @@ async function uploadFolder(accountId, src, dest, options) {
       logger.debug('Attempting to upload file "%s" to "%s"', file, destPath);
       try {
         await upload(accountId, file, destPath, apiOptions).then(resp => {
-          logApiUploadWarnings(resp);
+          const errorContext = new ApiErrorContext({
+            accountId,
+            request: destPath,
+            payload: src,
+          });
+          logApiUploadWarnings(resp, errorContext);
         });
         logger.log('Uploaded file "%s" to "%s"', file, destPath);
       } catch (error) {


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
This surfaces the warnings that the BE is returning on upload. Some errors are non-fatal which means that the upload/watch will still succeed. In this scenario we want to log the warnings to the user as `[WARNING]` messages.

## Screenshots
<!-- Provide images of the before and after functionality -->
![image](https://user-images.githubusercontent.com/6654014/126380885-5a4ce478-dea5-4b76-b87e-307d2af01d78.png)

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->
- [x] Test this to make sure it works as expected
## Who to Notify
<!-- /cc those you wish to know about the PR -->
cc/ @bkrainer 