### PR TITLE
Updated HubDB publish endpoint

### DIFF
--- a/packages/cli-lib/api/hubdb.js
+++ b/packages/cli-lib/api/hubdb.js
@@ -29,7 +29,7 @@ async function updateTable(accountId, tableId, schema) {
 
 async function publishTable(accountId, tableId) {
   return http.post(accountId, {
-    uri: `${HUBDB_API_PATH}/tables/${tableId}/draft/push-live`,
+    uri: `${HUBDB_API_PATH}/tables/${tableId}/draft/publish`,
   });
 }
 


### PR DESCRIPTION
## Description and Context
The BE team has updated the publish endpoint from `push-live` to `publish`. This PR updates the endpoint used.

## Who to Notify
@gobimcp 
