### PR TITLE
Surface error encountered when fetching scope data

### DIFF
--- a/packages/cli-lib/errorHandlers/apiErrors.js
+++ b/packages/cli-lib/errorHandlers/apiErrors.js
@@ -211,7 +211,7 @@ async function verifyAccessKeyAndUserAccess(accountId, scopeGroup) {
   try {
     scopesData = await fetchScopeData(accountId, scopeGroup);
   } catch (e) {
-    logger.debug('Error verifying access');
+    logger.debug(`Error verifying access of scopeGroup ${scopeGroup}: ${e}`);
     return;
   }
   const { portalScopesInGroup, userScopesInGroup } = scopesData;


### PR DESCRIPTION
## Description and Context
An error encountered when fetching scope data results in a message "Error verifying access" which is not very useful for debugging. 

This PR surfaces the error and associated `scopeGroup` that data was being fetched for.