### PR TITLE
Document theme command

### DIFF
--- a/packages/cli/commands/theme.js
+++ b/packages/cli/commands/theme.js
@@ -2,7 +2,8 @@ const marketplaceValidate = require('./marketplaceValidate/validateTheme');
 const { addConfigOptions, addAccountOptions } = require('../lib/commonOpts');
 
 exports.command = 'theme';
-exports.describe = 'Commands for working with themes, including marketplace validation with the marketplace-validate subcommand';
+exports.describe =
+  'Commands for working with themes, including marketplace validation with the marketplace-validate subcommand';
 
 exports.builder = yargs => {
   addConfigOptions(yargs, true);

--- a/packages/cli/commands/theme.js
+++ b/packages/cli/commands/theme.js
@@ -2,7 +2,7 @@ const marketplaceValidate = require('./marketplaceValidate/validateTheme');
 const { addConfigOptions, addAccountOptions } = require('../lib/commonOpts');
 
 exports.command = 'theme';
-exports.describe = false; // 'Commands for working with themes';
+exports.describe = 'Commands for working with themes, including marketplace validation';
 
 exports.builder = yargs => {
   addConfigOptions(yargs, true);

--- a/packages/cli/commands/theme.js
+++ b/packages/cli/commands/theme.js
@@ -2,7 +2,7 @@ const marketplaceValidate = require('./marketplaceValidate/validateTheme');
 const { addConfigOptions, addAccountOptions } = require('../lib/commonOpts');
 
 exports.command = 'theme';
-exports.describe = 'Commands for working with themes, including marketplace validation';
+exports.describe = 'Commands for working with themes, including marketplace validation with the marketplace-validate subcommand';
 
 exports.builder = yargs => {
   addConfigOptions(yargs, true);


### PR DESCRIPTION
## Description and Context
This PR adds a help menu for the `hs theme` command, including a more detailed description pointing towards the `marketplace-validate` subcommand

## Screenshots
<img width="820" alt="Screen Shot 2021-09-13 at 12 57 39 PM" src="https://user-images.githubusercontent.com/8165004/133148194-1a2e5295-407d-4e07-a388-26c4c73c6917.png">


## TODO
No

## Who to Notify
@ajlaporte 
