### PR TITLE
Fixing buildAnnotationValueGetter util

### DIFF
--- a/packages/cli-lib/templates.js
+++ b/packages/cli-lib/templates.js
@@ -1,5 +1,5 @@
 const fs = require('fs');
-const { logger } = require('@hubspot/cli-lib/logger');
+const { logger } = require('./logger');
 
 // Matches the .html file extension, excluding module.html
 const TEMPLATE_EXTENSION_REGEX = new RegExp(/(?<!module)\.html$/);

--- a/packages/cli-lib/templates.js
+++ b/packages/cli-lib/templates.js
@@ -1,3 +1,6 @@
+const fs = require('fs');
+const { logger } = require('@hubspot/cli-lib/logger');
+
 // Matches the .html file extension, excluding module.html
 const TEMPLATE_EXTENSION_REGEX = new RegExp(/(?<!module)\.html$/);
 
@@ -21,7 +24,14 @@ const getAnnotationValue = (annotations, key) => {
   return match ? match[1].trim() : null;
 };
 
-const buildAnnotationValueGetter = source => {
+const buildAnnotationValueGetter = file => {
+  let source;
+  try {
+    source = fs.readFileSync(file, 'utf8');
+  } catch (e) {
+    logger.error(`Error reading file annotations ${file}`);
+    return;
+  }
   const match = source.match(ANNOTATIONS_REGEX);
   const annotation = match && match[1] ? match[1] : '';
   return annotationKey => getAnnotationValue(annotation, annotationKey);

--- a/packages/cli/lib/validators/marketplaceValidators/theme/SectionValidator.js
+++ b/packages/cli/lib/validators/marketplaceValidators/theme/SectionValidator.js
@@ -1,7 +1,6 @@
 const {
   ANNOTATION_KEYS,
-  getAnnotationValue,
-  getFileAnnotations,
+  buildAnnotationValueGetter,
 } = require('@hubspot/cli-lib/templates');
 const BaseValidator = require('../BaseValidator');
 const { VALIDATOR_KEYS } = require('../../constants');
@@ -48,24 +47,17 @@ class SectionValidator extends BaseValidator {
 
     files.forEach(file => {
       if (file) {
-        const annotations = getFileAnnotations(file);
-        const templateType = getAnnotationValue(
-          annotations,
-          ANNOTATION_KEYS.templateType
-        );
+        const getAnnotationValue = buildAnnotationValueGetter(file);
+        const templateType = getAnnotationValue(ANNOTATION_KEYS.templateType);
 
         if (templateType !== 'section') {
           return;
         }
         sectionCount++;
 
-        const description = getAnnotationValue(
-          annotations,
-          ANNOTATION_KEYS.description
-        );
-        const label = getAnnotationValue(annotations, ANNOTATION_KEYS.label);
+        const description = getAnnotationValue(ANNOTATION_KEYS.description);
+        const label = getAnnotationValue(ANNOTATION_KEYS.label);
         const screenshotPath = getAnnotationValue(
-          annotations,
           ANNOTATION_KEYS.screenshotPath
         );
 

--- a/packages/cli/lib/validators/marketplaceValidators/theme/TemplateValidator.js
+++ b/packages/cli/lib/validators/marketplaceValidators/theme/TemplateValidator.js
@@ -1,4 +1,3 @@
-const fs = require('fs');
 const {
   ANNOTATION_KEYS,
   buildAnnotationValueGetter,
@@ -6,7 +5,6 @@ const {
 } = require('@hubspot/cli-lib/templates');
 const BaseValidator = require('../BaseValidator');
 const { VALIDATOR_KEYS } = require('../../constants');
-const { logger } = require('@hubspot/cli-lib/logger');
 
 const TEMPLATE_LIMIT = 50;
 const TEMPLATE_IGNORE_LIST = ['section'];
@@ -101,14 +99,7 @@ class TemplateValidator extends BaseValidator {
 
     files.forEach(file => {
       if (isCodedFile(file)) {
-        let data;
-        try {
-          data = fs.readFileSync(file, 'utf8');
-        } catch (e) {
-          logger.error(`Error reading file ${file}`);
-        }
-        const getAnnotationValue = buildAnnotationValueGetter(data);
-
+        const getAnnotationValue = buildAnnotationValueGetter(file);
         const isAvailableForNewContent = getAnnotationValue(
           ANNOTATION_KEYS.isAvailableForNewContent
         );


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
The annotation util was [updated here](https://github.com/HubSpot/hubspot-cli/pull/534), and a [PR here](https://github.com/HubSpot/hubspot-cli/pull/546) that used the old version of the util was merged.

I also updated the util to include readFileSync so it's a little DRY-er

## Screenshots
<!-- Provide images of the before and after functionality -->

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->
- [ ] Need to test this still
## Who to Notify
<!-- /cc those you wish to know about the PR -->
