### PR TITLE
fix error handler params

### DIFF
--- a/packages/cli/commands/project/init.js
+++ b/packages/cli/commands/project/init.js
@@ -67,7 +67,6 @@ exports.handler = async options => {
       );
     } else {
       return logApiErrorInstance(
-        accountId,
         e,
         new ApiErrorContext({ accountId, projectPath })
       );


### PR DESCRIPTION
## Description and Context
Removes the `accountId` which was incorrectly included in the params. Previously the CLI was swallowing API related errors.

## Screenshots
Fixed:
![image](https://user-images.githubusercontent.com/9009552/133508241-a1ff1caa-0878-47b6-bf6d-512e75132f34.png)

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
