### PR TITLE
Prevent spinnies error on upload if buildPolling fails

### DIFF
--- a/packages/cli/commands/project/deploy.js
+++ b/packages/cli/commands/project/deploy.js
@@ -80,7 +80,7 @@ exports.handler = async options => {
     await pollDeployStatus(
       accountId,
       projectConfig.name,
-      deployResp.deployId,
+      deployResp.id,
       deployedBuildId
     );
   } catch (e) {

--- a/packages/cli/commands/project/deploy.js
+++ b/packages/cli/commands/project/deploy.js
@@ -62,27 +62,22 @@ exports.handler = async options => {
     logger.error('No latest build ID was found.');
     return;
   };
+  const deployedBuildId = buildId || (await getBuildId());
+  let deployId;
 
   try {
-    const deployedBuildId = buildId || (await getBuildId());
-
     const deployResp = await deployProject(
       accountId,
       projectConfig.name,
       deployedBuildId
     );
 
+    deployId = deployResp.deployId;
+
     if (deployResp.error) {
       logger.error(`Deploy error: ${deployResp.error.message}`);
       return;
     }
-
-    await pollDeployStatus(
-      accountId,
-      projectConfig.name,
-      deployResp.id,
-      deployedBuildId
-    );
   } catch (e) {
     if (e.statusCode === 400) {
       logger.error(e.error.message);
@@ -93,6 +88,17 @@ exports.handler = async options => {
         new ApiErrorContext({ accountId, projectPath })
       );
     }
+  }
+
+  try {
+    await pollDeployStatus(
+      accountId,
+      projectConfig.name,
+      deployId,
+      deployedBuildId
+    );
+  } catch (err) {
+    logger.error(err);
   }
 };
 

--- a/packages/cli/commands/project/upload.js
+++ b/packages/cli/commands/project/upload.js
@@ -57,8 +57,12 @@ const uploadProjectFiles = async (accountId, projectName, filePath) => {
     )}`,
   });
 
+  let buildId;
+
   try {
     const upload = await uploadProject(accountId, projectName, filePath);
+
+    buildId = upload.buildId;
 
     spinnies.succeed('upload', {
       text: `Uploaded ${chalk.bold(projectName)} project files to ${chalk.bold(
@@ -67,9 +71,8 @@ const uploadProjectFiles = async (accountId, projectName, filePath) => {
     });
 
     logger.debug(
-      `Project "${projectName}" uploaded and build #${upload.buildId} created`
+      `Project "${projectName}" uploaded and build #${buildId} created`
     );
-    await pollBuildStatus(accountId, projectName, upload.buildId);
   } catch (err) {
     if (err.statusCode === 404) {
       return logger.error(
@@ -89,6 +92,12 @@ const uploadProjectFiles = async (accountId, projectName, filePath) => {
         projectName,
       }),
     });
+  }
+
+  try {
+    await pollBuildStatus(accountId, projectName, buildId);
+  } catch (err) {
+    logger.log(err);
   }
 };
 


### PR DESCRIPTION
## Description and Context
When polling was sharing a catch block with the upload function, which was causing issues where an inactive "spinner" was incorrectly updated. 

![image](https://user-images.githubusercontent.com/9009552/134371666-fce15991-83f6-4a01-b234-299f7fdeba49.png)


## Screenshots
<!-- Provide images of the before and after functionality -->

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
