### PR TITLE
Check if config file can be exposed via git during hs init

### DIFF
--- a/packages/cli/commands/init.js
+++ b/packages/cli/commands/init.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const fs = require('fs-extra');
+const { checkAndWarnGitInclusion } = require('@hubspot/cli-lib');
 const {
   getConfigPath,
   createEmptyConfigFile,
@@ -116,6 +117,8 @@ exports.handler = async options => {
     );
 
     trackAuthAction('init', authType, TRACKING_STATUS.COMPLETE, accountId);
+
+    checkAndWarnGitInclusion();
     process.exit();
   } catch (err) {
     logErrorInstance(err);


### PR DESCRIPTION
## Description and Context
 `hs init` does not perform the check to make sure that the `hubspot.config.yml` file is not committed to git repos

## Screenshots
![image](https://user-images.githubusercontent.com/9009552/134534829-f3583dc3-a61b-4a19-be88-9cc9876ce360.png)

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
