### PR TITLE
Roll hs init step into hs project upload

### DIFF
--- a/packages/cli/commands/project/deploy.js
+++ b/packages/cli/commands/project/deploy.js
@@ -87,11 +87,7 @@ exports.handler = async options => {
     if (e.statusCode === 400) {
       logger.error(e.error.message);
     } else {
-      logApiErrorInstance(
-        accountId,
-        e,
-        new ApiErrorContext({ accountId, projectPath })
-      );
+      logApiErrorInstance(e, new ApiErrorContext({ accountId, projectPath }));
     }
   }
 };

--- a/packages/cli/commands/project/upload.js
+++ b/packages/cli/commands/project/upload.js
@@ -101,10 +101,12 @@ exports.handler = async options => {
 
   trackCommandUsage('project-upload', { projectPath }, accountId);
 
-  const cwd = projectPath ? path.resolve(getCwd(), projectPath) : getCwd();
-  const projectConfig = await getProjectConfig(cwd);
+  const projectDir = projectPath
+    ? path.resolve(getCwd(), projectPath)
+    : getCwd();
+  const projectConfig = await getProjectConfig(projectDir);
 
-  validateProjectConfig(projectConfig);
+  validateProjectConfig(projectConfig, projectDir);
 
   await ensureProjectExists(accountId, projectConfig.name);
 
@@ -134,8 +136,10 @@ exports.handler = async options => {
 
   archive.pipe(output);
 
-  archive.directory(path.resolve(cwd, projectConfig.srcDir), false, file =>
-    shouldIgnoreFile(file.name) ? false : file
+  archive.directory(
+    path.resolve(projectDir, projectConfig.srcDir),
+    false,
+    file => (shouldIgnoreFile(file.name) ? false : file)
   );
 
   archive.finalize();

--- a/packages/cli/commands/project/upload.js
+++ b/packages/cli/commands/project/upload.js
@@ -84,12 +84,13 @@ const uploadProjectFiles = async (accountId, projectName, filePath) => {
       )} project files to ${chalk.bold(accountId)}`,
     });
 
-    logApiErrorInstance(err, {
-      context: new ApiErrorContext({
+    logApiErrorInstance(
+      err,
+      new ApiErrorContext({
         accountId,
         projectName,
-      }),
-    });
+      })
+    );
   }
 };
 

--- a/packages/cli/commands/project/upload.js
+++ b/packages/cli/commands/project/upload.js
@@ -28,7 +28,7 @@ const { shouldIgnoreFile } = require('@hubspot/cli-lib/ignoreRules');
 const { getCwd } = require('@hubspot/cli-lib/path');
 const { validateAccount } = require('../../lib/validation');
 const {
-  getOrCreateProjectConfig,
+  getProjectConfig,
   validateProjectConfig,
   pollBuildStatus,
   ensureProjectExists,
@@ -102,7 +102,7 @@ exports.handler = async options => {
   trackCommandUsage('project-upload', { projectPath }, accountId);
 
   const cwd = projectPath ? path.resolve(getCwd(), projectPath) : getCwd();
-  const projectConfig = await getOrCreateProjectConfig(cwd);
+  const projectConfig = await getProjectConfig(cwd);
 
   validateProjectConfig(projectConfig);
 

--- a/packages/cli/commands/project/upload.js
+++ b/packages/cli/commands/project/upload.js
@@ -31,7 +31,7 @@ const {
   getOrCreateProjectConfig,
   validateProjectConfig,
   pollBuildStatus,
-  ensureProject,
+  ensureProjectExists,
 } = require('../../lib/projects');
 
 const loadAndValidateOptions = async options => {
@@ -106,7 +106,7 @@ exports.handler = async options => {
 
   validateProjectConfig(projectConfig);
 
-  await ensureProject(accountId, projectConfig.name);
+  await ensureProjectExists(accountId, projectConfig.name);
 
   const tempFile = tmp.fileSync({ postfix: '.zip' });
 

--- a/packages/cli/commands/project/upload.js
+++ b/packages/cli/commands/project/upload.js
@@ -28,9 +28,10 @@ const { shouldIgnoreFile } = require('@hubspot/cli-lib/ignoreRules');
 const { getCwd } = require('@hubspot/cli-lib/path');
 const { validateAccount } = require('../../lib/validation');
 const {
-  getProjectConfig,
+  getOrCreateProjectConfig,
   validateProjectConfig,
   pollBuildStatus,
+  ensureProject,
 } = require('../../lib/projects');
 
 const loadAndValidateOptions = async options => {
@@ -101,9 +102,11 @@ exports.handler = async options => {
   trackCommandUsage('project-upload', { projectPath }, accountId);
 
   const cwd = projectPath ? path.resolve(getCwd(), projectPath) : getCwd();
-  const projectConfig = await getProjectConfig(cwd);
+  const projectConfig = await getOrCreateProjectConfig(cwd);
 
   validateProjectConfig(projectConfig);
+
+  await ensureProject(accountId, projectConfig.name);
 
   const tempFile = tmp.fileSync({ postfix: '.zip' });
 

--- a/packages/cli/lib/projects.js
+++ b/packages/cli/lib/projects.js
@@ -22,7 +22,10 @@ const {
   fetchProject,
   createProject,
 } = require('@hubspot/cli-lib/api/dfs');
-const { logApiErrorInstance } = require('@hubspot/cli-lib/errorHandlers');
+const {
+  logApiErrorInstance,
+  ApiErrorContext,
+} = require('@hubspot/cli-lib/errorHandlers');
 
 const isBuildComplete = build => {
   return (
@@ -134,7 +137,7 @@ const ensureProjectExists = async (accountId, projectName) => {
         try {
           return createProject(accountId, projectName);
         } catch (err) {
-          return logApiErrorInstance(err);
+          return logApiErrorInstance(err, new ApiErrorContext({ accountId }));
         }
       } else {
         return logger.log(
@@ -144,7 +147,7 @@ const ensureProjectExists = async (accountId, projectName) => {
         );
       }
     }
-    logApiErrorInstance(err);
+    logApiErrorInstance(err, new ApiErrorContext({ accountId }));
   }
 };
 

--- a/packages/cli/lib/projects.js
+++ b/packages/cli/lib/projects.js
@@ -94,7 +94,7 @@ const getOrCreateProjectConfig = async projectPath => {
   return projectConfig;
 };
 
-const validateProjectConfig = projectConfig => {
+const validateProjectConfig = (projectConfig, projectDir) => {
   if (!projectConfig) {
     logger.error(
       `Project config not found. Try running 'hs project init' first.`
@@ -109,7 +109,7 @@ const validateProjectConfig = projectConfig => {
     process.exit(1);
   }
 
-  if (!fs.existsSync(projectConfig.srcDir)) {
+  if (!fs.existsSync(path.resolve(projectDir, projectConfig.srcDir))) {
     logger.error(
       `Project source directory '${projectConfig.srcDir}' does not exist.`
     );

--- a/packages/cli/lib/projects.js
+++ b/packages/cli/lib/projects.js
@@ -62,6 +62,11 @@ const getOrCreateProjectConfig = async projectPath => {
   const projectConfig = await getProjectConfig(projectPath);
 
   if (!projectConfig) {
+    logger.log('');
+    logger.log(chalk.bold('> Welcome to HubSpot Developer Projects!'));
+    logger.log(
+      '\n-------------------------------------------------------------\n'
+    );
     const { name, srcDir } = await prompt([
       {
         name: 'name',
@@ -117,7 +122,7 @@ const validateProjectConfig = projectConfig => {
   }
 };
 
-const ensureProject = async (accountId, projectName) => {
+const ensureProjectExists = async (accountId, projectName) => {
   try {
     await fetchProject(accountId, projectName);
   } catch (err) {
@@ -125,23 +130,23 @@ const ensureProject = async (accountId, projectName) => {
       const { shouldCreateProject } = await prompt([
         {
           name: 'shouldCreateProject',
-          message: `This project does not exist in: . Would you like to create it?`,
+          message: `The project ${projectName} does not exist in ${accountId}. Would you like to create it?`,
           type: 'confirm',
         },
       ]);
+
       if (shouldCreateProject) {
         try {
-          await createProject(accountId, projectName);
+          return createProject(accountId, projectName);
         } catch (err) {
-          logApiErrorInstance(err);
+          return logApiErrorInstance(err);
         }
       } else {
-        logger.log(
+        return logger.log(
           `Your project ${chalk.bold(
             projectName
           )} could not be found in ${chalk.bold(accountId)}.`
         );
-        process.exit(1);
       }
     }
     logApiErrorInstance(err);
@@ -372,5 +377,5 @@ module.exports = {
   showWelcomeMessage,
   pollBuildStatus,
   pollDeployStatus,
-  ensureProject,
+  ensureProjectExists,
 };

--- a/packages/cli/lib/projects.js
+++ b/packages/cli/lib/projects.js
@@ -62,11 +62,6 @@ const getOrCreateProjectConfig = async projectPath => {
   const projectConfig = await getProjectConfig(projectPath);
 
   if (!projectConfig) {
-    logger.log('');
-    logger.log(chalk.bold('> Welcome to HubSpot Developer Projects!'));
-    logger.log(
-      '\n-------------------------------------------------------------\n'
-    );
     const { name, srcDir } = await prompt([
       {
         name: 'name',


### PR DESCRIPTION
## Description and Context
Now as part of the `hs project upload` command, we:
- make sure that a config exists, and if not- prompt the user to run `hs project init`
- check to see if the project exists in the account and if not, prompt the user to create it

When no config is found:
```
[ERROR] Project config not found. Try running 'hs project init' first.
```

When config is found but project doesn't exist in account:
```
? The project test12 does not exist in 123. Would you like to create it? (Y/n)
```

## Screenshots


## TODO
The next step here is to rename and update the existing `hs project init` function to `hs project create` and build out that command

## Who to Notify
<!-- /cc those you wish to know about the PR -->
