### PR TITLE
Exit 2 on FATAL marketplace validations

### DIFF
--- a/packages/cli/commands/marketplaceValidate/validateTheme.js
+++ b/packages/cli/commands/marketplaceValidate/validateTheme.js
@@ -75,7 +75,7 @@ exports.handler = async options => {
         .flat()
         .some(result => result.result === VALIDATION_RESULT.FATAL)
     ) {
-      process.exit(1);
+      process.exit(2);
     }
   });
 };


### PR DESCRIPTION
## Description and Context
This PR updates the exit code to `2` (instead of `1`) when the CLI has FATAL validation warnings. This will allow us to determine on the BE caller whether we are exiting because of a validation failure or because of an internal error of some other sort

## Screenshots
Before
<img width="570" alt="Screen Shot 2021-09-24 at 10 40 35 AM" src="https://user-images.githubusercontent.com/8165004/134693471-da37ccfa-fb79-46c0-9534-bcabb58e599f.png">

After
<img width="570" alt="Screen Shot 2021-09-24 at 10 39 53 AM" src="https://user-images.githubusercontent.com/8165004/134693359-2b1798e6-b888-44ff-aae3-4deae9084044.png">

## TODO
n/a

## Who to Notify
n/a