### PR TITLE
Fix: add buildId to deploy message

### DIFF
--- a/packages/cli/lib/projects.js
+++ b/packages/cli/lib/projects.js
@@ -32,17 +32,17 @@ const {
 const PROJECT_STRINGS = {
   BUILD: {
     INITIALIZE: (name, numOfComponents) =>
-      `Building ${chalk.bold(
-        name
-      )}\n\nFound ${numOfComponents} components in this project ...\n`,
+      `Building ${chalk.bold(name)}\n\nFound ${numOfComponents} component${
+        numOfComponents !== 1 ? 's' : ''
+      } in this project ...\n`,
     SUCCESS: name => `Built ${chalk.bold(name)}`,
     FAIL: name => `Failed to build ${chalk.bold(name)}`,
   },
   DEPLOY: {
     INITIALIZE: (name, numOfComponents) =>
-      `Deploying ${chalk.bold(
-        name
-      )}\n\nFound ${numOfComponents} components in this project ...\n`,
+      `Deploying ${chalk.bold(name)}\n\nFound ${numOfComponents} component${
+        numOfComponents !== 1 ? 's' : ''
+      } in this project ...\n`,
     SUCCESS: name => `Deployed ${chalk.bold(name)}`,
     FAIL: name => `Failed to deploy ${chalk.bold(name)}`,
   },


### PR DESCRIPTION
## Description and Context
During the deploy phase, the `deployId` is shown to the user when it should actually be displaying the `buildId`

## Screenshots
<!-- Provide images of the before and after functionality -->

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
