### PR TITLE
Add flag to forcefully create project on upload

### DIFF
--- a/packages/cli/commands/project/upload.js
+++ b/packages/cli/commands/project/upload.js
@@ -78,12 +78,6 @@ const uploadProjectFiles = async (accountId, projectName, filePath) => {
       `Project "${projectName}" uploaded and build #${buildId} created`
     );
   } catch (err) {
-    if (err.statusCode === 404) {
-      return logger.error(
-        `Project '${projectName}' does not exist. Try running 'hs project init' first.`
-      );
-    }
-
     spinnies.fail('upload', {
       text: `Failed to upload ${chalk.bold(
         projectName
@@ -106,7 +100,7 @@ const uploadProjectFiles = async (accountId, projectName, filePath) => {
 exports.handler = async options => {
   loadAndValidateOptions(options);
 
-  const { path: projectPath } = options;
+  const { forceCreate, path: projectPath } = options;
   const accountId = getAccountId(options);
 
   trackCommandUsage('project-upload', { projectPath }, accountId);
@@ -118,7 +112,7 @@ exports.handler = async options => {
 
   validateProjectConfig(projectConfig, projectDir);
 
-  await ensureProjectExists(accountId, projectConfig.name);
+  await ensureProjectExists(accountId, projectConfig.name, forceCreate);
 
   const tempFile = tmp.fileSync({ postfix: '.zip' });
 
@@ -216,6 +210,12 @@ exports.builder = yargs => {
   yargs.positional('path', {
     describe: 'Path to a project folder',
     type: 'string',
+  });
+
+  yargs.option('forceCreate', {
+    describe: 'Automatically create project if it does not exist',
+    type: 'boolean',
+    default: false,
   });
 
   yargs.example([['$0 project upload myProjectFolder', 'Upload a project']]);

--- a/packages/cli/lib/projects.js
+++ b/packages/cli/lib/projects.js
@@ -169,18 +169,23 @@ const validateProjectConfig = (projectConfig, projectDir) => {
   }
 };
 
-const ensureProjectExists = async (accountId, projectName) => {
+const ensureProjectExists = async (accountId, projectName, forceCreate) => {
   try {
     await fetchProject(accountId, projectName);
   } catch (err) {
     if (err.statusCode === 404) {
-      const { shouldCreateProject } = await prompt([
-        {
-          name: 'shouldCreateProject',
-          message: `The project ${projectName} does not exist in ${accountId}. Would you like to create it?`,
-          type: 'confirm',
-        },
-      ]);
+      let shouldCreateProject = forceCreate;
+
+      if (!shouldCreateProject) {
+        const promptResult = await prompt([
+          {
+            name: 'shouldCreateProject',
+            message: `The project ${projectName} does not exist in ${accountId}. Would you like to create it?`,
+            type: 'confirm',
+          },
+        ]);
+        shouldCreateProject = promptResult.shouldCreateProject;
+      }
 
       if (shouldCreateProject) {
         try {


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
Adding a flag to bypass the "do you want to create this project" question that we ask users on initial project upload. This will be used in the GH project upload action.

This is the question that this flag bypasses:
`? The project example-project does not exist in 123456. Would you like to create it? Yes`

Example usage:
`hs project upload --forceCreate`

## Screenshots
<!-- Provide images of the before and after functionality -->

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
