### PR TITLE
Fix personalAccessKey acceptance test

### DIFF
--- a/acceptance-tests/tests/init-personal-access-key.spec.js
+++ b/acceptance-tests/tests/init-personal-access-key.spec.js
@@ -18,7 +18,7 @@ describe('hs init using personalAccessKey', () => {
   it('should create a new config file', async () => {
     await cli.execute(
       ['init', `--c="${CONFIG_FILE_PATH}"`],
-      [cmd.ENTER, config.personalAccessKey, cmd.ENTER, 'QA', cmd.ENTER]
+      [config.personalAccessKey, cmd.ENTER, 'QA', cmd.ENTER]
     );
 
     expect(existsSync(CONFIG_FILE_PATH)).toBe(true);

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "publish-release": "yarn lerna publish --conventional-graduate",
     "publish-prerelease": "yarn lerna publish prerelease --preid beta --dist-tag next",
     "test": "jest",
-    "test-cli": "lerna run run-tests --stream",
+    "test-cli": "lerna run test-headless --stream",
     "jest": "jest --watch",
     "circular-deps": "yarn madge --circular packages"
   },

--- a/packages/cli/lib/prompts.js
+++ b/packages/cli/lib/prompts.js
@@ -18,10 +18,10 @@ const promptUser = async promptConfig => {
  * then opens their browser to the personal-access-key shortlink
  */
 const personalAccessKeyPrompt = async ({ env } = {}) => {
-  await promptUser([PERSONAL_ACCESS_KEY_BROWSER_OPEN_PREP]);
   const websiteOrigin = getHubSpotWebsiteOrigin(env);
   const url = `${websiteOrigin}/l/personal-access-key`;
   if (process.env.BROWSER !== 'none') {
+    await promptUser([PERSONAL_ACCESS_KEY_BROWSER_OPEN_PREP]);
     open(url, { url: true });
   }
 


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
Switches to use "headless mode" since the browser is not available in the GH Action container and I _believe_ this was causing inputs to happen too early, resulting in the bad PAK error.
## Screenshots
<!-- Provide images of the before and after functionality -->
![image](https://user-images.githubusercontent.com/9009552/138892694-36e448a4-83b9-4b6d-9584-6c0586166d56.png)

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
