### PR TITLE
Resolve projects from project root

### DIFF
--- a/packages/cli/commands/project/deploy.js
+++ b/packages/cli/commands/project/deploy.js
@@ -47,7 +47,7 @@ exports.handler = async options => {
   trackCommandUsage('project-deploy', { projectPath }, accountId);
 
   const cwd = projectPath ? path.resolve(getCwd(), projectPath) : getCwd();
-  const projectConfig = await getProjectConfig(cwd);
+  const { projectConfig } = await getProjectConfig(cwd);
 
   logger.debug(`Deploying project at path: ${projectPath}`);
 

--- a/packages/cli/commands/project/deploy.js
+++ b/packages/cli/commands/project/deploy.js
@@ -1,4 +1,3 @@
-const path = require('path');
 const {
   addAccountOptions,
   addConfigOptions,
@@ -19,7 +18,6 @@ const {
 } = require('@hubspot/cli-lib/errorHandlers');
 const { logger } = require('@hubspot/cli-lib/logger');
 const { deployProject, fetchProject } = require('@hubspot/cli-lib/api/dfs');
-const { getCwd } = require('@hubspot/cli-lib/path');
 const { validateAccount } = require('../../lib/validation');
 const { getProjectConfig, pollDeployStatus } = require('../../lib/projects');
 
@@ -46,8 +44,7 @@ exports.handler = async options => {
 
   trackCommandUsage('project-deploy', { projectPath }, accountId);
 
-  const cwd = projectPath ? path.resolve(getCwd(), projectPath) : getCwd();
-  const { projectConfig } = await getProjectConfig(cwd);
+  const { projectConfig } = await getProjectConfig(projectPath);
 
   logger.debug(`Deploying project at path: ${projectPath}`);
 

--- a/packages/cli/commands/project/upload.js
+++ b/packages/cli/commands/project/upload.js
@@ -108,7 +108,7 @@ exports.handler = async options => {
   const projectDir = projectPath
     ? path.resolve(getCwd(), projectPath)
     : getCwd();
-  const projectConfig = await getProjectConfig(projectDir);
+  const { projectConfig } = await getProjectConfig(projectDir);
 
   validateProjectConfig(projectConfig, projectDir);
 

--- a/packages/cli/commands/project/upload.js
+++ b/packages/cli/commands/project/upload.js
@@ -105,10 +105,8 @@ exports.handler = async options => {
 
   trackCommandUsage('project-upload', { projectPath }, accountId);
 
-  const projectDir = projectPath
-    ? path.resolve(getCwd(), projectPath)
-    : getCwd();
-  const { projectConfig } = await getProjectConfig(projectDir);
+  const cwd = projectPath ? path.resolve(getCwd(), projectPath) : getCwd();
+  const { projectConfig, projectDir } = await getProjectConfig(cwd);
 
   validateProjectConfig(projectConfig, projectDir);
 

--- a/packages/cli/commands/project/upload.js
+++ b/packages/cli/commands/project/upload.js
@@ -25,7 +25,6 @@ const {
 const { logger } = require('@hubspot/cli-lib/logger');
 const { uploadProject } = require('@hubspot/cli-lib/api/dfs');
 const { shouldIgnoreFile } = require('@hubspot/cli-lib/ignoreRules');
-const { getCwd } = require('@hubspot/cli-lib/path');
 const { validateAccount } = require('../../lib/validation');
 const {
   getProjectConfig,
@@ -105,8 +104,7 @@ exports.handler = async options => {
 
   trackCommandUsage('project-upload', { projectPath }, accountId);
 
-  const cwd = projectPath ? path.resolve(getCwd(), projectPath) : getCwd();
-  const { projectConfig, projectDir } = await getProjectConfig(cwd);
+  const { projectConfig, projectDir } = await getProjectConfig(projectPath);
 
   validateProjectConfig(projectConfig, projectDir);
 

--- a/packages/cli/lib/projects.js
+++ b/packages/cli/lib/projects.js
@@ -29,6 +29,7 @@ const {
   logApiErrorInstance,
   ApiErrorContext,
 } = require('@hubspot/cli-lib/errorHandlers');
+const { getCwd } = require('@hubspot/cli-lib/path');
 
 const PROJECT_STRINGS = {
   BUILD: {
@@ -59,9 +60,11 @@ const writeProjectConfig = (configPath, config) => {
   }
 };
 
-const getProjectConfig = async projectPath => {
+const getProjectConfig = async _dir => {
+  const projectDir = _dir ? path.resolve(getCwd(), _dir) : getCwd();
+
   const configPath = findup(PROJECT_CONFIG_FILE, {
-    cwd: projectPath,
+    cwd: projectDir,
     nocase: true,
   });
 

--- a/packages/cli/lib/projects.js
+++ b/packages/cli/lib/projects.js
@@ -65,25 +65,29 @@ const getProjectConfig = async projectPath => {
   });
 
   if (!configPath) {
-    return null;
+    return {};
   }
 
   try {
-    const projectConfig = fs.readFileSync(configPath);
-    return JSON.parse(projectConfig);
+    const config = fs.readFileSync(configPath);
+    const projectConfig = JSON.parse(config);
+    return {
+      configPath,
+      projectConfig,
+    };
   } catch (e) {
     logger.error('Could not read from project config');
   }
 };
 
 const createProjectConfig = async (projectPath, projectName) => {
-  const projectConfig = await getProjectConfig(projectPath);
+  const { projectConfig, configPath } = await getProjectConfig(projectPath);
   const projectConfigPath = path.join(projectPath, 'hsproject.json');
 
   if (projectConfig) {
     logger.log(
       `Found an existing project config in this folder (${chalk.bold(
-        projectConfig.name
+        configPath
       )})`
     );
   } else {

--- a/packages/cli/lib/projects.js
+++ b/packages/cli/lib/projects.js
@@ -85,7 +85,11 @@ const createProjectConfig = async (projectPath, projectName) => {
   const projectConfigPath = path.join(projectPath, 'hsproject.json');
 
   if (projectConfig) {
-    logger.log(`Found an existing project in (${chalk.bold(projectDir)})`);
+    logger.log(
+      `Projects cannot contain other projects. Found an existing project in (${chalk.bold(
+        projectDir
+      )})`
+    );
   } else {
     logger.log(
       `Creating project in ${projectPath ? projectPath : 'the current folder'}`

--- a/packages/cli/lib/projects.js
+++ b/packages/cli/lib/projects.js
@@ -72,7 +72,7 @@ const getProjectConfig = async projectPath => {
     const config = fs.readFileSync(configPath);
     const projectConfig = JSON.parse(config);
     return {
-      configPath,
+      projectDir: path.dirname(configPath),
       projectConfig,
     };
   } catch (e) {
@@ -81,15 +81,11 @@ const getProjectConfig = async projectPath => {
 };
 
 const createProjectConfig = async (projectPath, projectName) => {
-  const { projectConfig, configPath } = await getProjectConfig(projectPath);
+  const { projectConfig, projectDir } = await getProjectConfig(projectPath);
   const projectConfigPath = path.join(projectPath, 'hsproject.json');
 
   if (projectConfig) {
-    logger.log(
-      `Found an existing project config in this folder (${chalk.bold(
-        configPath
-      )})`
-    );
+    logger.log(`Found an existing project in (${chalk.bold(projectDir)})`);
   } else {
     logger.log(
       `Creating project in ${projectPath ? projectPath : 'the current folder'}`
@@ -167,7 +163,7 @@ const validateProjectConfig = (projectConfig, projectDir) => {
 
   if (!fs.existsSync(path.resolve(projectDir, projectConfig.srcDir))) {
     logger.error(
-      `Project source directory '${projectConfig.srcDir}' does not exist.`
+      `Project source directory '${projectConfig.srcDir}' could not be found in ${projectDir}.`
     );
     process.exit(1);
   }

--- a/packages/cli/lib/projects.js
+++ b/packages/cli/lib/projects.js
@@ -149,14 +149,14 @@ const createProjectConfig = async (projectPath, projectName) => {
 const validateProjectConfig = (projectConfig, projectDir) => {
   if (!projectConfig) {
     logger.error(
-      `Project config not found. Try running 'hs project init' first.`
+      `Project config not found. Try running 'hs project create' first.`
     );
     process.exit(1);
   }
 
   if (!projectConfig.name || !projectConfig.srcDir) {
     logger.error(
-      'Project config is missing required fields. Try running `hs project init`.'
+      'Project config is missing required fields. Try running `hs project create`.'
     );
     process.exit(1);
   }


### PR DESCRIPTION
## Description and Context
~- When a project already exists (in cwd or nested), provides better error message with a path to the project root~
- Allows you to run `project upload` and `project deploy` from anywhere inside of a project
- Removes some references to `hs project init`

## Screenshots
<!-- Provide images of the before and after functionality -->
- `init` > `create`
![image](https://user-images.githubusercontent.com/9009552/139142228-e4db7878-ebe7-496e-92a9-634b201f7b07.png)



## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
