### PR TITLE
Prompt user if project directory contains files

### DIFF
--- a/packages/cli/lib/projects.js
+++ b/packages/cli/lib/projects.js
@@ -87,6 +87,23 @@ const createProjectConfig = async (projectPath, projectName) => {
       )})`
     );
   } else {
+    if (fs.readdirSync(projectPath).length > 0) {
+      const { shouldCreateProject } = await prompt([
+        {
+          name: 'shouldCreateProject',
+          message: `(${chalk.bold(
+            projectPath
+          )}) is not empty. Would you like to create a project anyway?`,
+          type: 'confirm',
+        },
+      ]);
+
+      if (!shouldCreateProject) {
+        logger.debug('Exiting without creating a project');
+        process.exit(1);
+      }
+    }
+
     logger.log(
       `Creating project in ${projectPath ? projectPath : 'the current folder'}`
     );

--- a/packages/cli/lib/projects.js
+++ b/packages/cli/lib/projects.js
@@ -11,6 +11,7 @@ const {
   createProject: createProjectTemplate,
 } = require('@hubspot/cli-lib/projects');
 const { getHubSpotWebsiteOrigin } = require('@hubspot/cli-lib/lib/urls');
+const { shouldIgnoreFile } = require('@hubspot/cli-lib/ignoreRules');
 
 const {
   ENVIRONMENTS,
@@ -87,7 +88,11 @@ const createProjectConfig = async (projectPath, projectName) => {
       )})`
     );
   } else {
-    if (fs.readdirSync(projectPath).length > 0) {
+    const dirContents = fs
+      .readdirSync(projectPath)
+      .filter(file => !shouldIgnoreFile(file));
+
+    if (dirContents.length > 0) {
       const { shouldCreateProject } = await prompt([
         {
           name: 'shouldCreateProject',


### PR DESCRIPTION
## Description and Context
There's an open question creating a new project should always create a folder locally. In the mean time, this adds a check to see if the project directory contains any files and if it does, prompts the user to see if they'd like to proceed.

## Screenshots
<!-- Provide images of the before and after functionality -->
![image](https://user-images.githubusercontent.com/9009552/139276131-06f62c98-71ff-4a8f-b663-595a417a9c4a.png)


## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
