### PR TITLE
Fix bug where CLI appears to hang when build fails

### DIFF
--- a/packages/cli/lib/projects.js
+++ b/packages/cli/lib/projects.js
@@ -254,12 +254,11 @@ const makeGetTaskStatus = taskType => {
 
   return async (accountId, taskName, taskId, buildId) => {
     const isTaskComplete = task => {
-      const isStatusComplete =
-        task.status === statusText.STATES.SUCCESS ||
-        task.status === statusText.STATES.FAILURE;
-      return task.isAutoDeployEnabled
-        ? isStatusComplete && task.deployStatusTaskLocator
-        : isStatusComplete;
+      if (task.status === statusText.STATES.FAILURE) {
+        return true;
+      } else if (task.status === statusText.STATES.SUCCESS) {
+        return task.isAutoDeployEnabled ? !!task.deployStatusTaskLocator : true;
+      }
     };
 
     const spinnies = new Spinnies({


### PR DESCRIPTION
## Description and Context
Currently when polling for project status, when a build fails the CLI continues to look for a `deployId`, which results in the CLI appearing to hang.

This updates the check to skip the check for deploy Id on `FAILURE`
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->

## Screenshots
<!-- Provide images of the before and after functionality -->

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
