### PR TITLE
Fix bug while tailing logs for new function

### DIFF
--- a/packages/cli/commands/logs.js
+++ b/packages/cli/commands/logs.js
@@ -63,7 +63,7 @@ const endpointLog = async (accountId, options) => {
       getFunctionLogs(accountId, functionPath, { after });
     const fetchLatest = () => {
       try {
-        getLatestFunctionLog(accountId, functionPath);
+        return getLatestFunctionLog(accountId, functionPath);
       } catch (e) {
         handleLogsError(e, accountId, functionPath);
       }

--- a/packages/cli/lib/serverlessLogs.js
+++ b/packages/cli/lib/serverlessLogs.js
@@ -33,7 +33,7 @@ const tailLogs = async ({
 
   try {
     const latestLog = await fetchLatest();
-    initialAfter = base64EncodeString(latestLog.id);
+    initialAfter = latestLog && base64EncodeString(latestLog.id);
   } catch (e) {
     // A 404 means no latest log exists(never executed)
     if (e.statusCode !== 404) {


### PR DESCRIPTION
## Description and Context
An unexpected API error is displayed if you run `hs logs <route> --followw` on a function that has no log data / previous executions

<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->

## Screenshots
<!-- Provide images of the before and after functionality -->

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
