### PR TITLE
Add util for getting account description

### DIFF
--- a/packages/cli-lib/lib/config.js
+++ b/packages/cli-lib/lib/config.js
@@ -415,16 +415,6 @@ const getAccountConfig = accountId =>
     account => account.portalId === accountId
   );
 
-/**
- * Obtains formatted account description from config
- */
-const getAccountDescription = accountId => {
-  const account = getAccountConfig(accountId);
-  return account.name
-    ? `${account.name} (${account.portalId})`
-    : account.portalId;
-};
-
 /*
  * Returns a portalId from the config if it exists, else returns null
  */
@@ -816,7 +806,6 @@ module.exports = {
   findConfig,
   loadConfigFromEnvironment,
   getAccountConfig,
-  getAccountDescription,
   getAccountId,
   updateAccountConfig,
   updateDefaultAccount,

--- a/packages/cli-lib/lib/config.js
+++ b/packages/cli-lib/lib/config.js
@@ -415,6 +415,16 @@ const getAccountConfig = accountId =>
     account => account.portalId === accountId
   );
 
+/**
+ * Obtains formatted account description from config
+ */
+const getAccountDescription = accountId => {
+  const account = getAccountConfig(accountId);
+  return account.name
+    ? `${account.name} (${account.portalId})`
+    : account.portalId;
+};
+
 /*
  * Returns a portalId from the config if it exists, else returns null
  */
@@ -806,6 +816,7 @@ module.exports = {
   findConfig,
   loadConfigFromEnvironment,
   getAccountConfig,
+  getAccountDescription,
   getAccountId,
   updateAccountConfig,
   updateDefaultAccount,

--- a/packages/cli/commands/project/listBuilds.js
+++ b/packages/cli/commands/project/listBuilds.js
@@ -29,7 +29,7 @@ const {
 } = require('@hubspot/cli-lib/lib/table');
 const { getCwd } = require('@hubspot/cli-lib/path');
 const { validateAccount } = require('../../lib/validation');
-const { link } = require('../../lib/links');
+const { link } = require('../../lib/ui');
 const {
   getProjectConfig,
   getProjectDetailUrl,

--- a/packages/cli/commands/project/upload.js
+++ b/packages/cli/commands/project/upload.js
@@ -23,7 +23,7 @@ const {
   logApiErrorInstance,
   ApiErrorContext,
 } = require('@hubspot/cli-lib/errorHandlers');
-const { getAccountDescription } = require('@hubspot/cli-lib/lib/config');
+const { getAccountDescription } = require('../../lib/ui');
 const { logger } = require('@hubspot/cli-lib/logger');
 const { uploadProject } = require('@hubspot/cli-lib/api/dfs');
 const { shouldIgnoreFile } = require('@hubspot/cli-lib/ignoreRules');

--- a/packages/cli/commands/project/upload.js
+++ b/packages/cli/commands/project/upload.js
@@ -13,6 +13,7 @@ const {
 } = require('../../lib/commonOpts');
 const { trackCommandUsage } = require('../../lib/usageTracking');
 const { logDebugInfo } = require('../../lib/debugInfo');
+
 const {
   loadConfig,
   validateConfig,
@@ -22,6 +23,7 @@ const {
   logApiErrorInstance,
   ApiErrorContext,
 } = require('@hubspot/cli-lib/errorHandlers');
+const { getAccountDescription } = require('@hubspot/cli-lib/lib/config');
 const { logger } = require('@hubspot/cli-lib/logger');
 const { uploadProject } = require('@hubspot/cli-lib/api/dfs');
 const { shouldIgnoreFile } = require('@hubspot/cli-lib/ignoreRules');
@@ -55,9 +57,9 @@ const uploadProjectFiles = async (accountId, projectName, filePath) => {
   });
 
   spinnies.add('upload', {
-    text: `Uploading ${chalk.bold(projectName)} project files to ${chalk.bold(
-      accountId
-    )}`,
+    text: `Uploading ${chalk.bold(
+      projectName
+    )} project files to ${getAccountDescription(accountId)}`,
   });
 
   let buildId;
@@ -68,9 +70,9 @@ const uploadProjectFiles = async (accountId, projectName, filePath) => {
     buildId = upload.buildId;
 
     spinnies.succeed('upload', {
-      text: `Uploaded ${chalk.bold(projectName)} project files to ${chalk.bold(
-        accountId
-      )}`,
+      text: `Uploaded ${chalk.bold(
+        projectName
+      )} project files to ${getAccountDescription(accountId)}`,
     });
 
     logger.debug(
@@ -80,7 +82,7 @@ const uploadProjectFiles = async (accountId, projectName, filePath) => {
     spinnies.fail('upload', {
       text: `Failed to upload ${chalk.bold(
         projectName
-      )} project files to ${chalk.bold(accountId)}`,
+      )} project files to ${getAccountDescription(accountId)}`,
     });
 
     logApiErrorInstance(
@@ -162,7 +164,7 @@ exports.handler = async options => {
       logger.log(
         `Build #${buildId} succeeded. ${chalk.bold(
           'Automatically deploying'
-        )} to ${accountId}`
+        )} to ${getAccountDescription(accountId)}`
       );
       const { status } = await pollDeployStatus(
         accountId,

--- a/packages/cli/lib/links.js
+++ b/packages/cli/lib/links.js
@@ -1,4 +1,3 @@
-const supportsHyperlinks = require('supports-hyperlinks');
 const { getEnv } = require('@hubspot/cli-lib/lib/config');
 const { ENVIRONMENTS } = require('@hubspot/cli-lib/lib/constants');
 const { getHubSpotWebsiteOrigin } = require('@hubspot/cli-lib/lib/urls');
@@ -121,18 +120,9 @@ const openLink = (accountId, shortcut) => {
   logger.success(`We opened ${match.url} in your browser`);
 };
 
-const link = (linkText, url, options = {}) => {
-  if (supportsHyperlinks.stdout) {
-    return ['\u001B]8;;', url, '\u0007', linkText, '\u001B]8;;\u0007'].join('');
-  } else {
-    return options.fallback ? `${linkText}: ${url}` : linkText;
-  }
-};
-
 module.exports = {
   getSiteLinks,
   getSiteLinksAsArray,
   logSiteLinks,
   openLink,
-  link,
 };

--- a/packages/cli/lib/projects.js
+++ b/packages/cli/lib/projects.js
@@ -6,15 +6,11 @@ const findup = require('findup-sync');
 const { prompt } = require('inquirer');
 const Spinnies = require('spinnies');
 const { logger } = require('@hubspot/cli-lib/logger');
-const {
-  getEnv,
-  getAccountDescription,
-} = require('@hubspot/cli-lib/lib/config');
+const { getEnv } = require('@hubspot/cli-lib/lib/config');
 const {
   createProject: createProjectTemplate,
 } = require('@hubspot/cli-lib/projects');
 const { getHubSpotWebsiteOrigin } = require('@hubspot/cli-lib/lib/urls');
-
 const {
   ENVIRONMENTS,
   POLLING_DELAY,
@@ -33,6 +29,7 @@ const {
   ApiErrorContext,
 } = require('@hubspot/cli-lib/errorHandlers');
 const { getCwd } = require('@hubspot/cli-lib/path');
+const { getAccountDescription } = require('../lib/ui');
 
 const PROJECT_STRINGS = {
   BUILD: {

--- a/packages/cli/lib/projects.js
+++ b/packages/cli/lib/projects.js
@@ -6,7 +6,10 @@ const findup = require('findup-sync');
 const { prompt } = require('inquirer');
 const Spinnies = require('spinnies');
 const { logger } = require('@hubspot/cli-lib/logger');
-const { getEnv } = require('@hubspot/cli-lib/lib/config');
+const {
+  getEnv,
+  getAccountDescription,
+} = require('@hubspot/cli-lib/lib/config');
 const {
   createProject: createProjectTemplate,
 } = require('@hubspot/cli-lib/projects');
@@ -176,7 +179,9 @@ const ensureProjectExists = async (accountId, projectName, forceCreate) => {
         const promptResult = await prompt([
           {
             name: 'shouldCreateProject',
-            message: `The project ${projectName} does not exist in ${accountId}. Would you like to create it?`,
+            message: `The project ${projectName} does not exist in ${getAccountDescription(
+              accountId
+            )}. Would you like to create it?`,
             type: 'confirm',
           },
         ]);

--- a/packages/cli/lib/ui.js
+++ b/packages/cli/lib/ui.js
@@ -1,3 +1,4 @@
+const chalk = require('chalk');
 const supportsHyperlinks = require('supports-hyperlinks');
 const { getAccountConfig } = require('@hubspot/cli-lib/lib/config');
 
@@ -25,9 +26,9 @@ const link = (linkText, url, options = {}) => {
  */
 const getAccountDescription = accountId => {
   const account = getAccountConfig(accountId);
-  return account.name
-    ? `${account.name} (${account.portalId})`
-    : account.portalId;
+  return chalk.bold(
+    account.name ? `${account.name} (${account.portalId})` : account.portalId
+  );
 };
 
 module.exports = {

--- a/packages/cli/lib/ui.js
+++ b/packages/cli/lib/ui.js
@@ -1,0 +1,36 @@
+const supportsHyperlinks = require('supports-hyperlinks');
+const { getAccountConfig } = require('@hubspot/cli-lib/lib/config');
+
+/**
+ * Returns a hyperlink or link and description
+ *
+ * @param {string} linkText
+ * @param {string} url
+ * @param {object} options
+ * @returns {string}
+ */
+const link = (linkText, url, options = {}) => {
+  if (supportsHyperlinks.stdout) {
+    return ['\u001B]8;;', url, '\u0007', linkText, '\u001B]8;;\u0007'].join('');
+  } else {
+    return options.fallback ? `${linkText}: ${url}` : linkText;
+  }
+};
+
+/**
+ * Returns formatted account name and ID
+ *
+ * @param {number} accountId
+ * @returns {string}
+ */
+const getAccountDescription = accountId => {
+  const account = getAccountConfig(accountId);
+  return account.name
+    ? `${account.name} (${account.portalId})`
+    : account.portalId;
+};
+
+module.exports = {
+  link,
+  getAccountDescription,
+};


### PR DESCRIPTION
## Description and Context
An alternative to #575. This PR achieves the same goal of displaying `Account Name (Account ID)` but can be called anywhere that `accountId` is known and eliminates the need to pass around the `accountDescription` variable

This also introduces `cli/lib/ui` for CLI UI related utils
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->

## Screenshots
<!-- Provide images of the before and after functionality -->

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
