### PR TITLE
Encode theme folder when generating theme preview link

### DIFF
--- a/packages/cli-lib/lib/files.js
+++ b/packages/cli-lib/lib/files.js
@@ -25,7 +25,9 @@ const getThemePreviewUrl = (filePath, accountId) => {
     getEnv() === 'qa' ? ENVIRONMENTS.QA : ENVIRONMENTS.PROD
   );
 
-  return `${baseUrl}/theme-previewer/${accountId}/edit/${themeName}`;
+  return `${baseUrl}/theme-previewer/${accountId}/edit/${encodeURIComponent(
+    themeName
+  )}`;
 };
 
 module.exports = { getThemeJSONPath, getThemeNameFromPath, getThemePreviewUrl };


### PR DESCRIPTION
## Description and Context
Fixes #596 

Encodes the theme folder when generating a link to the theme previewer.


<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->

## Screenshots
![image](https://user-images.githubusercontent.com/9009552/141827774-8d981dcf-7cb0-4427-9401-d0af9484023e.png)

<!-- Provide images of the before and after functionality -->

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->
When testing this, I did find a flaw in the way this link is generated. If the theme is uploaded to a different folder, the preview link will not be accurate. For example

`hs upload "cool theme" theme2000` would yield a link to `/theme-previewer/1234567/edit/cool%20theme` when it should point to  `/theme-previewer/1234567/edit/theme2000`

Filed in https://github.com/HubSpot/hubspot-cli/issues/600

## Who to Notify
<!-- /cc those you wish to know about the PR -->
