### PR TITLE
Fix issue where `--use-env` does not work with `hs fetch`

### DIFF
--- a/packages/cli/commands/fetch.js
+++ b/packages/cli/commands/fetch.js
@@ -31,7 +31,7 @@ exports.handler = async options => {
   setLogLevel(options);
   logDebugInfo(options);
 
-  loadConfig(configPath);
+  loadConfig(configPath, options);
   checkAndWarnGitInclusion();
 
   if (


### PR DESCRIPTION
## Description and Context
`hs fetch` was not aware of the value of `--use-env`, so it always defaulted to trying to load a config from the filesystem

fixes #598 

<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->

## Screenshots
<!-- Provide images of the before and after functionality -->

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
