### PR TITLE
Make sure polling errors are always exposed

### DIFF
--- a/packages/cli/commands/project/deploy.js
+++ b/packages/cli/commands/project/deploy.js
@@ -77,38 +77,12 @@ exports.handler = async options => {
       return;
     }
 
-    const { status, subdeployStatuses } = await pollDeployStatus(
+    await pollDeployStatus(
       accountId,
       projectConfig.name,
       deployResp.id,
       deployedBuildId
     );
-
-    if (status === 'FAILURE') {
-      const failedSubdeploys = subdeployStatuses.filter(
-        subdeploy => subdeploy.status === 'FAILURE'
-      );
-
-      logger.log('-'.repeat(50));
-      logger.log(
-        `Deploy for build #${buildId} failed because there was a problem\ndeploying ${
-          failedSubdeploys.length === 1
-            ? failedSubdeploys[0].buildName
-            : failedSubdeploys.length + ' components'
-        }\n`
-      );
-      logger.log('See below for a summary of errors.');
-      logger.log('-'.repeat(50));
-
-      failedSubdeploys.forEach(subbuild => {
-        logger.log(
-          `\n--- ${subbuild.buildName} failed to deploy with the following error ---`
-        );
-        logger.error(subbuild.errorMessage);
-      });
-
-      exitCode = 1;
-    }
   } catch (e) {
     if (e.statusCode === 400) {
       logger.error(e.error.message);

--- a/packages/cli/commands/project/deploy.js
+++ b/packages/cli/commands/project/deploy.js
@@ -35,15 +35,18 @@ exports.handler = async options => {
 
   logger.debug(`Deploying project at path: ${projectPath}`);
 
+  let exitCode = 0;
+
   const getBuildId = async () => {
     const { latestBuild } = await fetchProject(accountId, projectConfig.name);
     if (latestBuild && latestBuild.buildId) {
       return latestBuild.buildId;
     }
     logger.error('No latest build ID was found.');
+    exitCode = 1;
     return;
   };
-  let exitCode = 0;
+
   try {
     const deployedBuildId = buildId || (await getBuildId());
 

--- a/packages/cli/commands/project/deploy.js
+++ b/packages/cli/commands/project/deploy.js
@@ -74,6 +74,7 @@ exports.handler = async options => {
 
     if (deployResp.error) {
       logger.error(`Deploy error: ${deployResp.error.message}`);
+      exitCode = 1;
       return;
     }
 

--- a/packages/cli/commands/project/deploy.js
+++ b/packages/cli/commands/project/deploy.js
@@ -62,7 +62,7 @@ exports.handler = async options => {
     logger.error('No latest build ID was found.');
     return;
   };
-
+  let exitCode = 0;
   try {
     const deployedBuildId = buildId || (await getBuildId());
 
@@ -77,19 +77,47 @@ exports.handler = async options => {
       return;
     }
 
-    await pollDeployStatus(
+    const { status, subdeployStatuses } = await pollDeployStatus(
       accountId,
       projectConfig.name,
       deployResp.id,
       deployedBuildId
     );
+
+    if (status === 'FAILURE') {
+      const failedSubdeploys = subdeployStatuses.filter(
+        subdeploy => subdeploy.status === 'FAILURE'
+      );
+
+      logger.log('-'.repeat(50));
+      logger.log(
+        `Deploy for build #${buildId} failed because there was a problem\ndeploying ${
+          failedSubdeploys.length === 1
+            ? failedSubdeploys[0].buildName
+            : failedSubdeploys.length + ' components'
+        }\n`
+      );
+      logger.log('See below for a summary of errors.');
+      logger.log('-'.repeat(50));
+
+      failedSubdeploys.forEach(subbuild => {
+        logger.log(
+          `\n--- ${subbuild.buildName} failed to deploy with the following error ---`
+        );
+        logger.error(subbuild.errorMessage);
+      });
+
+      exitCode = 1;
+    }
   } catch (e) {
     if (e.statusCode === 400) {
       logger.error(e.error.message);
     } else {
       logApiErrorInstance(e, new ApiErrorContext({ accountId, projectPath }));
     }
+    exitCode = 1;
   }
+  process.exit(exitCode);
 };
 
 exports.builder = yargs => {

--- a/packages/cli/commands/project/upload.js
+++ b/packages/cli/commands/project/upload.js
@@ -130,35 +130,9 @@ exports.handler = async options => {
     const {
       isAutoDeployEnabled,
       deployStatusTaskLocator,
-      status,
-      subbuildStatuses,
     } = await pollBuildStatus(accountId, projectConfig.name, buildId);
 
-    if (status === 'FAILURE') {
-      const failedSubbuilds = subbuildStatuses.filter(
-        subbuild => subbuild.status === 'FAILURE'
-      );
-
-      logger.log('-'.repeat(50));
-      logger.log(
-        `Build #${buildId} failed because there was a problem\nbuilding ${
-          failedSubbuilds.length === 1
-            ? failedSubbuilds[0].buildName
-            : failedSubbuilds.length + ' components'
-        }\n`
-      );
-      logger.log('See below for a summary of errors.');
-      logger.log('-'.repeat(50));
-
-      failedSubbuilds.forEach(subbuild => {
-        logger.log(
-          `\n--- ${subbuild.buildName} failed to build with the following error ---`
-        );
-        logger.error(subbuild.errorMessage);
-      });
-
-      exitCode = 1;
-    } else if (isAutoDeployEnabled && deployStatusTaskLocator) {
+    if (isAutoDeployEnabled && deployStatusTaskLocator) {
       logger.log(
         `Build #${buildId} succeeded. ${chalk.bold(
           'Automatically deploying'

--- a/packages/cli/commands/project/upload.js
+++ b/packages/cli/commands/project/upload.js
@@ -130,9 +130,13 @@ exports.handler = async options => {
     const {
       isAutoDeployEnabled,
       deployStatusTaskLocator,
+      status,
     } = await pollBuildStatus(accountId, projectConfig.name, buildId);
 
-    if (isAutoDeployEnabled && deployStatusTaskLocator) {
+    if (status === 'FAILURE') {
+      exitCode = 1;
+      return;
+    } else if (isAutoDeployEnabled && deployStatusTaskLocator) {
       logger.log(
         `Build #${buildId} succeeded. ${chalk.bold(
           'Automatically deploying'

--- a/packages/cli/lib/projects.js
+++ b/packages/cli/lib/projects.js
@@ -39,6 +39,10 @@ const PROJECT_STRINGS = {
       } in this project ...\n`,
     SUCCESS: name => `Built ${chalk.bold(name)}`,
     FAIL: name => `Failed to build ${chalk.bold(name)}`,
+    SUBTASK_FAIL: (taskId, name) =>
+      `Build #${taskId} failed because there was a problem\nbuilding ${chalk.bold(
+        name
+      )}`,
   },
   DEPLOY: {
     INITIALIZE: (name, numOfComponents) =>
@@ -47,6 +51,10 @@ const PROJECT_STRINGS = {
       } in this project ...\n`,
     SUCCESS: name => `Deployed ${chalk.bold(name)}`,
     FAIL: name => `Failed to deploy ${chalk.bold(name)}`,
+    SUBTASK_FAIL: (taskId, name) =>
+      `Deploy for build #${taskId} failed because there was a\nproblem deploying ${chalk.bold(
+        name
+      )}`,
   },
 };
 
@@ -337,22 +345,23 @@ const makeGetTaskStatus = taskType => {
 
               logger.log('-'.repeat(50));
               logger.log(
-                `Task for build #${buildId} failed because there was a problem\ndeploying ${
+                `${statusStrings.SUBTASK_FAIL(
+                  buildId || taskId,
                   failedSubtask.length === 1
                     ? failedSubtask[0][statusText.SUBTASK_NAME_KEY]
                     : failedSubtask.length + ' components'
-                }\n`
+                )}\n`
               );
               logger.log('See below for a summary of errors.');
               logger.log('-'.repeat(50));
 
-              failedSubtask.forEach(subtask => {
+              failedSubtask.forEach(subTask => {
                 logger.log(
-                  `\n--- ${
-                    subtask[statusText.SUBTASK_NAME_KEY]
-                  } failed to deploy with the following error ---`
+                  `\n--- ${chalk.bold(subTask[statusText.SUBTASK_NAME_KEY])} ${
+                    statusText.STATUS_TEXT[subTask.status]
+                  } with the following error ---`
                 );
-                logger.error(subtask.errorMessage);
+                logger.error(subTask.errorMessage);
               });
             }
 

--- a/packages/cli/lib/projects.js
+++ b/packages/cli/lib/projects.js
@@ -330,6 +330,30 @@ const makeGetTaskStatus = taskType => {
               spinnies.fail('overallTaskStatus', {
                 text: statusStrings.FAIL(taskName),
               });
+
+              const failedSubtask = subTaskStatus.filter(
+                subtask => subtask.status === 'FAILURE'
+              );
+
+              logger.log('-'.repeat(50));
+              logger.log(
+                `Task for build #${buildId} failed because there was a problem\ndeploying ${
+                  failedSubtask.length === 1
+                    ? failedSubtask[0][statusText.SUBTASK_NAME_KEY]
+                    : failedSubtask.length + ' components'
+                }\n`
+              );
+              logger.log('See below for a summary of errors.');
+              logger.log('-'.repeat(50));
+
+              failedSubtask.forEach(subtask => {
+                logger.log(
+                  `\n--- ${
+                    subtask[statusText.SUBTASK_NAME_KEY]
+                  } failed to deploy with the following error ---`
+                );
+                logger.error(subtask.errorMessage);
+              });
             }
 
             clearInterval(pollInterval);


### PR DESCRIPTION
## Description and Context
Previously polling errors were only shown when a build failed and not when an auto or manual deploy had failed. This moved the error handling logic closes to the abstract poll-er so that it always shows up.

<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->

## Screenshots
<!-- Provide images of the before and after functionality -->
**Failed build:** 
![image](https://user-images.githubusercontent.com/9009552/142662710-0e11a3f4-94a6-48cb-90a1-9a6d2cf37947.png)

**build succeeds, failed auto deploy:** 
![image](https://user-images.githubusercontent.com/9009552/142663216-e98f4be3-3434-40ab-8161-2d80cb1895a6.png)

**Failed manual deploy:** 
![image](https://user-images.githubusercontent.com/9009552/142662845-e3328cfa-3369-40ea-9b9e-f1bfa32fa28d.png)


##To test:
-To test a failed build you can upload a malformed `theme.json` file
-To test a failed deploy you can upload a malformed scheme json file
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
