### PR TITLE
Change failed status icon to exclamation mark

### DIFF
--- a/packages/cli/lib/projects.js
+++ b/packages/cli/lib/projects.js
@@ -271,6 +271,7 @@ const makeGetTaskStatus = taskType => {
     const spinnies = new Spinnies({
       succeedColor: 'white',
       failColor: 'white',
+      failPrefix: '\033[1m!\033[0m',
     });
 
     spinnies.add('overallTaskStatus', { text: 'Beginning' });

--- a/packages/cli/lib/projects.js
+++ b/packages/cli/lib/projects.js
@@ -271,7 +271,7 @@ const makeGetTaskStatus = taskType => {
     const spinnies = new Spinnies({
       succeedColor: 'white',
       failColor: 'white',
-      failPrefix: '\033[1m!\033[0m',
+      failPrefix: chalk.bold('!'),
     });
 
     spinnies.add('overallTaskStatus', { text: 'Beginning' });


### PR DESCRIPTION
## Description and Context
As @anthmatic noted, in the original plans for a failed project build or deploy, we wanted to use :exclamation: as a status icon instead of a red :x:. 

However, when we attempted to add ❗ as the status icon, the character spacing was off. I've done some research on resizing Unicode characters in a CLI environment, and I don't believe there's any easy way to adjust it. 

As a solution, I've added a bold **!** as a failed status icon for a similar effect. If we would rather go with the Unicode character, however, I'm all ears for alternate approaches :) 

## Screenshots
<!-- Provide images of the before and after functionality -->

With changes:

<img width="894" alt="Screen Shot 2021-11-23 at 2 04 09 PM" src="https://user-images.githubusercontent.com/25392256/143087850-7df82b65-c266-4ae5-866a-46f286c22768.png">

## Who to Notify
<!-- /cc those you wish to know about the PR --> @brodgers @anthmatic 
