### PR TITLE
Replace deprecated request library

### DIFF
--- a/acceptance-tests/tests/init-oauth2.spec.js
+++ b/acceptance-tests/tests/init-oauth2.spec.js
@@ -31,7 +31,7 @@ describe('hs init using oauth2', () => {
         cmd.ENTER,
         cmd.ENTER,
         () => {
-          const req = http.request({
+          const req = http.get({
             hostname: 'localhost',
             port: 3000,
             path: `/oauth-callback?code=${config.refreshToken}`,

--- a/packages/cli-lib/__tests__/errorHandlers.js
+++ b/packages/cli-lib/__tests__/errorHandlers.js
@@ -1,3 +1,4 @@
+// TODO - Replace This with logic for axios
 const { StatusCodeError } = require('request-promise-native/errors');
 const { getAccountConfig } = require('../lib/config');
 const { fetchScopeData } = require('../api/localDevAuth/authenticated');

--- a/packages/cli-lib/__tests__/http.js
+++ b/packages/cli-lib/__tests__/http.js
@@ -1,5 +1,4 @@
-const requestPN = require('request-promise-native');
-const request = require('request');
+const axios = require('axios');
 const fs = require('fs-extra');
 const moment = require('moment');
 const { getAndLoadConfigIfNeeded, getAccountConfig } = require('../lib/config');
@@ -7,12 +6,7 @@ const { ENVIRONMENTS } = require('../lib/constants');
 const http = require('../http');
 const { version } = require('../package.json');
 
-jest.mock('request-promise-native', () => ({
-  get: jest.fn().mockReturnValue(Promise.resolve()),
-  post: jest.fn().mockReturnValue(Promise.resolve()),
-}));
-
-jest.mock('request');
+jest.mock('axios');
 jest.mock('../lib/config');
 jest.mock('../logger');
 
@@ -39,7 +33,7 @@ describe('http', () => {
       });
     });
     it('makes a get request', async () => {
-      request.get.mockReturnValue({
+      axios.get.mockReturnValue({
         on: jest.fn((event, callback) => {
           if (event === 'response') {
             callback({ statusCode: 200 });
@@ -55,12 +49,12 @@ describe('http', () => {
         'path/to/local/file'
       );
 
-      expect(request.get).toHaveBeenCalledWith(
+      expect(axios.get).toHaveBeenCalledWith(
         expect.objectContaining({ uri: 'some/endpoint/path' })
       );
     });
     it('fetches a file and attempts to write it', async () => {
-      request.get.mockReturnValue({
+      axios.get.mockReturnValue({
         on: jest.fn((event, callback) => {
           if (event === 'response') {
             callback({ statusCode: 200 });
@@ -81,7 +75,7 @@ describe('http', () => {
       });
     });
     it('fails to fetch a file and does not attempt to write to disk', async () => {
-      request.get.mockReturnValue({
+      axios.get.mockReturnValue({
         on: jest.fn((event, callback) => {
           if (event === 'response') {
             callback({ statusCode: 404 });
@@ -155,7 +149,7 @@ describe('http', () => {
         uri: 'some/endpoint/path',
       });
 
-      expect(requestPN.get).toBeCalledWith({
+      expect(axios.get).toBeCalledWith({
         baseUrl: `https://api.hubapi.com`,
         uri: 'some/endpoint/path',
         headers: {
@@ -193,7 +187,7 @@ describe('http', () => {
         uri: 'some/endpoint/path',
       });
 
-      expect(requestPN.get).toBeCalledWith({
+      expect(axios.get).toBeCalledWith({
         baseUrl: `https://api.hubapi.com`,
         uri: 'some/endpoint/path',
         headers: {
@@ -228,7 +222,7 @@ describe('http', () => {
         uri: 'some/endpoint/path',
       });
 
-      expect(requestPN.get).toBeCalledWith({
+      expect(axios.get).toBeCalledWith({
         baseUrl: `https://api.hubapi.com`,
         uri: 'some/endpoint/path',
         headers: {

--- a/packages/cli-lib/api/appPipeline.js
+++ b/packages/cli-lib/api/appPipeline.js
@@ -3,8 +3,8 @@ const APP_PIPELINE_API_PATH = '/app-pipeline/v1';
 
 async function deployApp(accountId, appFolderPath) {
   return http.post(accountId, {
-    uri: `${APP_PIPELINE_API_PATH}/deploy/async`,
-    body: {
+    url: `${APP_PIPELINE_API_PATH}/deploy/async`,
+    data: {
       appPath: appFolderPath,
     },
   });
@@ -12,9 +12,9 @@ async function deployApp(accountId, appFolderPath) {
 
 async function deployAppSync(accountId, appFolderPath) {
   return http.post(accountId, {
-    uri: `${APP_PIPELINE_API_PATH}/deploy/sync`,
+    url: `${APP_PIPELINE_API_PATH}/deploy/sync`,
     timeout: 60000,
-    body: {
+    data: {
       appPath: appFolderPath,
     },
   });

--- a/packages/cli-lib/api/blogs.js
+++ b/packages/cli-lib/api/blogs.js
@@ -3,7 +3,7 @@ const BLOGS_API_PATH = 'blogs/v3';
 
 async function fetchBlogs(accountId, query = {}) {
   return http.get(accountId, {
-    uri: `${BLOGS_API_PATH}/blogs`,
+    url: `${BLOGS_API_PATH}/blogs`,
     query,
   });
 }

--- a/packages/cli-lib/api/content.js
+++ b/packages/cli-lib/api/content.js
@@ -3,7 +3,7 @@ const CONTENT_API_PATH = 'content/api/v4';
 
 async function fetchContent(accountId, query = {}) {
   return http.get(accountId, {
-    uri: `${CONTENT_API_PATH}/contents`,
+    url: `${CONTENT_API_PATH}/contents`,
     query,
   });
 }

--- a/packages/cli-lib/api/customObject.js
+++ b/packages/cli-lib/api/customObject.js
@@ -5,41 +5,41 @@ const CUSTOM_OBJECTS_API_PATH = 'crm/v3/objects';
 
 const createObject = (accountId, objectTypeId, filePath) =>
   http.post(accountId, {
-    uri: `${CUSTOM_OBJECTS_API_PATH}/${objectTypeId}`,
-    body: JSON.parse(fs.readFileSync(filePath, 'utf-8')),
+    url: `${CUSTOM_OBJECTS_API_PATH}/${objectTypeId}`,
+    data: JSON.parse(fs.readFileSync(filePath, 'utf-8')),
   });
 
 const updateObject = async (accountId, objectTypeId, filePath) =>
   http.post(accountId, {
-    uri: `${CUSTOM_OBJECTS_API_PATH}/${objectTypeId}`,
-    body: JSON.parse(fs.readFileSync(filePath, 'utf-8')),
+    url: `${CUSTOM_OBJECTS_API_PATH}/${objectTypeId}`,
+    data: JSON.parse(fs.readFileSync(filePath, 'utf-8')),
   });
 
 const fetchObject = async (accountId, objectTypeId, instanceId) =>
   http.get(accountId, {
-    uri: `${CUSTOM_OBJECTS_API_PATH}/${objectTypeId}/${instanceId}`,
+    url: `${CUSTOM_OBJECTS_API_PATH}/${objectTypeId}/${instanceId}`,
   });
 
 const fetchObjects = async (accountId, objectTypeId) =>
   http.get(accountId, {
-    uri: `${CUSTOM_OBJECTS_API_PATH}/${objectTypeId}`,
+    url: `${CUSTOM_OBJECTS_API_PATH}/${objectTypeId}`,
   });
 
 const archiveObject = async (accountId, objectTypeId, instanceId) =>
   http.delete(accountId, {
-    uri: `${CUSTOM_OBJECTS_API_PATH}/${objectTypeId}/${instanceId}`,
+    url: `${CUSTOM_OBJECTS_API_PATH}/${objectTypeId}/${instanceId}`,
   });
 
 const searchObjects = async (accountId, objectTypeId, filePath) =>
   http.post(accountId, {
-    uri: `${CUSTOM_OBJECTS_API_PATH}/${objectTypeId}/search`,
-    body: JSON.parse(fs.readFileSync(filePath, 'utf-8')),
+    url: `${CUSTOM_OBJECTS_API_PATH}/${objectTypeId}/search`,
+    data: JSON.parse(fs.readFileSync(filePath, 'utf-8')),
   });
 
 const batchCreateObjects = (accountId, objectTypeId, filePath) =>
   http.post(accountId, {
-    uri: `${CUSTOM_OBJECTS_API_PATH}/${objectTypeId}/batch/create`,
-    body: JSON.parse(fs.readFileSync(filePath, 'utf-8')),
+    url: `${CUSTOM_OBJECTS_API_PATH}/${objectTypeId}/batch/create`,
+    data: JSON.parse(fs.readFileSync(filePath, 'utf-8')),
   });
 
 module.exports = {

--- a/packages/cli-lib/api/designManager.js
+++ b/packages/cli-lib/api/designManager.js
@@ -9,7 +9,7 @@ const DESIGN_MANAGER_API_PATH = 'designmanager/v1';
  */
 async function fetchMenus(accountId, query = {}) {
   return http.get(accountId, {
-    uri: `${DESIGN_MANAGER_API_PATH}/menus`,
+    url: `${DESIGN_MANAGER_API_PATH}/menus`,
     query,
   });
 }
@@ -21,13 +21,13 @@ async function fetchMenus(accountId, query = {}) {
  */
 async function fetchBuiltinMapping(accountId) {
   return http.get(accountId, {
-    uri: `${DESIGN_MANAGER_API_PATH}/widgets/builtin-mapping`,
+    url: `${DESIGN_MANAGER_API_PATH}/widgets/builtin-mapping`,
   });
 }
 
 async function fetchRawAssetByPath(accountId, path) {
   return http.get(accountId, {
-    uri: `${DESIGN_MANAGER_API_PATH}/raw-assets/by-path/${path}?portalId=${accountId}`,
+    url: `${DESIGN_MANAGER_API_PATH}/raw-assets/by-path/${path}?portalId=${accountId}`,
   });
 }
 

--- a/packages/cli-lib/api/dfs.js
+++ b/packages/cli-lib/api/dfs.js
@@ -12,7 +12,7 @@ const PROJECTS_DEPLOY_API_PATH = 'dfs/deploy/v1';
  */
 async function fetchProjects(portalId) {
   return http.get(portalId, {
-    uri: PROJECTS_API_PATH,
+    url: PROJECTS_API_PATH,
   });
 }
 
@@ -25,8 +25,8 @@ async function fetchProjects(portalId) {
  */
 async function createProject(portalId, name) {
   return http.post(portalId, {
-    uri: PROJECTS_API_PATH,
-    body: {
+    url: PROJECTS_API_PATH,
+    data: {
       name,
     },
   });
@@ -42,7 +42,7 @@ async function createProject(portalId, name) {
  */
 async function uploadProject(accountId, projectName, projectFile) {
   return http.post(accountId, {
-    uri: `${PROJECTS_API_PATH}/upload/${encodeURIComponent(projectName)}`,
+    url: `${PROJECTS_API_PATH}/upload/${encodeURIComponent(projectName)}`,
     timeout: 60000,
     formData: {
       file: fs.createReadStream(projectFile),
@@ -59,7 +59,7 @@ async function uploadProject(accountId, projectName, projectFile) {
  */
 async function fetchProject(portalId, projectName) {
   return http.get(portalId, {
-    uri: `${PROJECTS_API_PATH}/${encodeURIComponent(projectName)}`,
+    url: `${PROJECTS_API_PATH}/${encodeURIComponent(projectName)}`,
   });
 }
 
@@ -72,7 +72,7 @@ async function fetchProject(portalId, projectName) {
  */
 async function deleteProject(portalId, projectName) {
   return http.delete(portalId, {
-    uri: `${PROJECTS_API_PATH}/${encodeURIComponent(projectName)}`,
+    url: `${PROJECTS_API_PATH}/${encodeURIComponent(projectName)}`,
   });
 }
 
@@ -85,7 +85,7 @@ async function deleteProject(portalId, projectName) {
  */
 async function fetchProjectBuilds(portalId, projectName, query) {
   return http.get(portalId, {
-    uri: `${PROJECTS_API_PATH}/${encodeURIComponent(projectName)}/builds`,
+    url: `${PROJECTS_API_PATH}/${encodeURIComponent(projectName)}/builds`,
     query,
   });
 }
@@ -100,7 +100,7 @@ async function fetchProjectBuilds(portalId, projectName, query) {
  */
 async function getBuildStatus(portalId, projectName, buildId) {
   return http.get(portalId, {
-    uri: `${PROJECTS_API_PATH}/${encodeURIComponent(
+    url: `${PROJECTS_API_PATH}/${encodeURIComponent(
       projectName
     )}/builds/${buildId}/status`,
   });
@@ -116,8 +116,8 @@ async function getBuildStatus(portalId, projectName, buildId) {
  */
 async function deployProject(portalId, projectName, buildId) {
   return http.post(portalId, {
-    uri: `${PROJECTS_DEPLOY_API_PATH}/deploys/queue/async`,
-    body: {
+    url: `${PROJECTS_DEPLOY_API_PATH}/deploys/queue/async`,
+    data: {
       projectName,
       buildId,
     },
@@ -134,7 +134,7 @@ async function deployProject(portalId, projectName, buildId) {
  */
 async function getDeployStatus(portalId, projectName, deployId) {
   return http.get(portalId, {
-    uri: `${PROJECTS_DEPLOY_API_PATH}/deploy-status/projects/${encodeURIComponent(
+    url: `${PROJECTS_DEPLOY_API_PATH}/deploy-status/projects/${encodeURIComponent(
       projectName
     )}/deploys/${deployId}`,
   });
@@ -149,7 +149,7 @@ async function getDeployStatus(portalId, projectName, deployId) {
  */
 async function fetchProjectSettings(portalId, projectName) {
   return http.get(portalId, {
-    uri: `${PROJECTS_API_PATH}/${encodeURIComponent(projectName)}/settings`,
+    url: `${PROJECTS_API_PATH}/${encodeURIComponent(projectName)}/settings`,
   });
 }
 

--- a/packages/cli-lib/api/fileManager.js
+++ b/packages/cli-lib/api/fileManager.js
@@ -24,20 +24,20 @@ async function uploadFile(accountId, src, dest) {
   }
 
   return http.post(accountId, {
-    uri: `${FILE_MANAGER_V3_API_PATH}/files/upload`,
+    url: `${FILE_MANAGER_V3_API_PATH}/files/upload`,
     formData,
   });
 }
 
 async function fetchStat(accountId, src) {
   return http.get(accountId, {
-    uri: `${FILE_MANAGER_V2_API_PATH}/files/stat/${src}`,
+    url: `${FILE_MANAGER_V2_API_PATH}/files/stat/${src}`,
   });
 }
 
 async function fetchFiles(accountId, folderId, { offset, archived }) {
   return http.get(accountId, {
-    uri: `${FILE_MANAGER_V2_API_PATH}/files/`,
+    url: `${FILE_MANAGER_V2_API_PATH}/files/`,
     qs: {
       hidden: 0,
       offset: offset,
@@ -49,7 +49,7 @@ async function fetchFiles(accountId, folderId, { offset, archived }) {
 
 async function fetchFolders(accountId, folderId) {
   return http.get(accountId, {
-    uri: `${FILE_MANAGER_V2_API_PATH}/folders/`,
+    url: `${FILE_MANAGER_V2_API_PATH}/folders/`,
     qs: {
       hidden: 0,
       parent_folder_id: folderId,

--- a/packages/cli-lib/api/fileMapper.js
+++ b/packages/cli-lib/api/fileMapper.js
@@ -54,7 +54,7 @@ function createFileMapperNodeFromStreamResponse(filePath, response) {
  */
 async function upload(accountId, src, dest, options = {}) {
   return http.post(accountId, {
-    uri: `${FILE_MAPPER_API_PATH}/upload/${encodeURIComponent(dest)}`,
+    url: `${FILE_MAPPER_API_PATH}/upload/${encodeURIComponent(dest)}`,
     formData: {
       file: fs.createReadStream(path.resolve(getCwd(), src)),
     },
@@ -73,7 +73,7 @@ async function upload(accountId, src, dest, options = {}) {
  */
 async function fetchModule(accountId, moduleId, options = {}) {
   return http.get(accountId, {
-    uri: `${FILE_MAPPER_API_PATH}/modules/${moduleId}`,
+    url: `${FILE_MAPPER_API_PATH}/modules/${moduleId}`,
     ...options,
   });
 }
@@ -92,7 +92,7 @@ async function fetchFileStream(accountId, filePath, destination, options = {}) {
   const response = await http.getOctetStream(
     accountId,
     {
-      uri: `${FILE_MAPPER_API_PATH}/stream/${encodeURIComponent(filePath)}`,
+      url: `${FILE_MAPPER_API_PATH}/stream/${encodeURIComponent(filePath)}`,
       ...options,
     },
     destination
@@ -111,7 +111,7 @@ async function fetchFileStream(accountId, filePath, destination, options = {}) {
  */
 async function download(accountId, filepath, options = {}) {
   return http.get(accountId, {
-    uri: `${FILE_MAPPER_API_PATH}/download/${encodeURIComponent(filepath)}`,
+    url: `${FILE_MAPPER_API_PATH}/download/${encodeURIComponent(filepath)}`,
     ...options,
   });
 }
@@ -127,7 +127,7 @@ async function download(accountId, filepath, options = {}) {
  */
 async function downloadDefault(accountId, filepath, options = {}) {
   return http.get(accountId, {
-    uri: `${FILE_MAPPER_API_PATH}/download-default/${filepath}`,
+    url: `${FILE_MAPPER_API_PATH}/download-default/${filepath}`,
     ...options,
   });
 }
@@ -143,7 +143,7 @@ async function downloadDefault(accountId, filepath, options = {}) {
  */
 async function deleteFile(accountId, filePath, options = {}) {
   return http.delete(accountId, {
-    uri: `${FILE_MAPPER_API_PATH}/delete/${encodeURIComponent(filePath)}`,
+    url: `${FILE_MAPPER_API_PATH}/delete/${encodeURIComponent(filePath)}`,
     ...options,
   });
 }
@@ -163,7 +163,7 @@ async function deleteFolder(accountId, folderPath, options = {}) {
     '`cli-lib/api/fileMapper#deleteFolder()` is deprecated. Use `cli-lib/api/fileMapper#deleteFile()` instead.'
   );
   return http.delete(accountId, {
-    uri: `${FILE_MAPPER_API_PATH}/delete/folder/${folderPath}`,
+    url: `${FILE_MAPPER_API_PATH}/delete/folder/${folderPath}`,
     ...options,
   });
 }
@@ -208,8 +208,8 @@ async function trackUsage(eventName, eventClass, meta = {}, accountId) {
   if (accountConfig && accountConfig.authType === 'personalaccesskey') {
     logger.debug('Sending usage event to authenticated endpoint');
     return http.post(accountId, {
-      uri: `${path}/authenticated`,
-      body: usageEvent,
+      url: `${path}/authenticated`,
+      data: usageEvent,
       resolveWithFullResponse: true,
     });
   }
@@ -218,8 +218,8 @@ async function trackUsage(eventName, eventClass, meta = {}, accountId) {
   const requestOptions = http.getRequestOptions(
     { env },
     {
-      uri: path,
-      body: usageEvent,
+      url: path,
+      data: usageEvent,
       resolveWithFullResponse: true,
     }
   );
@@ -238,7 +238,7 @@ async function trackUsage(eventName, eventClass, meta = {}, accountId) {
  */
 async function moveFile(portalId, srcPath, destPath) {
   return http.put(portalId, {
-    uri: `${FILE_MAPPER_API_PATH}/rename/${srcPath}?path=${destPath}`,
+    url: `${FILE_MAPPER_API_PATH}/rename/${srcPath}?path=${destPath}`,
   });
 }
 
@@ -251,7 +251,7 @@ async function moveFile(portalId, srcPath, destPath) {
  */
 async function getDirectoryContentsByPath(portalId, path) {
   return http.get(portalId, {
-    uri: `${FILE_MAPPER_API_PATH}/meta/${path}`,
+    url: `${FILE_MAPPER_API_PATH}/meta/${path}`,
   });
 }
 

--- a/packages/cli-lib/api/fileMapper.js
+++ b/packages/cli-lib/api/fileMapper.js
@@ -224,7 +224,7 @@ async function trackUsage(eventName, eventClass, meta = {}, accountId) {
     }
   );
   logger.debug('Sending usage event to unauthenticated endpoint');
-  return http.request.post(requestOptions);
+  return http.post(requestOptions);
 }
 
 /**

--- a/packages/cli-lib/api/fileTransport.js
+++ b/packages/cli-lib/api/fileTransport.js
@@ -7,7 +7,7 @@ const HUBFILES_API_PATH = '/file-transport/v1/hubfiles';
 
 async function createSchema(accountId, filepath) {
   return http.post(accountId, {
-    uri: `${HUBFILES_API_PATH}/object-schemas`,
+    url: `${HUBFILES_API_PATH}/object-schemas`,
     formData: {
       file: fs.createReadStream(path.resolve(getCwd(), filepath)),
     },
@@ -16,7 +16,7 @@ async function createSchema(accountId, filepath) {
 
 async function updateSchema(accountId, filepath) {
   return http.put(accountId, {
-    uri: `${HUBFILES_API_PATH}/object-schemas`,
+    url: `${HUBFILES_API_PATH}/object-schemas`,
     formData: {
       file: fs.createReadStream(path.resolve(getCwd(), filepath)),
     },
@@ -27,7 +27,7 @@ async function fetchSchema(accountId, objectName, path) {
   return http.getOctetStream(
     accountId,
     {
-      uri: `${HUBFILES_API_PATH}/object-schemas/${objectName}`,
+      url: `${HUBFILES_API_PATH}/object-schemas/${objectName}`,
     },
     path
   );

--- a/packages/cli-lib/api/functions.js
+++ b/packages/cli-lib/api/functions.js
@@ -3,23 +3,23 @@ const FUNCTION_API_PATH = 'cms/v3/functions';
 
 async function getFunctionByPath(accountId, functionPath) {
   return http.get(accountId, {
-    uri: `${FUNCTION_API_PATH}/function/by-path/${functionPath}`,
+    url: `${FUNCTION_API_PATH}/function/by-path/${functionPath}`,
   });
 }
 
 async function getRoutes(accountId) {
   return http.get(accountId, {
-    uri: `${FUNCTION_API_PATH}/routes`,
+    url: `${FUNCTION_API_PATH}/routes`,
   });
 }
 
 async function buildPackage(portalId, folderPath) {
   return http.post(portalId, {
-    uri: `${FUNCTION_API_PATH}/build/async`,
+    url: `${FUNCTION_API_PATH}/build/async`,
     headers: {
       Accept: 'text/plain',
     },
-    body: {
+    data: {
       folderPath,
     },
   });
@@ -27,7 +27,7 @@ async function buildPackage(portalId, folderPath) {
 
 async function getBuildStatus(portalId, buildId) {
   return http.get(portalId, {
-    uri: `${FUNCTION_API_PATH}/build/${buildId}/poll`,
+    url: `${FUNCTION_API_PATH}/build/${buildId}/poll`,
   });
 }
 
@@ -41,8 +41,8 @@ async function getProjectAppFunctionLogs(
   const { limit = 5 } = query;
 
   return http.get(accountId, {
-    uri: `${FUNCTION_API_PATH}/app-function/logs/project/${projectName}/function/${functionName}`,
-    query: { ...query, limit, appPath },
+    url: `${FUNCTION_API_PATH}/app-function/logs/project/${projectName}/function/${functionName}`,
+    params: { ...query, limit, appPath },
   });
 }
 
@@ -53,8 +53,8 @@ async function getLatestProjectAppFunctionLog(
   appPath
 ) {
   return http.get(accountId, {
-    uri: `${FUNCTION_API_PATH}/app-function/logs/project/${projectName}/function/${functionName}/latest`,
-    query: { appPath },
+    url: `${FUNCTION_API_PATH}/app-function/logs/project/${projectName}/function/${functionName}/latest`,
+    params: { appPath },
   });
 }
 

--- a/packages/cli-lib/api/hubdb.js
+++ b/packages/cli-lib/api/hubdb.js
@@ -3,67 +3,67 @@ const HUBDB_API_PATH = 'cms/v3/hubdb';
 
 async function fetchTables(accountId) {
   return http.get(accountId, {
-    uri: `${HUBDB_API_PATH}/tables`,
+    url: `${HUBDB_API_PATH}/tables`,
   });
 }
 
 async function fetchTable(accountId, tableId) {
   return http.get(accountId, {
-    uri: `${HUBDB_API_PATH}/tables/${tableId}`,
+    url: `${HUBDB_API_PATH}/tables/${tableId}`,
   });
 }
 
 async function createTable(accountId, schema) {
   return http.post(accountId, {
-    uri: `${HUBDB_API_PATH}/tables`,
-    body: schema,
+    url: `${HUBDB_API_PATH}/tables`,
+    data: schema,
   });
 }
 
 async function updateTable(accountId, tableId, schema) {
   return http.patch(accountId, {
-    uri: `${HUBDB_API_PATH}/tables/${tableId}/draft`,
-    body: schema,
+    url: `${HUBDB_API_PATH}/tables/${tableId}/draft`,
+    data: schema,
   });
 }
 
 async function publishTable(accountId, tableId) {
   return http.post(accountId, {
-    uri: `${HUBDB_API_PATH}/tables/${tableId}/draft/publish`,
+    url: `${HUBDB_API_PATH}/tables/${tableId}/draft/publish`,
   });
 }
 
 async function deleteTable(accountId, tableId) {
   return http.delete(accountId, {
-    uri: `${HUBDB_API_PATH}/tables/${tableId}`,
+    url: `${HUBDB_API_PATH}/tables/${tableId}`,
   });
 }
 
 async function updateRows(accountId, tableId, rows) {
   return http.post(accountId, {
-    uri: `${HUBDB_API_PATH}/tables/${tableId}/rows/draft/batch/update`,
-    body: rows,
+    url: `${HUBDB_API_PATH}/tables/${tableId}/rows/draft/batch/update`,
+    data: rows,
   });
 }
 
 async function createRows(accountId, tableId, rows) {
   return http.post(accountId, {
-    uri: `${HUBDB_API_PATH}/tables/${tableId}/rows/draft/batch/create`,
-    body: { inputs: rows },
+    url: `${HUBDB_API_PATH}/tables/${tableId}/rows/draft/batch/create`,
+    data: { inputs: rows },
   });
 }
 
 async function fetchRows(accountId, tableId, query = {}) {
   return http.get(accountId, {
-    uri: `${HUBDB_API_PATH}/tables/${tableId}/rows/draft`,
+    url: `${HUBDB_API_PATH}/tables/${tableId}/rows/draft`,
     query,
   });
 }
 
 async function deleteRows(accountId, tableId, rowIds) {
   return http.post(accountId, {
-    uri: `${HUBDB_API_PATH}/tables/${tableId}/rows/draft/batch/purge`,
-    body: { inputs: rowIds },
+    url: `${HUBDB_API_PATH}/tables/${tableId}/rows/draft/batch/purge`,
+    data: { inputs: rowIds },
   });
 }
 

--- a/packages/cli-lib/api/localDevAuth/authenticated.js
+++ b/packages/cli-lib/api/localDevAuth/authenticated.js
@@ -3,7 +3,7 @@ const http = require('../../http');
 async function fetchScopeData(accountId, scopeGroup) {
   return http.get(accountId, {
     url: `localdevauth/v1/auth/check-scopes`,
-    query: {
+    params: {
       scopeGroup,
     },
   });

--- a/packages/cli-lib/api/localDevAuth/authenticated.js
+++ b/packages/cli-lib/api/localDevAuth/authenticated.js
@@ -2,7 +2,7 @@ const http = require('../../http');
 
 async function fetchScopeData(accountId, scopeGroup) {
   return http.get(accountId, {
-    uri: `localdevauth/v1/auth/check-scopes`,
+    url: `localdevauth/v1/auth/check-scopes`,
     query: {
       scopeGroup,
     },

--- a/packages/cli-lib/api/localDevAuth/unauthenticated.js
+++ b/packages/cli-lib/api/localDevAuth/unauthenticated.js
@@ -9,19 +9,19 @@ async function fetchAccessToken(
   env = ENVIRONMENTS.PROD,
   portalId
 ) {
-  const query = portalId ? { portalId } : {};
+  const params = portalId ? { portalId } : {};
   const requestOptions = getRequestOptions(
     { env },
     {
-      uri: `${LOCALDEVAUTH_API_AUTH_PATH}/refresh`,
-      body: {
+      url: `${LOCALDEVAUTH_API_AUTH_PATH}/refresh`,
+      data: {
         encodedOAuthRefreshToken: personalAccessKey,
       },
-      qs: query,
+      params,
     }
   );
 
-  return axios.post(requestOptions);
+  return axios({ method: 'post', ...requestOptions });
 }
 
 module.exports = {

--- a/packages/cli-lib/api/localDevAuth/unauthenticated.js
+++ b/packages/cli-lib/api/localDevAuth/unauthenticated.js
@@ -1,4 +1,4 @@
-const request = require('request-promise-native');
+const axios = require('axios');
 const { getRequestOptions } = require('../../http/requestOptions');
 const { ENVIRONMENTS } = require('../../lib/constants');
 
@@ -21,7 +21,7 @@ async function fetchAccessToken(
     }
   );
 
-  return request.post(requestOptions);
+  return axios.post(requestOptions);
 }
 
 module.exports = {

--- a/packages/cli-lib/api/marketplace.js
+++ b/packages/cli-lib/api/marketplace.js
@@ -11,8 +11,8 @@ const MARKETPLACE_API_PATH = 'product/marketplace/v2/template/render';
  */
 async function fetchDependencies(accountId, sourceCode) {
   return http.post(accountId, {
-    uri: MARKETPLACE_API_PATH,
-    body: { template_source: sourceCode },
+    url: MARKETPLACE_API_PATH,
+    data: { template_source: sourceCode },
   });
 }
 

--- a/packages/cli-lib/api/results.js
+++ b/packages/cli-lib/api/results.js
@@ -6,14 +6,14 @@ async function getFunctionLogs(accountId, route, query = {}) {
   const { limit = 5 } = query;
 
   return http.get(accountId, {
-    uri: `${RESULTS_API_PATH}/by-route/${route}`,
-    query: { ...query, limit },
+    url: `${RESULTS_API_PATH}/by-route/${route}`,
+    params: { ...query, limit },
   });
 }
 
 async function getLatestFunctionLog(accountId, route) {
   return http.get(accountId, {
-    uri: `${RESULTS_API_PATH}/by-route/${route}/latest`,
+    url: `${RESULTS_API_PATH}/by-route/${route}/latest`,
   });
 }
 

--- a/packages/cli-lib/api/sandbox-hubs.js
+++ b/packages/cli-lib/api/sandbox-hubs.js
@@ -3,8 +3,8 @@ const SANDBOX_API_PATH = 'sandbox-hubs/v1';
 
 async function createSandbox(accountId, name) {
   return http.post(accountId, {
-    body: { name },
-    uri: SANDBOX_API_PATH,
+    data: { name },
+    url: SANDBOX_API_PATH,
   });
 }
 

--- a/packages/cli-lib/api/schema.js
+++ b/packages/cli-lib/api/schema.js
@@ -5,29 +5,29 @@ const SCHEMA_API_PATH = 'crm-object-schemas/v3/schemas';
 
 const createSchema = (accountId, filePath) =>
   http.post(accountId, {
-    uri: SCHEMA_API_PATH,
-    body: JSON.parse(fs.readFileSync(filePath, 'utf-8')),
+    url: SCHEMA_API_PATH,
+    data: JSON.parse(fs.readFileSync(filePath, 'utf-8')),
   });
 
 const updateSchema = async (accountId, schemaObjectType, filePath) =>
   http.patch(accountId, {
-    uri: `${SCHEMA_API_PATH}/${schemaObjectType}`,
-    body: JSON.parse(fs.readFileSync(filePath, 'utf-8')),
+    url: `${SCHEMA_API_PATH}/${schemaObjectType}`,
+    data: JSON.parse(fs.readFileSync(filePath, 'utf-8')),
   });
 
 const fetchSchema = async (accountId, schemaObjectType) =>
   http.get(accountId, {
-    uri: `${SCHEMA_API_PATH}/${schemaObjectType}`,
+    url: `${SCHEMA_API_PATH}/${schemaObjectType}`,
   });
 
 const fetchSchemas = async accountId =>
   http.get(accountId, {
-    uri: SCHEMA_API_PATH,
+    url: SCHEMA_API_PATH,
   });
 
 const deleteSchema = async (accountId, schemaObjectType) =>
   http.delete(accountId, {
-    uri: `${SCHEMA_API_PATH}/${schemaObjectType}`,
+    url: `${SCHEMA_API_PATH}/${schemaObjectType}`,
   });
 
 module.exports = {

--- a/packages/cli-lib/api/secrets.js
+++ b/packages/cli-lib/api/secrets.js
@@ -4,8 +4,8 @@ const SECRETS_API_PATH = 'cms/v3/functions/secrets';
 
 async function addSecret(accountId, key, value) {
   return http.post(accountId, {
-    uri: SECRETS_API_PATH,
-    body: {
+    url: SECRETS_API_PATH,
+    data: {
       key,
       secret: value,
     },
@@ -14,8 +14,8 @@ async function addSecret(accountId, key, value) {
 
 async function updateSecret(accountId, key, value) {
   return http.put(accountId, {
-    uri: SECRETS_API_PATH,
-    body: {
+    url: SECRETS_API_PATH,
+    data: {
       key,
       secret: value,
     },
@@ -24,13 +24,13 @@ async function updateSecret(accountId, key, value) {
 
 async function deleteSecret(accountId, key) {
   return http.delete(accountId, {
-    uri: `${SECRETS_API_PATH}/${key}`,
+    url: `${SECRETS_API_PATH}/${key}`,
   });
 }
 
 async function fetchSecrets(accountId) {
   return http.get(accountId, {
-    uri: `${SECRETS_API_PATH}`,
+    url: `${SECRETS_API_PATH}`,
   });
 }
 

--- a/packages/cli-lib/api/validate.js
+++ b/packages/cli-lib/api/validate.js
@@ -11,8 +11,8 @@ const HUBL_VALIDATE_API_PATH = 'cos-rendering/v1/internal/validate';
  */
 async function validateHubl(accountId, sourceCode, hublValidationOptions) {
   return http.post(accountId, {
-    uri: HUBL_VALIDATE_API_PATH,
-    body: {
+    url: HUBL_VALIDATE_API_PATH,
+    data: {
       template_source: sourceCode,
       ...hublValidationOptions,
     },

--- a/packages/cli-lib/github.js
+++ b/packages/cli-lib/github.js
@@ -1,4 +1,4 @@
-const request = require('request-promise-native');
+const axios = require('axios');
 const { logger } = require('./logger');
 const { logErrorInstance } = require('./errorHandlers');
 const { DEFAULT_USER_AGENT_HEADERS } = require('./http/requestOptions');
@@ -13,7 +13,7 @@ async function fetchJsonFromRepository(repoName, filePath) {
     const URI = `https://raw.githubusercontent.com/HubSpot/${repoName}/${filePath}`;
     logger.debug(`Fetching ${URI}...`);
 
-    return request.get(URI, {
+    return axios.get(URI, {
       json: true,
       headers: { ...DEFAULT_USER_AGENT_HEADERS },
     });

--- a/packages/cli-lib/http.js
+++ b/packages/cli-lib/http.js
@@ -1,6 +1,5 @@
 const path = require('path');
-const request = require('request');
-const requestPN = require('request-promise-native');
+const axios = require('axios');
 const fs = require('fs-extra');
 const contentDisposition = require('content-disposition');
 
@@ -95,23 +94,23 @@ const addQueryParams = (requestOptions, params = {}) => {
 const getRequest = async (accountId, options) => {
   const { query, ...rest } = options;
   const requestOptions = addQueryParams(rest, query);
-  return requestPN.get(await withAuth(accountId, requestOptions));
+  return axios.get(await withAuth(accountId, requestOptions));
 };
 
 const postRequest = async (accountId, options) => {
-  return requestPN.post(await withAuth(accountId, options));
+  return axios.post(await withAuth(accountId, options));
 };
 
 const putRequest = async (accountId, options) => {
-  return requestPN.put(await withAuth(accountId, options));
+  return axios.put(await withAuth(accountId, options));
 };
 
 const patchRequest = async (accountId, options) => {
-  return requestPN.patch(await withAuth(accountId, options));
+  return axios.patch(await withAuth(accountId, options));
 };
 
 const deleteRequest = async (accountId, options) => {
-  return requestPN.del(await withAuth(accountId, options));
+  return axios.del(await withAuth(accountId, options));
 };
 
 const createGetRequestStream = ({ contentType }) => async (
@@ -141,7 +140,7 @@ const createGetRequestStream = ({ contentType }) => async (
   return new Promise(async (resolve, reject) => {
     try {
       const { headers, ...opts } = await withAuth(accountId, requestOptions);
-      const req = request.get({
+      const req = axios.get({
         ...opts,
         headers: {
           ...headers,
@@ -194,7 +193,6 @@ const createGetRequestStream = ({ contentType }) => async (
 
 module.exports = {
   getRequestOptions,
-  request: requestPN,
   get: getRequest,
   getOctetStream: createGetRequestStream({
     contentType: 'application/octet-stream',

--- a/packages/cli-lib/http.js
+++ b/packages/cli-lib/http.js
@@ -43,12 +43,12 @@ const withPersonalAccessKey = async (
 };
 
 const withPortalId = (portalId, requestOptions) => {
-  const { qs } = requestOptions;
+  const { params } = requestOptions;
 
   return {
     ...requestOptions,
-    qs: {
-      ...qs,
+    params: {
+      ...params,
       portalId,
     },
   };
@@ -69,24 +69,24 @@ const withAuth = async (accountId, options) => {
   if (authType === 'oauth2') {
     return withOauth(accountId, accountConfig, requestOptions);
   }
-  const { qs } = requestOptions;
+  const { params } = requestOptions;
 
   return {
     ...requestOptions,
-    qs: {
-      ...qs,
+    params: {
+      ...params,
       hapikey: apiKey,
     },
   };
 };
 
-const addQueryParams = (requestOptions, params = {}) => {
-  const { qs } = requestOptions;
+const addQueryParams = (requestOptions, additionalParams = {}) => {
+  const { params } = requestOptions;
   return {
     ...requestOptions,
-    qs: {
-      ...qs,
+    params: {
       ...params,
+      ...additionalParams,
     },
   };
 };
@@ -94,23 +94,26 @@ const addQueryParams = (requestOptions, params = {}) => {
 const getRequest = async (accountId, options) => {
   const { query, ...rest } = options;
   const requestOptions = addQueryParams(rest, query);
-  return axios.get(await withAuth(accountId, requestOptions));
+  return axios({
+    method: 'get',
+    ...(await withAuth(accountId, requestOptions)),
+  });
 };
 
 const postRequest = async (accountId, options) => {
-  return axios.post(await withAuth(accountId, options));
+  return axios({ method: 'post', ...(await withAuth(accountId, options)) });
 };
 
 const putRequest = async (accountId, options) => {
-  return axios.put(await withAuth(accountId, options));
+  return axios({ method: 'put', ...(await withAuth(accountId, options)) });
 };
 
 const patchRequest = async (accountId, options) => {
-  return axios.patch(await withAuth(accountId, options));
+  return axios({ method: 'patch', ...(await withAuth(accountId, options)) });
 };
 
 const deleteRequest = async (accountId, options) => {
-  return axios.del(await withAuth(accountId, options));
+  return axios({ method: 'delete', ...(await withAuth(accountId, options)) });
 };
 
 const createGetRequestStream = ({ contentType }) => async (
@@ -140,7 +143,8 @@ const createGetRequestStream = ({ contentType }) => async (
   return new Promise(async (resolve, reject) => {
     try {
       const { headers, ...opts } = await withAuth(accountId, requestOptions);
-      const req = axios.get({
+      const req = axios({
+        method: 'get',
         ...opts,
         headers: {
           ...headers,

--- a/packages/cli-lib/http/requestOptions.js
+++ b/packages/cli-lib/http/requestOptions.js
@@ -10,7 +10,7 @@ const getRequestOptions = (options = {}, requestOptions = {}) => {
   const { env } = options;
   const { httpTimeout, httpUseLocalhost } = getAndLoadConfigIfNeeded();
   return {
-    baseUrl: getHubSpotApiOrigin(env, httpUseLocalhost),
+    baseURL: getHubSpotApiOrigin(env, httpUseLocalhost),
     headers: {
       ...DEFAULT_USER_AGENT_HEADERS,
     },

--- a/packages/cli-lib/lib/models/OAuth2Manager.js
+++ b/packages/cli-lib/lib/models/OAuth2Manager.js
@@ -1,4 +1,4 @@
-const request = require('request-promise-native');
+const axios = require('axios');
 const moment = require('moment');
 
 const { HubSpotAuthError } = require('./Errors');
@@ -54,7 +54,7 @@ class OAuth2Manager {
       `Fetching access token for accountId ${this.accountId} for clientId ${this.clientId}`
     );
     try {
-      this.refreshTokenRequest = request.post(
+      this.refreshTokenRequest = axios.post(
         `${getHubSpotApiOrigin(this.env)}/oauth/v1/token`,
         {
           form: exchangeProof,

--- a/packages/cli-lib/package.json
+++ b/packages/cli-lib/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/HubSpot/hubspot-cms-tools"
   },
   "dependencies": {
+    "axios": "^0.24.0",
     "chalk": "^2.4.2",
     "chokidar": "^3.0.1",
     "content-disposition": "^0.5.3",
@@ -21,8 +22,6 @@
     "moment": "^2.24.0",
     "p-queue": "^6.0.2",
     "prettier": "^1.19.1",
-    "request": "^2.87.0",
-    "request-promise-native": "^1.0.7",
     "table": "^6.6.0",
     "unixify": "1.0.0"
   },

--- a/packages/cli-lib/personalAccessKey.js
+++ b/packages/cli-lib/personalAccessKey.js
@@ -28,7 +28,8 @@ async function getAccessToken(
 ) {
   let response;
   try {
-    response = await fetchAccessToken(personalAccessKey, env, accountId);
+    const { data } = await fetchAccessToken(personalAccessKey, env, accountId);
+    response = data;
   } catch (e) {
     if (e.response) {
       const errorOutput = `Error while retrieving new access token: ${e.response.body.message}.`;

--- a/packages/cli-lib/projects.js
+++ b/packages/cli-lib/projects.js
@@ -3,7 +3,7 @@ const path = require('path');
 const os = require('os');
 const { promisify } = require('util');
 
-const request = require('request-promise-native');
+const axios = require('axios');
 const extract = promisify(require('extract-zip'));
 
 const { logger } = require('./logger');
@@ -33,7 +33,7 @@ async function fetchReleaseData(repoName, tag = '') {
     ? `https://api.github.com/repos/HubSpot/${repoName}/releases/tags/${tag}`
     : `https://api.github.com/repos/HubSpot/${repoName}/releases/latest`;
   try {
-    return await request.get(URI, {
+    return await axios.get(URI, {
       headers: { ...DEFAULT_USER_AGENT_HEADERS },
       json: true,
     });
@@ -71,7 +71,7 @@ async function downloadProject(
       const { name } = releaseData;
       logger.log(`Fetching ${name}...`);
     }
-    const zip = await request.get(zipUrl, {
+    const zip = await axios.get(zipUrl, {
       encoding: null,
       headers: { ...DEFAULT_USER_AGENT_HEADERS },
     });

--- a/packages/cli/commands/functions/list.js
+++ b/packages/cli/commands/functions/list.js
@@ -36,7 +36,7 @@ exports.handler = async options => {
 
   logger.debug(i18n(`${i18nKey}.debug.gettingFunctions`));
 
-  const routesResp = await getRoutes(accountId).catch(async e => {
+  const { data: routesResp } = await getRoutes(accountId).catch(async e => {
     await logApiErrorInstance(accountId, e, new ApiErrorContext({ accountId }));
     process.exit(EXIT_CODES.SUCCESS);
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1958,6 +1958,13 @@ aws4@^1.8.0:
   resolved "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
+axios@^0.24.0:
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.24.0.tgz#804e6fa1e4b9c5288501dd9dff56a7a0940d20d6"
+  integrity sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==
+  dependencies:
+    follow-redirects "^1.14.4"
+
 babel-jest@^26.6.3:
   version "26.6.3"
   resolved "https://registry.npmjs.org/babel-jest/-/babel-jest-26.6.3.tgz"
@@ -3938,6 +3945,11 @@ flatten@^1.0.2:
   version "1.0.3"
   resolved "https://registry.npmjs.org/flatten/-/flatten-1.0.3.tgz"
   integrity sha512-dVsPA/UwQ8+2uoFe5GHtiBMu48dWLTdsuEd7CKGlZlD78r1TTWBvDuFaFGKCo/ZfEr95Uk56vZoX86OsHkUeIg==
+
+follow-redirects@^1.14.4:
+  version "1.14.5"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.5.tgz#f09a5848981d3c772b5392309778523f8d85c381"
+  integrity sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA==
 
 for-in@^1.0.2:
   version "1.0.2"
@@ -7850,7 +7862,7 @@ request-promise-core@1.1.4:
   dependencies:
     lodash "^4.17.19"
 
-request-promise-native@^1.0.7, request-promise-native@^1.0.9:
+request-promise-native@^1.0.9:
   version "1.0.9"
   resolved "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz"
   integrity sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==
@@ -7859,7 +7871,7 @@ request-promise-native@^1.0.7, request-promise-native@^1.0.9:
     stealthy-require "^1.1.1"
     tough-cookie "^2.3.3"
 
-request@^2.87.0, request@^2.88.0, request@^2.88.2:
+request@^2.88.0, request@^2.88.2:
   version "2.88.2"
   resolved "https://registry.npmjs.org/request/-/request-2.88.2.tgz"
   integrity sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==


### PR DESCRIPTION
## Description and Context
The [request](https://www.npmjs.com/package/request) library has been deprecated. This PR seeks to replace that http library with another.
Fixes HubSpot/cli-lib#25 

### Selection of new http library

Some thoughts when choosing a new http library include...
- Features
- Maturity
- Ratings
- Community/support
- Ease of migration

Based on initial research, it seems that [axios](https://www.npmjs.com/package/axios) seems like a logical replacement based on high usage, high user ratings, and active community ([some comparison data of node http libraries](https://openbase.com/categories/js/best-nodejs-http-request-libraries)).

I've created this initial PR that updates the CLI to use [axios](https://www.npmjs.com/package/axios) and includes some of the necessary changes that will need to be made to the code to support the new library as a way to provide some context.

### Migration

There are several necessary changes that will need to be made, and the PR may get rather lengthy and would no doubt require a significant QA effort to catch as many bugs as possible. @brandenrodgers suggested that we could add the `axios` dependency and keep the `request` dependency, updating the CLI in smaller chunks. This may require some redundant code (http.js) to support both libraries and would mean that extra thought would need to be made during the transition period, but the trade-off is that the PRs would be easier to review and QA testing could be more focused on the are being changed.

### TODO
- Update tests to work with axios errors

## Who to Notify
@gcorne @brandenrodgers @anthmatic @kemmerle @bmatto 
