### PR TITLE
fix i18n key for function deploy

### DIFF
--- a/packages/cli/commands/functions/deploy.js
+++ b/packages/cli/commands/functions/deploy.js
@@ -83,7 +83,7 @@ exports.handler = async options => {
     spinner.stop();
     await outputBuildLog(successResp.cdnUrl);
     logger.success(
-      i18n(`${i18nKey}.success.deploy`, {
+      i18n(`${i18nKey}.success.deployed`, {
         accountId,
         buildTimeSeconds,
         functionPath,


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
Fixing a typo that was causing us to show a "missing translation" error for function deploy.

Here's the lyaml key: https://github.com/HubSpot/hubspot-cli/blob/master/packages/cli-lib/lang/en.lyaml#L274

## Screenshots
<!-- Provide images of the before and after functionality -->

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
