### PR TITLE
Support Projects-compatible theme boilerplate

### DIFF
--- a/packages/cli-lib/projects.js
+++ b/packages/cli-lib/projects.js
@@ -57,13 +57,14 @@ async function fetchReleaseData(repoName, tag = '') {
 async function downloadProject(
   repoName,
   tag = '',
-  releaseType = GITHUB_RELEASE_TYPES.RELEASE
+  releaseType = GITHUB_RELEASE_TYPES.RELEASE,
+  ref
 ) {
   try {
     let zipUrl;
     if (releaseType === GITHUB_RELEASE_TYPES.REPOSITORY) {
       logger.log(`Fetching ${releaseType} with name ${repoName}...`);
-      zipUrl = `https://api.github.com/repos/HubSpot/${repoName}/zipball`;
+      zipUrl = `https://api.github.com/repos/HubSpot/${repoName}/zipball/${ref}`;
     } else {
       const releaseData = await fetchReleaseData(repoName, tag);
       if (!releaseData) return;
@@ -180,9 +181,9 @@ function cleanupTemp(tmpDir) {
  * @returns {Boolean} `true` if successful, `false` otherwise.
  */
 async function createProject(dest, type, repoName, sourceDir, options = {}) {
-  const { themeVersion, projectVersion, releaseType } = options;
+  const { themeVersion, projectVersion, releaseType, ref } = options;
   const tag = projectVersion || themeVersion;
-  const zip = await downloadProject(repoName, tag, releaseType);
+  const zip = await downloadProject(repoName, tag, releaseType, ref);
   if (!zip) return false;
   const { extractDir, tmpDir } = (await extractProjectZip(repoName, zip)) || {};
   const success =

--- a/packages/cli-lib/projects.js
+++ b/packages/cli-lib/projects.js
@@ -64,7 +64,9 @@ async function downloadProject(
     let zipUrl;
     if (releaseType === GITHUB_RELEASE_TYPES.REPOSITORY) {
       logger.log(`Fetching ${releaseType} with name ${repoName}...`);
-      zipUrl = `https://api.github.com/repos/HubSpot/${repoName}/zipball/${ref}`;
+      zipUrl = `https://api.github.com/repos/HubSpot/${repoName}/zipball${
+        ref ? `/${ref}` : ''
+      }`;
     } else {
       const releaseData = await fetchReleaseData(repoName, tag);
       if (!releaseData) return;

--- a/packages/cli/commands/create/website-theme.js
+++ b/packages/cli/commands/create/website-theme.js
@@ -1,8 +1,19 @@
 const { createProject } = require('@hubspot/cli-lib/projects');
+const { GITHUB_RELEASE_TYPES } = require('@hubspot/cli-lib/lib/constants');
+const { getIsInProject } = require('../../lib/projects');
+
+const PROJECT_BOILERPLATE_REF = 'cms-boilerplate-developer-projects';
 
 module.exports = {
   dest: ({ name, assetType }) => name || assetType,
-  execute: ({ dest, assetType, options }) => {
+  execute: async ({ dest, assetType, options }) => {
+    const isInProject = await getIsInProject(dest);
+
+    if (isInProject) {
+      options.ref = PROJECT_BOILERPLATE_REF;
+      // releaseType has to be 'REPOSITORY' to download a specific branch
+      options.releaseType = GITHUB_RELEASE_TYPES.REPOSITORY;
+    }
     createProject(dest, assetType, 'cms-theme-boilerplate', 'src', options);
   },
 };

--- a/packages/cli/lib/projects.js
+++ b/packages/cli/lib/projects.js
@@ -69,7 +69,12 @@ const writeProjectConfig = (configPath, config) => {
   }
 };
 
-const getProjectConfig = async _dir => {
+const getIsInProject = async _dir => {
+  const configPath = await getProjectConfigPath(_dir);
+  return !!configPath;
+};
+
+const getProjectConfigPath = async _dir => {
   const projectDir = _dir ? path.resolve(getCwd(), _dir) : getCwd();
 
   const configPath = findup(PROJECT_CONFIG_FILE, {
@@ -77,6 +82,11 @@ const getProjectConfig = async _dir => {
     nocase: true,
   });
 
+  return configPath;
+};
+
+const getProjectConfig = async _dir => {
+  const configPath = await getProjectConfigPath(_dir);
   if (!configPath) {
     return { projectConfig: null, projectDir: null };
   }
@@ -381,6 +391,7 @@ const makeGetTaskStatus = taskType => {
 module.exports = {
   writeProjectConfig,
   getProjectConfig,
+  getIsInProject,
   createProjectConfig,
   validateProjectConfig,
   showWelcomeMessage,


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
Relevant cms-theme-boilerplate branch: https://github.com/HubSpot/cms-theme-boilerplate/pull/404

This updates the `hs create website-theme` command to dynamically download the Projects-compatible version of the theme boilerplate repo if the destination folder is within a Project.

I also added a `getIsInProject` util because I think that will be useful to have.

## Screenshots
<!-- Provide images of the before and after functionality -->

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
cc/ @jasonnrosa 