### PR TITLE
Make project command help visible

### DIFF
--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -401,8 +401,9 @@ en:
       project:
         subcommands:
           create:
+            describe: "Create a new project"
             examples:
-              default: "Create a project"
+              default: "Create a new project"
             options:
               location:
                 describe: "Directory where project should be created"
@@ -411,6 +412,7 @@ en:
               template:
                 describe: "Which template?"
           deploy:
+            describe: "Deploy a project build"
             debug:
               deploying: "Deploying project at path: {{ path }}"
             errors:
@@ -456,7 +458,7 @@ en:
               cleanedUpTempFile: "Cleaned up temporary file {{ path }}"
               compressed: "Project files compressed: {{ byteCount }} bytes"
               compressing: "Compressing build files to \"{{ path }}\""
-            describe: "Upload a project."
+            describe: "Upload your project files and create a new build"
             examples:
               default: "Upload a project"
             loading:
@@ -476,7 +478,7 @@ en:
               path:
                 describe: "Path to a project folder"
           watch:
-            describe: "Path to a project folder"
+            describe: "Watch your local project for changes and automatically upload changed files to a new build in HubSpot"
             examples:
               default: "Watch a project within the myProjectFolder folder"
             logs: 

--- a/packages/cli/commands/project/create.js
+++ b/packages/cli/commands/project/create.js
@@ -17,7 +17,7 @@ const { i18n } = require('@hubspot/cli-lib/lib/lang');
 const i18nKey = 'cli.commands.project.subcommands.create';
 
 exports.command = 'create';
-exports.describe = false;
+exports.describe = i18n(`${i18nKey}.describe`);
 
 exports.handler = async options => {
   await loadAndValidateOptions(options);

--- a/packages/cli/commands/project/deploy.js
+++ b/packages/cli/commands/project/deploy.js
@@ -23,7 +23,7 @@ const i18nKey = 'cli.commands.project.subcommands.deploy';
 const { EXIT_CODES } = require('../../lib/enums/exitCodes');
 
 exports.command = 'deploy [path]';
-exports.describe = false;
+exports.describe = i18n(`${i18nKey}.describe`);
 
 exports.handler = async options => {
   await loadAndValidateOptions(options);

--- a/packages/cli/commands/project/upload.js
+++ b/packages/cli/commands/project/upload.js
@@ -33,7 +33,7 @@ const i18nKey = 'cli.commands.project.subcommands.upload';
 const { EXIT_CODES } = require('../../lib/enums/exitCodes');
 
 exports.command = 'upload [path]';
-exports.describe = false;
+exports.describe = i18n(`${i18nKey}.describe`);
 
 const uploadProjectFiles = async (accountId, projectName, filePath) => {
   const spinnies = new Spinnies({

--- a/packages/cli/commands/project/watch.js
+++ b/packages/cli/commands/project/watch.js
@@ -25,7 +25,7 @@ const { EXIT_CODES } = require('../../lib/enums/exitCodes');
 const i18nKey = 'cli.commands.project.subcommands.watch';
 
 exports.command = 'watch [path]';
-exports.describe = false;
+exports.describe = i18n(`${i18nKey}.describe`);
 
 const handleBuildStatus = async (accountId, projectName, buildId) => {
   const {


### PR DESCRIPTION
## Description and Context
Updates so that `hs project --help` shows the help for subcommands but the top level command is still not visible in `hs --help`
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->

## Screenshots
<!-- Provide images of the before and after functionality -->

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
