### PR TITLE
Project watch: watch for deleted directories

### DIFF
--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -485,7 +485,8 @@ en:
               watching: "Watcher is ready and watching \"{{ projectDir }}\". Any changes detected will be automatically uploaded and added to the current staging build."
               resuming: "Resuming watcher..."
               uploadSucceeded: "Uploaded file \"{{ filePath }}\" to \"{{ remotePath }}\""
-              deleteSucceeded: "Deleted file \"{{ remotePath }}\""
+              deleteFileSucceeded: "Deleted file \"{{ remotePath }}\""
+              deleteFolderSucceeded: "Deleted folder \"{{ remotePath }}\""
               createNewBuild: "Staging build #{{ buildId }} created"
               buildCancelled: "Staging build has been cancelled. Please try running `hs project watch` again"
             debug:
@@ -500,7 +501,8 @@ en:
             errors:
               projectLocked: "The previous staging build is still in progress"
               uploadFailed: "Failed to upload file \"{{ filePath }}\" to \"{{ remotePath }}\""
-              deleteFailed: "Failed to delete file \"{{ remotePath }}\""
+              deleteFileFailed: "Failed to delete file \"{{ remotePath }}\""
+              deleteFolderFailed: "Failed to delete folder \"{{ remotePath }}\""
       remove: 
         describe: "Delete a file or folder from HubSpot."
         deleted: "Deleted \"{{ path }}\" from account {{ accountId }}"

--- a/packages/cli-lib/projectsWatch.js
+++ b/packages/cli-lib/projectsWatch.js
@@ -101,7 +101,7 @@ const queueFileUpload = async (
     try {
       if (action === 'upload') {
         await uploadFileToBuild(accountId, projectName, filePath, remotePath);
-      } else if (action === 'delete') {
+      } else if (action === 'deleteFile' || action === 'deleteFolder') {
         await deleteFileFromBuild(accountId, projectName, remotePath);
       }
       logger.log(
@@ -186,7 +186,7 @@ const createWatcher = async (
       projectConfig.name,
       projectSourceDir,
       filePath,
-      'delete'
+      'deleteFile'
     );
   });
   watcher.on('unlinkDir', async filePath => {
@@ -195,7 +195,7 @@ const createWatcher = async (
       projectConfig.name,
       projectSourceDir,
       filePath,
-      'delete'
+      'deleteFolder'
     );
   });
 };

--- a/packages/cli-lib/projectsWatch.js
+++ b/packages/cli-lib/projectsWatch.js
@@ -83,7 +83,7 @@ const queueFileUpload = async (
   remotePath,
   action
 ) => {
-  if (!isAllowedExtension(filePath)) {
+  if (action === 'upload' && !isAllowedExtension(filePath)) {
     logger.debug(i18n(`${i18nKey}.debug.extensionNotAllowed`, { filePath }));
     return;
   }
@@ -181,6 +181,15 @@ const createWatcher = async (
     addFile(accountId, projectConfig.name, projectSourceDir, filePath);
   });
   watcher.on('unlink', async filePath => {
+    addFile(
+      accountId,
+      projectConfig.name,
+      projectSourceDir,
+      filePath,
+      'delete'
+    );
+  });
+  watcher.on('unlinkDir', async filePath => {
     addFile(
       accountId,
       projectConfig.name,

--- a/packages/cli-lib/projectsWatch.js
+++ b/packages/cli-lib/projectsWatch.js
@@ -28,7 +28,7 @@ const processStandByQueue = async (accountId, projectName) => {
   queue.addAll(
     standbyeQueue.map(({ filePath, remotePath, action }) => {
       return async () => {
-        queueFileUpload(accountId, projectName, filePath, remotePath, action);
+        queueFileOrFolder(accountId, projectName, filePath, remotePath, action);
       };
     })
   );
@@ -76,7 +76,7 @@ const debounceQueueBuild = (accountId, projectName) => {
   }, 2000);
 };
 
-const queueFileUpload = async (
+const queueFileOrFolder = async (
   accountId,
   projectName,
   filePath,
@@ -132,7 +132,7 @@ const createNewBuild = async (accountId, projectName) => {
   }
 };
 
-const addFile = async (
+const handleWatchEvent = async (
   accountId,
   projectName,
   projectSourceDir,
@@ -149,7 +149,13 @@ const addFile = async (
           action,
         });
   } else {
-    await queueFileUpload(accountId, projectName, filePath, remotePath, action);
+    await queueFileOrFolder(
+      accountId,
+      projectName,
+      filePath,
+      remotePath,
+      action
+    );
   }
 };
 
@@ -174,27 +180,27 @@ const createWatcher = async (
   watcher.on('ready', async () => {
     logger.log(i18n(`${i18nKey}.logs.watching`, { projectDir }));
   });
-  watcher.on('add', async filePath => {
-    addFile(accountId, projectConfig.name, projectSourceDir, filePath);
+  watcher.on('add', async path => {
+    handleWatchEvent(accountId, projectConfig.name, projectSourceDir, path);
   });
-  watcher.on('change', async filePath => {
-    addFile(accountId, projectConfig.name, projectSourceDir, filePath);
+  watcher.on('change', async path => {
+    handleWatchEvent(accountId, projectConfig.name, projectSourceDir, path);
   });
-  watcher.on('unlink', async filePath => {
-    addFile(
+  watcher.on('unlink', async path => {
+    handleWatchEvent(
       accountId,
       projectConfig.name,
       projectSourceDir,
-      filePath,
+      path,
       'deleteFile'
     );
   });
-  watcher.on('unlinkDir', async filePath => {
-    addFile(
+  watcher.on('unlinkDir', async path => {
+    handleWatchEvent(
       accountId,
       projectConfig.name,
       projectSourceDir,
-      filePath,
+      path,
       'deleteFolder'
     );
   });


### PR DESCRIPTION
## Description and Context
`project watch` was previous only watching for directories. This updates the watcher to include directories and hit the same delete endpoint.
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->

## Screenshots
<!-- Provide images of the before and after functionality -->

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
