### PR TITLE
Support uploading  project files on watch

### DIFF
--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -489,7 +489,6 @@ en:
               deleteFolderSucceeded: "Deleted folder \"{{ remotePath }}\""
               createNewBuild: "Staging build #{{ buildId }} created"
               buildCancelled: "Staging build has been cancelled. Please try running `hs project watch` again"
-              initialUploadRequired: "This project has no builds. Uploading files."
             debug:
               attemptNewBuild: "Attempting to create a new build"
               uploading: "Attempting to upload file \"{{ filePath }}\" to \"{{ remotePath }}\""

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -481,13 +481,14 @@ en:
             describe: "Watch your local project for changes and automatically upload changed files to a new build in HubSpot"
             examples:
               default: "Watch a project within the myProjectFolder folder"
-            logs: 
+            logs:
               watching: "Watcher is ready and watching \"{{ projectDir }}\". Any changes detected will be automatically uploaded and added to the current staging build."
               resuming: "Resuming watcher..."
               uploadSucceeded: "Uploaded file \"{{ filePath }}\" to \"{{ remotePath }}\""
               deleteSucceeded: "Deleted file \"{{ remotePath }}\""
               createNewBuild: "Staging build #{{ buildId }} created"
               buildCancelled: "Staging build has been cancelled. Please try running `hs project watch` again"
+              initialUploadRequired: "This project has no builds. Uploading files."
             debug:
               attemptNewBuild: "Attempting to create a new build"
               uploading: "Attempting to upload file \"{{ filePath }}\" to \"{{ remotePath }}\""
@@ -501,7 +502,7 @@ en:
               projectLocked: "The previous staging build is still in progress"
               uploadFailed: "Failed to upload file \"{{ filePath }}\" to \"{{ remotePath }}\""
               deleteFailed: "Failed to delete file \"{{ remotePath }}\""
-      remove: 
+      remove:
         describe: "Delete a file or folder from HubSpot."
         deleted: "Deleted \"{{ path }}\" from account {{ accountId }}"
         errors:

--- a/packages/cli/commands/project/watch.js
+++ b/packages/cli/commands/project/watch.js
@@ -101,7 +101,6 @@ exports.handler = async options => {
 
   // Upload all files if no build exists for this project yet
   if (!results || !results.length) {
-    logger.log(i18n(`${i18nKey}.logs.initialUploadRequired`));
     await handleProjectUpload(
       accountId,
       projectConfig,

--- a/packages/cli/commands/project/watch.js
+++ b/packages/cli/commands/project/watch.js
@@ -1,6 +1,5 @@
 const { i18n } = require('@hubspot/cli-lib/lib/lang');
 const { createWatcher } = require('@hubspot/cli-lib/projectsWatch');
-const { cancelStagedBuild } = require('@hubspot/cli-lib/api/dfs');
 const {
   logApiErrorInstance,
   ApiErrorContext,
@@ -14,11 +13,17 @@ const {
 } = require('../../lib/commonOpts');
 const { trackCommandUsage } = require('../../lib/usageTracking');
 const {
+  ensureProjectExists,
   getProjectConfig,
-  validateProjectConfig,
+  handleProjectUpload,
   pollBuildStatus,
   pollDeployStatus,
+  validateProjectConfig,
 } = require('../../lib/projects');
+const {
+  cancelStagedBuild,
+  fetchProjectBuilds,
+} = require('@hubspot/cli-lib/api/dfs');
 const { loadAndValidateOptions } = require('../../lib/validation');
 const { EXIT_CODES } = require('../../lib/enums/exitCodes');
 
@@ -76,13 +81,36 @@ exports.handler = async options => {
 
   validateProjectConfig(projectConfig, projectDir);
 
-  await createWatcher(
+  await ensureProjectExists(accountId, projectConfig.name);
+
+  const { results } = await fetchProjectBuilds(
     accountId,
-    projectConfig,
-    projectDir,
-    handleBuildStatus,
-    handleSigInt
+    projectConfig.name,
+    options
   );
+
+  const startWatching = async () => {
+    await createWatcher(
+      accountId,
+      projectConfig,
+      projectDir,
+      handleBuildStatus,
+      handleSigInt
+    );
+  };
+
+  // Upload all files if no build exists for this project yet
+  if (!results || !results.length) {
+    logger.log(i18n(`${i18nKey}.logs.initialUploadRequired`));
+    await handleProjectUpload(
+      accountId,
+      projectConfig,
+      projectDir,
+      startWatching
+    );
+  } else {
+    await startWatching();
+  }
 };
 
 exports.builder = yargs => {

--- a/packages/cli/lib/projects.js
+++ b/packages/cli/lib/projects.js
@@ -1,6 +1,7 @@
 const fs = require('fs-extra');
 const path = require('path');
-
+const archiver = require('archiver');
+const tmp = require('tmp');
 const chalk = require('chalk');
 const findup = require('findup-sync');
 const Spinnies = require('spinnies');
@@ -22,15 +23,18 @@ const {
   getBuildStatus,
   getDeployStatus,
   fetchProject,
+  uploadProject,
 } = require('@hubspot/cli-lib/api/dfs');
 const {
   logApiErrorInstance,
   ApiErrorContext,
 } = require('@hubspot/cli-lib/errorHandlers');
+const { shouldIgnoreFile } = require('@hubspot/cli-lib/ignoreRules');
 const { getCwd } = require('@hubspot/cli-lib/path');
 const { promptUser } = require('./prompts/promptUtils');
 const { EXIT_CODES } = require('./enums/exitCodes');
 const { uiLine, uiAccountDescription } = require('../lib/ui');
+const { i18n } = require('@hubspot/cli-lib/lib/lang');
 
 const PROJECT_STRINGS = {
   BUILD: {
@@ -232,6 +236,108 @@ const getProjectDetailUrl = (projectName, accountId) => {
   return `${baseUrl}/developer-projects/${accountId}/project/${projectName}`;
 };
 
+const uploadProjectFiles = async (accountId, projectName, filePath) => {
+  const i18nKey = 'cli.commands.project.subcommands.upload';
+  const spinnies = new Spinnies({
+    succeedColor: 'white',
+  });
+  const accountIdentifier = uiAccountDescription(accountId);
+
+  spinnies.add('upload', {
+    text: i18n(`${i18nKey}.loading.upload.add`, {
+      accountIdentifier,
+      projectName,
+    }),
+  });
+
+  let buildId;
+
+  try {
+    const upload = await uploadProject(accountId, projectName, filePath);
+
+    buildId = upload.buildId;
+
+    spinnies.succeed('upload', {
+      text: i18n(`${i18nKey}.loading.upload.succeed`, {
+        accountIdentifier,
+        projectName,
+      }),
+    });
+
+    logger.debug(
+      i18n(`${i18nKey}.debug.buildCreated`, {
+        buildId,
+        projectName,
+      })
+    );
+  } catch (err) {
+    spinnies.fail('upload', {
+      text: i18n(`${i18nKey}.loading.upload.fail`, {
+        accountIdentifier,
+        projectName,
+      }),
+    });
+
+    logApiErrorInstance(
+      err,
+      new ApiErrorContext({
+        accountId,
+        projectName,
+      })
+    );
+    process.exit(EXIT_CODES.ERROR);
+  }
+
+  return { buildId };
+};
+
+const handleProjectUpload = async (
+  accountId,
+  projectConfig,
+  projectDir,
+  callbackFunc
+) => {
+  const i18nKey = 'cli.commands.project.subcommands.upload';
+  const tempFile = tmp.fileSync({ postfix: '.zip' });
+
+  logger.debug(
+    i18n(`${i18nKey}.debug.compressing`, {
+      path: tempFile.name,
+    })
+  );
+
+  const output = fs.createWriteStream(tempFile.name);
+  const archive = archiver('zip');
+
+  output.on('close', async function() {
+    logger.debug(
+      i18n(`${i18nKey}.debug.compressed`, {
+        byteCount: archive.pointer(),
+      })
+    );
+
+    const { buildId } = await uploadProjectFiles(
+      accountId,
+      projectConfig.name,
+      tempFile.name
+    );
+
+    if (callbackFunc) {
+      callbackFunc(tempFile, buildId);
+    }
+  });
+
+  archive.pipe(output);
+
+  archive.directory(
+    path.resolve(projectDir, projectConfig.srcDir),
+    false,
+    file => (shouldIgnoreFile(file.name) ? false : file)
+  );
+
+  archive.finalize();
+};
+
 const showWelcomeMessage = () => {
   logger.log('');
   logger.log(chalk.bold('Welcome to HubSpot Developer Projects!'));
@@ -392,6 +498,7 @@ module.exports = {
   writeProjectConfig,
   getProjectConfig,
   getIsInProject,
+  handleProjectUpload,
   createProjectConfig,
   validateProjectConfig,
   showWelcomeMessage,


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
The `hs project watch` command currently requires a project to exist in HubSpot AND for it to contain at least one build. This PR updates the command to automatically create the project and upload all project files if it detects that the project doesn't exist in HubSpot yet.

I DRYed things up a bit by moving the upload util into a shared place. 

## Screenshots
<!-- Provide images of the before and after functionality -->
![image](https://user-images.githubusercontent.com/6654014/151614951-717b3902-7cc8-4c98-a23a-e13e7b6ea74d.png)

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->
- [ ] Get feedback on UX/copy from @markhazlewood

## Who to Notify
<!-- /cc those you wish to know about the PR -->
cc/ @gcorne 