### PR TITLE
Updates to project upload and watch commands

### DIFF
--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -468,7 +468,8 @@ en:
                 succeed: "Uploaded {{#bold}}{{ projectName }}{{/bold}} project files to {{ accountIdentifier }}"
             logs:
               buildSucceeded: "Build #{{ buildId }} succeeded\n"
-              buildSucceededAutomaticallyDeploying: "Build #{{ buildId }} succeeded. {{#bold}}Automatically deploying{{/bold}} to {{ accountIdentifier }}"
+              buildSucceededAutomaticallyDeploying: "Build #{{ buildId }} succeeded. {{#bold}}Automatically deploying{{/bold}} to {{ accountIdentifier }}\n"
+              viewBuild: "\nView build #{{ buildId }} in HubSpot\n"
               readyToGoLive: "🚀 Ready to take your project live?"
               runCommand: "Run `{{ command }}`"
             options:
@@ -477,18 +478,27 @@ en:
             positionals:
               path:
                 describe: "Path to a project folder"
+          unlock:
+            describe: "Unlock a locked project"
+            examples:
+              default: "Unlock a locked project in the myProjectsFolder folder"
+            logs:
+              unlockSucceeded: "Successfully unlocked the project"
+            positionals:
+              path:
+                describe: "Path to a project folder"
           watch:
             describe: "Watch your local project for changes and automatically upload changed files to a new build in HubSpot"
             examples:
               default: "Watch a project within the myProjectFolder folder"
             logs:
-              watching: "Watcher is ready and watching \"{{ projectDir }}\". Any changes detected will be automatically uploaded and added to the current staging build."
+              watching: "Watcher is ready and watching \"{{ projectDir }}\". Any changes detected will be automatically uploaded."
               resuming: "Resuming watcher..."
               uploadSucceeded: "Uploaded file \"{{ filePath }}\" to \"{{ remotePath }}\""
               deleteFileSucceeded: "Deleted file \"{{ remotePath }}\""
               deleteFolderSucceeded: "Deleted folder \"{{ remotePath }}\""
-              createNewBuild: "Staging build #{{ buildId }} created"
-              buildCancelled: "Staging build has been cancelled. Please try running `hs project watch` again"
+              previousStagingBuildCancelled: "Killed the previous watch process. Please try running `hs project watch` again"
+              processExited: "Stopping watcher..."
             debug:
               attemptNewBuild: "Attempting to create a new build"
               uploading: "Attempting to upload file \"{{ filePath }}\" to \"{{ remotePath }}\""
@@ -496,13 +506,15 @@ en:
               ignored: "Skipping \"{{ filePath }}\" due to an ignore rule"
               pause: "Pausing watcher, attempting to queue build"
               buildStarted: "Build queued."
-              buildCancelled: "The current staging build has been cancelled. Exiting..."
               fileAlreadyQueued: "File \"{{ filePath }}\" is already queued for upload"
             errors:
-              projectLocked: "The previous staging build is still in progress"
+              projectLocked: "The previous watch process is still in progress"
               uploadFailed: "Failed to upload file \"{{ filePath }}\" to \"{{ remotePath }}\""
               deleteFileFailed: "Failed to delete file \"{{ remotePath }}\""
               deleteFolderFailed: "Failed to delete folder \"{{ remotePath }}\""
+            positionals:
+              path:
+                describe: "Path to a project folder"
           download:
             describe: "Download your project files from HubSpot and write to a path on your computer"
             examples:

--- a/packages/cli-lib/lib/process.js
+++ b/packages/cli-lib/lib/process.js
@@ -1,8 +1,36 @@
+const readline = require('readline');
+
 const handleExit = callback => {
-  process.on('exit', callback);
-  process.on('SIGINT', callback);
+  const terminationSignals = [
+    'beforeExit',
+    'SIGINT',
+    'SIGUSR1',
+    'SIGUSR2',
+    'uncaughtException',
+    'SIGTERM',
+    'SIGHUP',
+  ];
+  terminationSignals.forEach(signal => {
+    process.removeAllListeners(signal);
+
+    process.on(signal, async () => {
+      await callback();
+    });
+  });
+};
+
+const handleKeypress = callback => {
+  readline.emitKeypressEvents(process.stdin);
+  process.stdin.setRawMode(true);
+
+  process.stdin.on('keypress', (str, key) => {
+    if (key) {
+      callback(key);
+    }
+  });
 };
 
 module.exports = {
   handleExit,
+  handleKeypress,
 };

--- a/packages/cli/commands/project/upload.js
+++ b/packages/cli/commands/project/upload.js
@@ -48,6 +48,8 @@ exports.handler = async options => {
       status,
     } = await pollBuildStatus(accountId, projectConfig.name, buildId);
 
+    uiLine();
+
     if (status === 'FAILURE') {
       exitCode = EXIT_CODES.ERROR;
       return;

--- a/packages/cli/commands/project/watch.js
+++ b/packages/cli/commands/project/watch.js
@@ -26,6 +26,7 @@ const {
 } = require('@hubspot/cli-lib/api/dfs');
 const { loadAndValidateOptions } = require('../../lib/validation');
 const { EXIT_CODES } = require('../../lib/enums/exitCodes');
+const { handleKeypress, handleExit } = require('@hubspot/cli-lib/lib/process');
 
 const i18nKey = 'cli.commands.project.subcommands.watch';
 
@@ -48,13 +49,13 @@ const handleBuildStatus = async (accountId, projectName, buildId) => {
   }
 };
 
-const handleSigInt = (accountId, projectName, currentBuildId) => {
-  process.removeAllListeners('SIGINT');
-  process.on('SIGINT', async () => {
+const handleUserInput = (accountId, projectName, currentBuildId) => {
+  const onTerminate = async () => {
+    logger.log(i18n(`${i18nKey}.logs.processExited`));
+
     if (currentBuildId) {
       try {
         await cancelStagedBuild(accountId, projectName);
-        logger.debug(i18n(`${i18nKey}.debug.buildCancelled`));
         process.exit(EXIT_CODES.SUCCESS);
       } catch (err) {
         logApiErrorInstance(
@@ -65,6 +66,13 @@ const handleSigInt = (accountId, projectName, currentBuildId) => {
       }
     } else {
       process.exit(EXIT_CODES.SUCCESS);
+    }
+  };
+
+  handleExit(onTerminate);
+  handleKeypress(key => {
+    if ((key.ctrl && key.name === 'c') || key.name === 'q') {
+      onTerminate();
     }
   });
 };
@@ -95,7 +103,7 @@ exports.handler = async options => {
       projectConfig,
       projectDir,
       handleBuildStatus,
-      handleSigInt
+      handleUserInput
     );
   };
 
@@ -114,7 +122,7 @@ exports.handler = async options => {
 
 exports.builder = yargs => {
   yargs.positional('path', {
-    describe: i18n(`${i18nKey}.describe`),
+    describe: i18n(`${i18nKey}.positionals.path.describe`),
     type: 'string',
   });
 


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
This makes a handful of small UX improvements to the project upload and watch commands.

### Upload
- Added a link to Projects UI for the newly created build
- Indented the subbuild statuses so hierarchy is more clear
- Added some lines to make it more closely match the initial mocks

### Watch
- Properly clean up staged build in more scenarios (including when the user closes the terminal tab)
- Show the user a prompt to quit the watch process
- Remove the word "staging" from all output because it is confusing to the users.

## Screenshots
<!-- Provide images of the before and after functionality -->
### Updated watch output
<img width="699" alt="image" src="https://user-images.githubusercontent.com/6654014/160015423-f4a8f3ee-9947-404f-9b64-5c422cb3b95d.png">

### Upload (building)
<img width="696" alt="Screen Shot 2022-03-24 at 5 44 55 PM" src="https://user-images.githubusercontent.com/6654014/160015687-0c77eb19-f749-4312-8c03-ebf57bbe8ffe.png">

### Upload (deploying)
<img width="693" alt="Screen Shot 2022-03-24 at 5 45 10 PM" src="https://user-images.githubusercontent.com/6654014/160015715-9bdc470f-0624-4ea7-af11-68b675708d9d.png">

### Upload (done)
<img width="699" alt="Screen Shot 2022-03-24 at 5 45 18 PM" src="https://user-images.githubusercontent.com/6654014/160015744-c618c1a9-067c-4932-97a2-25f03bacc135.png">

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
cc/ @gcorne @markhazlewood @kemmerle @m-roll