### PR TITLE
Support initial upload for project watch

### DIFF
--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -503,6 +503,12 @@ en:
               uploadFailed: "Failed to upload file \"{{ filePath }}\" to \"{{ remotePath }}\""
               deleteFileFailed: "Failed to delete file \"{{ remotePath }}\""
               deleteFolderFailed: "Failed to delete folder \"{{ remotePath }}\""
+            positionals:
+              path:
+                describe: "Path to a project folder"
+            options:
+              initialUpload:
+                describe: "Upload directory before watching for updates"
           download:
             describe: "Download your project files from HubSpot and write to a path on your computer"
             examples:
@@ -621,10 +627,14 @@ en:
           destinationRequired: "A destination directory needs to be passed"
           invalidPath: "The \"{{ path }}\" is not a path to a directory"
         options:
-          disableInitial: "Disable the initial upload when watching a directory (default)"
-          initialUpload: "Upload directory before watching for updates"
-          notify: "Log to specified file when a watch task is triggered and after workers have gone idle. Ex. --notify path/to/file"
-          remove: "Will cause watch to delete files in your HubSpot account that are not found locally."
+          disableInitial:
+            describe: "Disable the initial upload when watching a directory (default)"
+          initialUpload:
+            describe: "Upload directory before watching for updates"
+          notify:
+            describe: "Log to specified file when a watch task is triggered and after workers have gone idle. Ex. --notify path/to/file"
+          remove:
+            describe: "Will cause watch to delete files in your HubSpot account that are not found locally."
         positionals:
           src:
             describe: "Path to the local directory your files are in, relative to your current working directory"

--- a/packages/cli/commands/project/watch.js
+++ b/packages/cli/commands/project/watch.js
@@ -72,7 +72,7 @@ const handleSigInt = (accountId, projectName, currentBuildId) => {
 exports.handler = async options => {
   await loadAndValidateOptions(options);
 
-  const { path: projectPath } = options;
+  const { initialUpload, path: projectPath } = options;
   const accountId = getAccountId(options);
 
   trackCommandUsage('project-watch', { projectPath }, accountId);
@@ -83,11 +83,12 @@ exports.handler = async options => {
 
   await ensureProjectExists(accountId, projectConfig.name);
 
-  const { results } = await fetchProjectBuilds(
+  const { results: builds } = await fetchProjectBuilds(
     accountId,
     projectConfig.name,
     options
   );
+  const hasNoBuilds = !builds || !builds.length;
 
   const startWatching = async () => {
     await createWatcher(
@@ -100,7 +101,7 @@ exports.handler = async options => {
   };
 
   // Upload all files if no build exists for this project yet
-  if (!results || !results.length) {
+  if (initialUpload || hasNoBuilds) {
     await handleProjectUpload(
       accountId,
       projectConfig,
@@ -114,8 +115,14 @@ exports.handler = async options => {
 
 exports.builder = yargs => {
   yargs.positional('path', {
-    describe: i18n(`${i18nKey}.describe`),
+    describe: i18n(`${i18nKey}.positionals.path.describe`),
     type: 'string',
+  });
+
+  yargs.option('initial-upload', {
+    alias: 'i',
+    describe: i18n(`${i18nKey}.options.initialUpload.describe`),
+    type: 'boolean',
   });
 
   yargs.example([


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
Adding the `--initial-upload` option for the `hs project watch` command.

Now there are two scenarios where the project watch command will run an upload before starting the watch.
1. There are no builds in the project yet
2. The user sets initial upload to true

The next step is to decide if this should default to true or false, but this should be a reasonable first step.

## Screenshots
<!-- Provide images of the before and after functionality -->
<img width="759" alt="image" src="https://user-images.githubusercontent.com/6654014/160193684-4b3c7d0a-9d14-40c3-b64d-7f22ffdf3981.png">

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
