### PR TITLE
Remove content type from GET request when fetching files

### DIFF
--- a/packages/cli-lib/http.js
+++ b/packages/cli-lib/http.js
@@ -145,7 +145,6 @@ const createGetRequestStream = ({ contentType }) => async (
         ...opts,
         headers: {
           ...headers,
-          'content-type': 'application/json',
           accept: contentType,
         },
         json: false,

--- a/packages/cli-lib/http.js
+++ b/packages/cli-lib/http.js
@@ -145,7 +145,7 @@ const createGetRequestStream = ({ contentType }) => async (
         ...opts,
         headers: {
           ...headers,
-          'content-type': contentType,
+          'content-type': 'application/json',
           accept: contentType,
         },
         json: false,


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
While investigating #659, which has since been fixed on the BE, I noticed that we're setting the content type for this GET request to be the same as the `accept` value. This means that we've been sending a `'content-type': 'application/octet-stream'` header. Since this is a get request, I think we can leave off the content type header altogether.

## Screenshots
<!-- Provide images of the before and after functionality -->

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
