### PR TITLE
Improve file upload failure handling

### DIFF
--- a/packages/cli-lib/index.js
+++ b/packages/cli-lib/index.js
@@ -16,7 +16,7 @@ const {
   writeConfig,
 } = require('./lib/config');
 const { checkAndWarnGitInclusion } = require('./lib/git');
-const { uploadFolder } = require('./lib/uploadFolder');
+const { hasUploadErrors, uploadFolder } = require('./lib/uploadFolder');
 const { watch } = require('./lib/watch');
 const { read } = require('./lib/read');
 const { walk } = require('./lib/walk');
@@ -37,6 +37,7 @@ module.exports = {
   getAccountId,
   getPortalConfig: getAccountConfig,
   getPortalId: getAccountId,
+  hasUploadErrors,
   updateAccountConfig,
   updatePortalConfig: updateAccountConfig,
   uploadFolder,

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -614,6 +614,7 @@ en:
           invalidExtension: "The file \"{{ path }}\" does not have a valid extension"
           invalidPath: "The path \"{{ path }}\" is not a path to a file or folder"
           uploadFailed: "Uploading file \"{{ src }}\" to \"{{ dest }}\" failed"
+          someFilesFailed: "One or more files failed to upload to \"{{ dest }}\" in the Design Manager"
         positionals:
           src:
             describe: "Path to the local file, relative to your current working directory."

--- a/packages/cli-lib/lib/uploadFolder.js
+++ b/packages/cli-lib/lib/uploadFolder.js
@@ -155,9 +155,8 @@ async function uploadFolder(accountId, src, dest, options) {
 }
 
 function hasUploadErrors(results) {
-  return (
-    results.filter(result => result.resultType === FileUploadResultType.FAILURE)
-      .length > 0
+  return results.some(
+    result => result.resultType === FileUploadResultType.FAILURE
   );
 }
 

--- a/packages/cli-lib/lib/uploadFolder.js
+++ b/packages/cli-lib/lib/uploadFolder.js
@@ -19,6 +19,11 @@ const {
   isFatalError,
 } = require('../errorHandlers');
 
+const FileUploadResultType = {
+  SUCCESS: 'SUCCESS',
+  FAILURE: 'FAILURE',
+};
+
 const queue = new PQueue({
   concurrency: 10,
 });
@@ -112,13 +117,18 @@ async function uploadFolder(accountId, src, dest, options) {
     await queue.addAll(filesToUpload.map(uploadFile));
   }
 
-  return queue.addAll(
+  const results = await queue.addAll(
     failures.map(({ file, destPath }) => {
       return async () => {
         logger.debug('Retrying to upload file "%s" to "%s"', file, destPath);
         try {
           await upload(accountId, file, destPath, apiOptions);
           logger.log('Uploaded file "%s" to "%s"', file, destPath);
+          return {
+            resultType: FileUploadResultType.SUCCESS,
+            error: null,
+            file,
+          };
         } catch (error) {
           logger.error('Uploading file "%s" to "%s" failed', file, destPath);
           if (isFatalError(error)) {
@@ -132,12 +142,27 @@ async function uploadFolder(accountId, src, dest, options) {
               payload: file,
             })
           );
+          return {
+            resultType: FileUploadResultType.FAILURE,
+            error,
+            file,
+          };
         }
       };
     })
   );
+  return results;
+}
+
+function hasUploadErrors(results) {
+  return (
+    results.filter(result => result.resultType === FileUploadResultType.FAILURE)
+      .length > 0
+  );
 }
 
 module.exports = {
+  hasUploadErrors,
+  FileUploadResultType,
   uploadFolder,
 };

--- a/packages/cli/commands/upload.js
+++ b/packages/cli/commands/upload.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 
-const { uploadFolder } = require('@hubspot/cli-lib');
+const { uploadFolder, hasUploadErrors } = require('@hubspot/cli-lib');
 const { getFileMapperQueryValues } = require('@hubspot/cli-lib/fileMapper');
 const { upload } = require('@hubspot/cli-lib/api/fileMapper');
 const {
@@ -163,13 +163,22 @@ exports.handler = async options => {
     uploadFolder(accountId, absoluteSrcPath, dest, {
       mode,
     })
-      .then(() => {
-        logger.success(
-          i18n(`${i18nKey}.success.uploadComplete`, {
-            dest,
-          })
-        );
-        logThemePreview(src, accountId);
+      .then(results => {
+        if (!hasUploadErrors(results)) {
+          logger.success(
+            i18n(`${i18nKey}.success.uploadComplete`, {
+              dest,
+            })
+          );
+          logThemePreview(src, accountId);
+        } else {
+          logger.error(
+            i18n(`${i18nKey}.errors.someFilesFailed`, {
+              dest,
+            })
+          );
+          process.exit(EXIT_CODES.ERROR);
+        }
       })
       .catch(error => {
         logger.error(

--- a/packages/cli/commands/upload.js
+++ b/packages/cli/commands/upload.js
@@ -150,6 +150,7 @@ exports.handler = async options => {
             payload: src,
           })
         );
+        process.exit(EXIT_CODES.ERROR);
       });
   } else {
     logger.log(
@@ -180,6 +181,7 @@ exports.handler = async options => {
         logErrorInstance(error, {
           accountId,
         });
+        process.exit(EXIT_CODES.ERROR);
       });
   }
 };

--- a/packages/cli/commands/upload.js
+++ b/packages/cli/commands/upload.js
@@ -55,7 +55,7 @@ exports.handler = async options => {
   await loadAndValidateOptions(options);
 
   if (!validateMode(options)) {
-    process.exit(EXIT_CODES.ERROR);
+    process.exit(EXIT_CODES.WARNING);
   }
 
   const accountId = getAccountId(options);
@@ -98,7 +98,7 @@ exports.handler = async options => {
 
   if (srcDestIssues.length) {
     srcDestIssues.forEach(({ message }) => logger.error(message));
-    process.exit(EXIT_CODES.ERROR);
+    process.exit(EXIT_CODES.WARNING);
   }
   if (stats.isFile()) {
     if (!isAllowedExtension(src)) {
@@ -150,7 +150,7 @@ exports.handler = async options => {
             payload: src,
           })
         );
-        process.exit(EXIT_CODES.ERROR);
+        process.exit(EXIT_CODES.WARNING);
       });
   } else {
     logger.log(
@@ -177,7 +177,7 @@ exports.handler = async options => {
               dest,
             })
           );
-          process.exit(EXIT_CODES.ERROR);
+          process.exit(EXIT_CODES.WARNING);
         }
       })
       .catch(error => {
@@ -190,7 +190,7 @@ exports.handler = async options => {
         logErrorInstance(error, {
           accountId,
         });
-        process.exit(EXIT_CODES.ERROR);
+        process.exit(EXIT_CODES.WARNING);
       });
   }
 };


### PR DESCRIPTION
## Description and Context

This PR treats any failure to upload a file as a failure of the `hs upload` command and uses the `WARNING` exit code so that scripts and other automated system detect the failures.

Fixes #626 

One thing that I wonder about is if we should also incorporate warnings as proposed in #531 — not in as command failures but into the output that is logged. In general, I think there is an opportunity to improve the output.

## Screenshots
Before:
<img width="1020" alt="image" src="https://user-images.githubusercontent.com/266036/162514530-adbd8d5f-81bb-401c-a8f8-7015314f0e1c.png">

After:
<img width="1027" alt="image" src="https://user-images.githubusercontent.com/266036/162514911-16a43149-2fc9-4b4a-98c3-417623300db2.png">

## Who to Notify
@anthmatic @miketalley @brandenrodgers @stephenandersondev @SteffenMahler
