### PR TITLE
Add prompt when users forget `hs project` command

### DIFF
--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -2,7 +2,7 @@ en:
   cli:
     commands:
       generalErrors:
-        srcIsProject: "\"{{ src }}\" is a project folder. Did you mean \"hs project {{command}}\"?"
+        srcIsProject: "\"{{ src }}\" is in a project folder. Did you mean \"hs project {{command}}\"?"
       accounts:
         describe: "Commands for working with accounts."
         subcommands:

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -2,7 +2,7 @@ en:
   cli:
     commands:
       generalErrors:
-        srcIsProject: "\"{{ src }}\" is a project folder. Please use a command with the \"hs project\" prefix."
+        srcIsProject: "\"{{ src }}\" is a project folder. Did you mean \"hs project {{command}}\"?"
       accounts:
         describe: "Commands for working with accounts."
         subcommands:

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -1,6 +1,8 @@
 en:
   cli:
     commands:
+      generalErrors:
+        srcIsProject: "\"{{ src }}\" is a project folder. Please use a command with the \"hs project\" prefix."
       accounts:
         describe: "Commands for working with accounts."
         subcommands:

--- a/packages/cli/bin/cli.js
+++ b/packages/cli/bin/cli.js
@@ -82,10 +82,7 @@ const argv = yargs
     type: 'boolean',
   })
   .check(argv => {
-    if (
-      argv._.length === 1 &&
-      (argv._.join(' ') === 'upload' || argv._.join(' ') === 'watch')
-    ) {
+    if (argv._.length === 1 && ['upload', 'watch'].includes(argv._[0])) {
       if (getIsInProject(argv.src)) {
         logger.error(
           i18n(`${i18nKey}.srcIsProject`, {

--- a/packages/cli/bin/cli.js
+++ b/packages/cli/bin/cli.js
@@ -82,12 +82,21 @@ const argv = yargs
     type: 'boolean',
   })
   .check(argv => {
-    if (getIsInProject(argv.src)) {
-      throw new Error(
-        i18n(`${i18nKey}.srcIsProject`, {
-          src: argv.src,
-        })
-      );
+    if (
+      argv._.length === 1 &&
+      (argv._.join(' ') === 'upload' || argv._.join(' ') === 'watch')
+    ) {
+      if (getIsInProject(argv.src)) {
+        logger.error(
+          i18n(`${i18nKey}.srcIsProject`, {
+            src: argv.src,
+            command: argv._.join(' '),
+          })
+        );
+        process.exit(EXIT_CODES.ERROR);
+      } else {
+        return true;
+      }
     } else {
       return true;
     }

--- a/packages/cli/lib/projects.js
+++ b/packages/cli/lib/projects.js
@@ -45,12 +45,12 @@ const writeProjectConfig = (configPath, config) => {
   }
 };
 
-const getIsInProject = async _dir => {
-  const configPath = await getProjectConfigPath(_dir);
+const getIsInProject = _dir => {
+  const configPath = getProjectConfigPath(_dir);
   return !!configPath;
 };
 
-const getProjectConfigPath = async _dir => {
+const getProjectConfigPath = _dir => {
   const projectDir = _dir ? path.resolve(getCwd(), _dir) : getCwd();
 
   const configPath = findup(PROJECT_CONFIG_FILE, {


### PR DESCRIPTION
## Description and Context
We would like to add a warning, when a customer attempts to run a command (like `hs watch`) on a project folder to remind them to run the correct project-specific command (like `hs project watch`). 

## Screenshots
Current (`hs upload` succeeds with a project folder)

![Screen Shot 2022-04-20 at 9 30 36 AM](https://user-images.githubusercontent.com/25392256/164241678-cec83ea3-acee-4084-82b7-bff5400047e2.png)

With these changes (`hs upload` errors out with a project folder)

![Screen Shot 2022-04-20 at 9 29 44 AM](https://user-images.githubusercontent.com/25392256/164241878-cefcf841-9448-4f7c-ad0b-427cad556277.png)

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->
1) I would love some feedback on the copy for the error. 

2) I think we'll just need to thoroughly test all the commands to ensure that we're not accidentally blocking any commands that we should run. 

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@brandenrodgers 
