### PR TITLE
Open projects page from CLI

### DIFF
--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -535,6 +535,14 @@ en:
             options:
               buildNumber:
                 describe: "The build number to download"
+          open:
+            describe: "Open available projects for the specified account"
+            options:
+              account:
+                describe: "View account projects"
+            examples:
+              default: "Opens the projects page for the specified account"
+            success: "Successfully opened projects for account id \"{{ accountId }}\""
       remove:
         describe: "Delete a file or folder from HubSpot."
         deleted: "Deleted \"{{ path }}\" from account {{ accountId }}"

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -538,11 +538,11 @@ en:
           open:
             describe: "Open available projects for the specified account"
             options:
-              account:
-                describe: "View account projects"
+              project:
+                describe: "Name of project to open"
             examples:
               default: "Opens the projects page for the specified account"
-            success: "Successfully opened projects for account id \"{{ accountId }}\""
+            success: "Successfully opened \"{{ projectName }}\""
       remove:
         describe: "Delete a file or folder from HubSpot."
         deleted: "Deleted \"{{ path }}\" from account {{ accountId }}"
@@ -743,5 +743,9 @@ en:
             invalidValue: "You entered an invalid value. Please try again."
         sandboxesPrompt:
           enterName: "Enter a name to use for the sandbox: "
+          errors:
+            invalidName: "You entered an invalid name. Please try again."
+        projectNamePrompt:
+          enterName: "Name of project you want to open: "
           errors:
             invalidName: "You entered an invalid name. Please try again."

--- a/packages/cli/commands/project.js
+++ b/packages/cli/commands/project.js
@@ -6,6 +6,7 @@ const listBuilds = require('./project/listBuilds');
 const logs = require('./project/logs');
 const watch = require('./project/watch');
 const download = require('./project/download');
+const open = require('./project/open');
 
 exports.command = 'project';
 exports.describe = false; //'Commands for working with projects';
@@ -22,6 +23,7 @@ exports.builder = yargs => {
   yargs.command(listBuilds).demandCommand(0, '');
   yargs.command(logs).demandCommand(1, '');
   yargs.command(download).demandCommand(0, '');
+  yargs.command(open).demandCommand(0, '');
 
   return yargs;
 };

--- a/packages/cli/commands/project/open.js
+++ b/packages/cli/commands/project/open.js
@@ -53,6 +53,7 @@ exports.handler = async options => {
   const url = getProjectDetailUrl(projectName, accountId);
   open(url, { url: true });
   logger.success(i18n(`${i18nKey}.success`, { projectName }));
+  process.exit(EXIT_CODES.SUCCESS);
 };
 
 exports.builder = yargs => {

--- a/packages/cli/commands/project/open.js
+++ b/packages/cli/commands/project/open.js
@@ -1,0 +1,52 @@
+const open = require('open');
+const { ENVIRONMENTS } = require('@hubspot/cli-lib/lib/constants');
+const {
+  addAccountOptions,
+  addConfigOptions,
+  getAccountId,
+  addUseEnvironmentOptions,
+  addTestingOptions,
+} = require('../../lib/commonOpts');
+const { loadAndValidateOptions } = require('../../lib/validation');
+const { i18n } = require('@hubspot/cli-lib/lib/lang');
+const { getHubSpotWebsiteOrigin } = require('@hubspot/cli-lib/lib/urls');
+const { logger } = require('@hubspot/cli-lib/logger');
+
+const i18nKey = 'cli.commands.project.subcommands.open';
+
+exports.command = 'open';
+exports.describe = i18n(`${i18nKey}.describe`);
+
+const openProjectPage = ({ env, accountId } = {}) => {
+  const websiteOrigin = getHubSpotWebsiteOrigin(env);
+  const url = `${websiteOrigin}/developer-projects/${accountId}`;
+  open(url, { url: true });
+};
+
+exports.handler = async options => {
+  await loadAndValidateOptions(options);
+
+  const accountId = getAccountId(options);
+
+  const env = options.qa ? ENVIRONMENTS.QA : ENVIRONMENTS.PROD;
+  openProjectPage({ env, accountId });
+  logger.success(i18n(`${i18nKey}.success`, { accountId }));
+};
+
+exports.builder = yargs => {
+  addConfigOptions(yargs, true);
+  addAccountOptions(yargs, true);
+  addUseEnvironmentOptions(yargs, true);
+  addTestingOptions(yargs, true);
+
+  yargs.options({
+    account: {
+      describe: i18n(`${i18nKey}.options.account.describe`),
+      type: 'string',
+    },
+  });
+
+  yargs.example([['$0 project open', i18n(`${i18nKey}.examples.default`)]]);
+
+  return yargs;
+};

--- a/packages/cli/lib/projects.js
+++ b/packages/cli/lib/projects.js
@@ -162,6 +162,26 @@ const validateProjectConfig = (projectConfig, projectDir) => {
   }
 };
 
+const verifyProjectExists = async (accountId, projectName) => {
+  try {
+    const project = await fetchProject(accountId, projectName);
+    if (project) {
+      return true;
+    }
+  } catch (err) {
+    if (err.statusCode === 404) {
+      logger.error(
+        `Your project ${chalk.bold(
+          projectName
+        )} could not be found in ${chalk.bold(accountId)}.`
+      );
+    } else {
+      logApiErrorInstance(err, new ApiErrorContext({ accountId }));
+    }
+    return false;
+  }
+};
+
 const ensureProjectExists = async (
   accountId,
   projectName,
@@ -523,4 +543,5 @@ module.exports = {
   pollBuildStatus,
   pollDeployStatus,
   ensureProjectExists,
+  verifyProjectExists,
 };

--- a/packages/cli/lib/projects.js
+++ b/packages/cli/lib/projects.js
@@ -162,33 +162,14 @@ const validateProjectConfig = (projectConfig, projectDir) => {
   }
 };
 
-const verifyProjectExists = async (accountId, projectName) => {
-  try {
-    const project = await fetchProject(accountId, projectName);
-    if (project) {
-      return true;
-    }
-  } catch (err) {
-    if (err.statusCode === 404) {
-      logger.error(
-        `Your project ${chalk.bold(
-          projectName
-        )} could not be found in ${chalk.bold(accountId)}.`
-      );
-    } else {
-      logApiErrorInstance(err, new ApiErrorContext({ accountId }));
-    }
-    return false;
-  }
-};
-
 const ensureProjectExists = async (
   accountId,
   projectName,
   { forceCreate = false, allowCreate = true } = {}
 ) => {
   try {
-    await fetchProject(accountId, projectName);
+    const project = await fetchProject(accountId, projectName);
+    return !!project;
   } catch (err) {
     if (err.statusCode === 404) {
       let shouldCreateProject = forceCreate;
@@ -213,14 +194,16 @@ const ensureProjectExists = async (
           return logApiErrorInstance(err, new ApiErrorContext({ accountId }));
         }
       } else {
-        return logger.log(
+        logger.log(
           `Your project ${chalk.bold(
             projectName
           )} could not be found in ${chalk.bold(accountId)}.`
         );
+        return false;
       }
     }
     logApiErrorInstance(err, new ApiErrorContext({ accountId }));
+    return false;
   }
 };
 
@@ -543,5 +526,4 @@ module.exports = {
   pollBuildStatus,
   pollDeployStatus,
   ensureProjectExists,
-  verifyProjectExists,
 };

--- a/packages/cli/lib/prompts/projectNamePrompt.js
+++ b/packages/cli/lib/prompts/projectNamePrompt.js
@@ -1,21 +1,27 @@
 const { promptUser } = require('./promptUtils');
 const { i18n } = require('@hubspot/cli-lib/lib/lang');
+const { ensureProjectExists } = require('../projects');
 
 const i18nKey = 'cli.lib.prompts.projectNamePrompt';
 
-const projectNamePrompt = () => {
-  return promptUser([
-    {
-      name: 'projectName',
-      message: i18n(`${i18nKey}.enterName`),
-      validate(val) {
-        if (typeof val !== 'string') {
-          return i18n(`${i18nKey}.errors.invalidName`);
-        }
-        return true;
-      },
+const projectNamePrompt = accountId => {
+  return promptUser({
+    name: 'projectName',
+    message: i18n(`${i18nKey}.enterName`),
+    validate: async val => {
+      if (typeof val !== 'string') {
+        return i18n(`${i18nKey}.errors.invalidName`);
+      }
+      const projectExists = await ensureProjectExists(accountId, val, {
+        allowCreate: false,
+      });
+
+      if (!projectExists) {
+        return false;
+      }
+      return true;
     },
-  ]);
+  });
 };
 
 module.exports = {

--- a/packages/cli/lib/prompts/projectNamePrompt.js
+++ b/packages/cli/lib/prompts/projectNamePrompt.js
@@ -1,0 +1,23 @@
+const { promptUser } = require('./promptUtils');
+const { i18n } = require('@hubspot/cli-lib/lib/lang');
+
+const i18nKey = 'cli.lib.prompts.projectNamePrompt';
+
+const projectNamePrompt = () => {
+  return promptUser([
+    {
+      name: 'projectName',
+      message: i18n(`${i18nKey}.enterName`),
+      validate(val) {
+        if (typeof val !== 'string') {
+          return i18n(`${i18nKey}.errors.invalidName`);
+        }
+        return true;
+      },
+    },
+  ]);
+};
+
+module.exports = {
+  projectNamePrompt,
+};


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->

- Adds a new command `hs projects open` that will open the projects page in a browser window for the default account
  - `const url = ${websiteOrigin}/developer-projects/${accountId};`
- User can specify QA for testing 
- User can use the `--account=` option to specify which account to open projects for

## Screenshots

<img width="535" alt="Screen Shot 2022-04-20 at 3 00 55 PM" src="https://user-images.githubusercontent.com/16788677/164303746-c961e719-53d0-4436-99d0-5ceb026c3771.png">

## Who to Notify
<!-- /cc those you wish to know about the PR -->

@brandenrodgers 
