### PR TITLE
Better fallbacks for `hs project deploy` command

### DIFF
--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -408,13 +408,13 @@ en:
               deploy: "Deploy error: {{ details }}"
               noBuildId: "No latest build ID was found."
             examples:
-              default: "Deploy a project within the myProjectFolder folder"
+              default: "Deploy the latest build of the current project"
+              withOptions: "Deploy build 5 of the project my-project"
             options:
               buildId:
                 describe: "Project build ID to be deployed"
-            positionals:
-              path:
-                describe: "Path to a project folder"
+              project:
+                describe: "Project name"
           logs:
             describe: "Get execution logs for a serverless function within a project"
             errors:
@@ -770,6 +770,7 @@ en:
           errors:
             invalidName: "You entered an invalid name. Please try again."
         projectNamePrompt:
-          enterName: "Name of project you want to open: "
+          enterName: "[--project] Enter project name:"
           errors:
             invalidName: "You entered an invalid name. Please try again."
+            projectDoesNotExist: "Project \"{{ projectName }}\" could not be found in \"{{ accountId }}\""

--- a/packages/cli/commands/project/open.js
+++ b/packages/cli/commands/project/open.js
@@ -6,6 +6,7 @@ const {
   addUseEnvironmentOptions,
   addTestingOptions,
 } = require('../../lib/commonOpts');
+const { trackCommandUsage } = require('../../lib/usageTracking');
 const { loadAndValidateOptions } = require('../../lib/validation');
 const { i18n } = require('@hubspot/cli-lib/lib/lang');
 const { logger } = require('@hubspot/cli-lib/logger');
@@ -27,6 +28,9 @@ exports.handler = async options => {
 
   const accountId = getAccountId(options);
   const { project } = options;
+
+  trackCommandUsage('project-open', { project }, accountId);
+
   const { projectConfig } = await getProjectConfig();
 
   let projectName = project;
@@ -42,7 +46,7 @@ exports.handler = async options => {
   } else if (!projectName && projectConfig) {
     projectName = projectConfig.name;
   } else if (!projectName && !projectConfig) {
-    const namePrompt = await projectNamePrompt(accountId, projectConfig);
+    const namePrompt = await projectNamePrompt(accountId);
 
     if (!namePrompt.projectName) {
       process.exit(EXIT_CODES.ERROR);

--- a/packages/cli/lib/projects.js
+++ b/packages/cli/lib/projects.js
@@ -165,7 +165,7 @@ const validateProjectConfig = (projectConfig, projectDir) => {
 const ensureProjectExists = async (
   accountId,
   projectName,
-  { forceCreate = false, allowCreate = true } = {}
+  { forceCreate = false, allowCreate = true, noLogs = false } = {}
 ) => {
   try {
     const project = await fetchProject(accountId, projectName);
@@ -194,11 +194,13 @@ const ensureProjectExists = async (
           return logApiErrorInstance(err, new ApiErrorContext({ accountId }));
         }
       } else {
-        logger.log(
-          `Your project ${chalk.bold(
-            projectName
-          )} could not be found in ${chalk.bold(accountId)}.`
-        );
+        if (!noLogs) {
+          logger.log(
+            `Your project ${chalk.bold(
+              projectName
+            )} could not be found in ${chalk.bold(accountId)}.`
+          );
+        }
         return false;
       }
     }

--- a/packages/cli/lib/prompts/projectNamePrompt.js
+++ b/packages/cli/lib/prompts/projectNamePrompt.js
@@ -4,20 +4,24 @@ const { ensureProjectExists } = require('../projects');
 
 const i18nKey = 'cli.lib.prompts.projectNamePrompt';
 
-const projectNamePrompt = accountId => {
+const projectNamePrompt = (accountId, options = {}) => {
   return promptUser({
     name: 'projectName',
     message: i18n(`${i18nKey}.enterName`),
+    when: !options.project,
     validate: async val => {
-      if (typeof val !== 'string') {
+      if (typeof val !== 'string' || !val) {
         return i18n(`${i18nKey}.errors.invalidName`);
       }
       const projectExists = await ensureProjectExists(accountId, val, {
         allowCreate: false,
+        noLogs: true,
       });
-
       if (!projectExists) {
-        return false;
+        return i18n(`${i18nKey}.errors.projectDoesNotExist`, {
+          projectName: val,
+          accountId,
+        });
       }
       return true;
     },


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
Some users are running `hs project deploy` while not in a project folder. This adds a fallback prompt to ask the user which project they'd like to deploy.

The order of precedence is:
1. The `project` option
2. The CWD project if there is one
3. We prompt for a project name

## Screenshots
**NOTE: These all failed because by default this command will attempt to deploy the most recent build. The most recent build was already deployed in my project, so the action fails.**

<!-- Provide images of the before and after functionality -->
**Without option and while not in a project folder**
<img width="686" alt="image" src="https://user-images.githubusercontent.com/6654014/166814270-07ad1c88-91a5-40f1-8da7-7f06138045f9.png">
**With option**
<img width="896" alt="image" src="https://user-images.githubusercontent.com/6654014/166814378-3b27de9d-0aa6-47d2-8863-c3317182dd11.png">
**Without option and while in a project folder**
<img width="709" alt="image" src="https://user-images.githubusercontent.com/6654014/166814507-945726d3-043b-4b11-96bb-875956d19989.png">

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
