### PR TITLE
Log useful account commands when user auths a new account

### DIFF
--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -40,6 +40,8 @@ en:
               defaultAccountUpdated: "Default account updated to \"{{ accountName }}\""
       auth:
         describe: "Configure authentication for a HubSpot account. Supported authentication protocols are {{ supportedProtocols }}."
+        logs:
+          setAsDefaultAccountPrompt: "Set this account as the default?"
         errors:
           accountNameExists: "Account name \"{{ name }}\" already exists, please enter a different name."
           noConfigFileFound: "No config file was found. To create a new config file, use the \"hs init\" command."
@@ -49,6 +51,7 @@ en:
             describe: "Authentication mechanism"
             defaultDescription: "\"{{ authMethod }}\": \nAn access token tied to a specific user account. This is the recommended way of authenticating with local development tools."
         success:
+          setAsDefaultAccount: "Account \"{{ accountName }}\" set as the default account"
           configFileUpdated: "Account \"{{ accountName }}\" updated in {{ configFilename }} using \"{{ authType }}\""
       config:
         describe: "Commands for working with the config file."
@@ -333,7 +336,7 @@ en:
             defaultDescription: "\"{{ defaultType }}\": \nAn access token tied to a specific user account. This is the recommended way of authenticating with local development tools."
         success:
           configFileCreated: "Created config file \"{{ configPath }}\""
-          configFileUpdated: "Connected account \"{{ account }}\" using \"{{ authType }}\"."
+          configFileUpdated: "Connected account \"{{ account }}\" using \"{{ authType }}\" and set it as the default account"
         logs:
           updateConfig: "To update an existing config file, use the \"hs auth\" command."
         errors:

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -41,10 +41,7 @@ en:
               defaultAccountUpdated: "Default account updated to \"{{ accountName }}\""
       auth:
         describe: "Configure authentication for a HubSpot account. Supported authentication protocols are {{ supportedProtocols }}."
-        logs:
-          setAsDefaultAccountPrompt: "Set this account as the default?"
         errors:
-          accountNameExists: "Account name \"{{ name }}\" already exists, please enter a different name."
           noConfigFileFound: "No config file was found. To create a new config file, use the \"hs init\" command."
           unsupportedAuthType: "Unsupported auth type: {{ type }}. The only supported authentication protocols are {{ supportedProtocols }}."
         positionals:
@@ -55,8 +52,6 @@ en:
           account:
             describe: "HubSpot account to authenticate"
         success:
-          setAsDefaultAccount: "Account \"{{ accountName }}\" set as the default account"
-          keepingCurrentDefault: "Account \"{{ accountName }}\" will continue to be the default account"
           configFileUpdated: "Account \"{{ accountName }}\" updated in {{ configFilename }} using \"{{ authType }}\""
       config:
         describe: "Commands for working with the config file."
@@ -563,7 +558,6 @@ en:
         subcommands:
           create:
             describe: "Create a sandbox account"
-            enterAccountName: "Enter a unique name to reference your account: "
             debug:
               creating: "Creating sandbox \"{{ name }}\""
             examples:
@@ -750,11 +744,21 @@ en:
           appName: "[--app] Select the app"
           functionName: "[--function] Enter the app function name:"
           endpointName: "[--endpoint] Enter the public endpoint path:"
+        setAsDefaultAccountPrompt:
+          setAsDefaultAccountMessage: "Set this account as the default?"
+          setAsDefaultAccount: "Account \"{{ accountName }}\" set as the default account"
+          keepingCurrentDefault: "Account \"{{ accountName }}\" will continue to be the default account"
+        enterAccountNamePrompt:
+          enterAccountName: "Enter a unique name to reference this account in the CLI:"
+          errors:
+            invalidName: "You entered an invalid name. Please try again."
+            nameRequired: "The name may not be blank. Please try again."
+            spacesInName: "The name may not contain spaces. Please try again."
+            accountNameExists: "Account name \"{{ name }}\" already exists, please enter a different name."
         personalAccessKeyPrompt:
           enterAccountId: "Enter the account ID for your account (the number under the DOMAIN column at https://app.hubspot.com/myaccounts-beta ): "
           enterClientId: "Enter your OAuth2 client ID: "
           enterClientSecret: "Enter your OAuth2 client secret: "
-          enterAccountName: "Enter a unique name to reference this account in the CLI:"
           enterApiKey: "Enter the API key for your account (found at https://app.hubspot.com/l/api-key): "
           enterPersonalAccessKey: "Enter your personal access key: "
           selectScopes: "Select access scopes (see https://developers.hubspot.com/docs/methods/oauth2/initiate-oauth-integration#scopes)"
@@ -766,7 +770,6 @@ en:
           errors:
             invalidAccountId: "You did not enter a valid account ID. Please try again."
             invalidAPIKey: "You did not enter a valid API key. Please try again"
-            invalidName: "You entered an invalid name. Please try again."
             invalidOauthClientId: "You entered an invalid OAuth2 client ID. Please try again."
             invalidOauthClientIdLength: "The OAuth2 client ID must be 36 characters long. Please try again."
             invalidOauthClientSecret: "You entered an invalid OAuth2 client secret. Please try again."
@@ -774,8 +777,6 @@ en:
             invalidOauthClientSecretCopy: "Please copy the actual OAuth2 client secret rather than the asterisks that mask it."
             invalidPersonalAccessKey: "You did not enter a valid access key. Please try again."
             invalidPersonalAccessKeyCopy: "Please copy the actual access key rather than the bullets that mask it."
-            nameRequired: "The name may not be blank. Please try again."
-            spacesInName: "The name may not contain spaces. Please try again."
         folderOverwritePrompt:
           overwriteConfirm: "The folder with name \"{{ folderName }}\" already exists. Overwrite?"
         createTemplatePrompt:

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -42,7 +42,7 @@ en:
       auth:
         describe: "Configure authentication for a HubSpot account. Supported authentication protocols are {{ supportedProtocols }}."
         logs:
-          setAsDefaultAccountPrompt: "Set this account as the default for CLI commands?"
+          setAsDefaultAccountPrompt: "Set this account as the default?"
         errors:
           accountNameExists: "Account name \"{{ name }}\" already exists, please enter a different name."
           noConfigFileFound: "No config file was found. To create a new config file, use the \"hs init\" command."

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -25,11 +25,11 @@ en:
             success:
               renamed: "Account \"{{ name }}\" renamed to \"{{ newName }}\""
           use:
-            describe: "Change default account in config"
+            describe: "Set the Hubspot account to use as the default account. The default account can be overridden with the \"--account\" option."
             errors:
               accountNotFound: "The account \"{{ specifiedAccount }}\" could not be found in {{ configPath }}"
             examples:
-              default: "Select account to use as the default from a list"
+              default: "Select a HubSpot account to use as the default account"
               idBased: "Set the default account to the account in the config with accountId equal to \"1234567\""
               nameBased: "Set the default account to the account in the config with name equal to \"MyAccount\""
             positionals:
@@ -676,14 +676,33 @@ en:
         featureHighlight:
           defaultTitle: "What's next?"
           commandKeys:
-            help: "Run `hs --help` to see a list of available commands"
-            auth: "Run `hs auth` to connect the CLI to additional HubSpot accounts"
-            accountsUse: "Run `hs accounts use` to easily switch between accounts"
-            accountsList: "Run `hs accounts list` to see a list of configured HubSpot accounts"
-            create: "🎨 Add components to your project with `hs create`"
-            projectUpload: "🏗  Run `hs project upload` to upload your files to HubSpot and trigger builds"
-            projectDeploy: "🚀 Ready to take your project live? Run `hs project deploy`"
-            projectHelp: "🔗 Use `hs project --help` to learn more about available commands"
+            accountOption:
+              command: "--account"
+              message: "Use the {{ command }} option with any command to override the default account"
+            accountsListCommand:
+              command: hs accounts list
+              message: "Run {{ command }} to see a list of configured HubSpot accounts"
+            accountsUseCommand:
+              command: "hs accounts use"
+              message: "Run {{ command }} to set the Hubspot account that the CLI will target by default"
+            authCommand:
+              command: "hs auth"
+              message: "Run {{ command }} to connect the CLI to additional HubSpot accounts"
+            createCommand:
+              command: "hs create"
+              message: "Add new components to your project with {{ command }}"
+            helpCommand:
+              command: "hs --help"
+              message: "Run {{ command }} to see a list of available commands"
+            projectDeployCommand:
+              command: "hs project deploy"
+              message: "Ready to take your project live? Run {{ command }}"
+            projectHelpCommand:
+              command: "hs project --help"
+              message: "Run {{ command }} to learn more about available project commands"
+            projectUploadCommand:
+              command: "hs project upload"
+              message: "Run {{ command }} to upload your project to HubSpot and trigger builds"
       commonOpts:
         options:
           portal:
@@ -721,7 +740,8 @@ en:
           enterApiKey: "Enter the API key for your account (found at https://app.hubspot.com/l/api-key): "
           enterPersonalAccessKey: "Enter your personal access key: "
           selectScopes: "Select access scopes (see https://developers.hubspot.com/docs/methods/oauth2/initiate-oauth-integration#scopes)"
-          personalAccessKeyBrowserOpenPrep: "When you're ready, we'll open a secure page in your default browser where you can view and copy your personal access key, which you'll need to complete the next step.\n<Press enter to open the page and generate your personal access key>"
+          personalAccessKeySetupTitle: "HubSpot Personal Access Key Setup"
+          personalAccessKeyBrowserOpenPrep: "When you're ready, we'll open a secure page in your default browser where you can view and copy your personal access key, which you'll need to complete the next step."
           logs:
             openingWebBrowser: "Opening {{ url }} in your web browser"
           errors:

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -40,9 +40,6 @@ en:
               defaultAccountUpdated: "Default account updated to \"{{ accountName }}\""
       auth:
         describe: "Configure authentication for a HubSpot account. Supported authentication protocols are {{ supportedProtocols }}."
-        logs:
-          acccountsUseHelp: "Run `hs accounts use` to easily switch between accounts"
-          acccountsListHelp: "Try `hs accounts list` to see a list of configured HubSpot accounts"
         errors:
           accountNameExists: "Account name \"{{ name }}\" already exists, please enter a different name."
           noConfigFileFound: "No config file was found. To create a new config file, use the \"hs init\" command."
@@ -52,7 +49,7 @@ en:
             describe: "Authentication mechanism"
             defaultDescription: "\"{{ authMethod }}\": \nAn access token tied to a specific user account. This is the recommended way of authenticating with local development tools."
         success:
-          configFileUpdated: "{{ accountName }} updated in {{ configFilename }} with {{ authType }}"
+          configFileUpdated: "Account \"{{ accountName }}\" updated in {{ configFilename }} using \"{{ authType }}\""
       config:
         describe: "Commands for working with the config file."
         subcommands:
@@ -335,8 +332,9 @@ en:
             describe: "Specify auth method to use [\"personalaccesskey\", \"oauth2\", \"apikey\"]"
             defaultDescription: "\"{{ defaultType }}\": \nAn access token tied to a specific user account. This is the recommended way of authenticating with local development tools."
         success:
-          configFileCreated: "The config file \"{{ configPath }}\" was created using \"{{ authType }}\" for account {{ account }}."
-        info:
+          configFileCreated: "Created config file \"{{ configPath }}\""
+          configFileUpdated: "Connected account \"{{ account }}\" using \"{{ authType }}\"."
+        logs:
           updateConfig: "To update an existing config file, use the \"hs auth\" command."
         errors:
           configFileExists: "The config file {{ configPath }} already exists."
@@ -674,6 +672,18 @@ en:
           initialUpload: "To upload the directory run \"hs upload\" beforehand or add the \"--initial-upload\" option when running \"hs watch\"."
           notUploaded: "The \"hs watch\" command no longer uploads the watched directory when started. The directory \"{{ path }}\" was not uploaded."
     lib:
+      ui:
+        featureHighlight:
+          defaultTitle: "What's next?"
+          commandKeys:
+            help: "Run `hs --help` to see a list of available commands"
+            auth: "Run `hs auth` to connect the CLI to additional HubSpot accounts"
+            accountsUse: "Run `hs accounts use` to easily switch between accounts"
+            accountsList: "Run `hs accounts list` to see a list of configured HubSpot accounts"
+            create: "🎨 Add components to your project with `hs create`"
+            projectUpload: "🏗  Run `hs project upload` to upload your files to HubSpot and trigger builds"
+            projectDeploy: "🚀 Ready to take your project live? Run `hs project deploy`"
+            projectHelp: "🔗 Use `hs project --help` to learn more about available commands"
       commonOpts:
         options:
           portal:

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -397,6 +397,8 @@ en:
         subcommands:
           create:
             describe: "Create a new project"
+            logs:
+              welcomeMessage: "Welcome to HubSpot Developer Projects!"
             examples:
               default: "Create a new project"
             options:

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -40,6 +40,9 @@ en:
               defaultAccountUpdated: "Default account updated to \"{{ accountName }}\""
       auth:
         describe: "Configure authentication for a HubSpot account. Supported authentication protocols are {{ supportedProtocols }}."
+        logs:
+          acccountsUseHelp: "Run `hs accounts use` to easily switch between accounts"
+          acccountsListHelp: "Try `hs accounts list` to see a list of configured HubSpot accounts"
         errors:
           accountNameExists: "Account name \"{{ name }}\" already exists, please enter a different name."
           noConfigFileFound: "No config file was found. To create a new config file, use the \"hs init\" command."
@@ -49,7 +52,7 @@ en:
             describe: "Authentication mechanism"
             defaultDescription: "\"{{ authMethod }}\": \nAn access token tied to a specific user account. This is the recommended way of authenticating with local development tools."
         success:
-          configFileUpdated: "{{ configFilename }} updated with {{ authMethod }}."
+          configFileUpdated: "{{ accountName }} updated in {{ configFilename }} with {{ authType }}"
       config:
         describe: "Commands for working with the config file."
         subcommands:

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -42,7 +42,7 @@ en:
       auth:
         describe: "Configure authentication for a HubSpot account. Supported authentication protocols are {{ supportedProtocols }}."
         logs:
-          setAsDefaultAccountPrompt: "Set this account as the default?"
+          setAsDefaultAccountPrompt: "Set this account as the default for CLI commands?"
         errors:
           accountNameExists: "Account name \"{{ name }}\" already exists, please enter a different name."
           noConfigFileFound: "No config file was found. To create a new config file, use the \"hs init\" command."
@@ -746,7 +746,7 @@ en:
           enterAccountId: "Enter the account ID for your account (the number under the DOMAIN column at https://app.hubspot.com/myaccounts-beta ): "
           enterClientId: "Enter your OAuth2 client ID: "
           enterClientSecret: "Enter your OAuth2 client secret: "
-          enterAccountName: "Enter a unique name to reference your account: "
+          enterAccountName: "Enter a unique name to reference this account in the CLI:"
           enterApiKey: "Enter the API key for your account (found at https://app.hubspot.com/l/api-key): "
           enterPersonalAccessKey: "Enter your personal access key: "
           selectScopes: "Select access scopes (see https://developers.hubspot.com/docs/methods/oauth2/initiate-oauth-integration#scopes)"

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -56,6 +56,7 @@ en:
             describe: "HubSpot account to authenticate"
         success:
           setAsDefaultAccount: "Account \"{{ accountName }}\" set as the default account"
+          keepingCurrentDefault: "Account \"{{ accountName }}\" will continue to be the default account"
           configFileUpdated: "Account \"{{ accountName }}\" updated in {{ configFilename }} using \"{{ authType }}\""
       config:
         describe: "Commands for working with the config file."
@@ -701,7 +702,7 @@ en:
               command: "hs create"
               message: "Add new components to your project with {{ command }}"
             helpCommand:
-              command: "hs --help"
+              command: "hs help"
               message: "Run {{ command }} to see a list of available commands"
             projectDeployCommand:
               command: "hs project deploy"
@@ -750,7 +751,8 @@ en:
           enterPersonalAccessKey: "Enter your personal access key: "
           selectScopes: "Select access scopes (see https://developers.hubspot.com/docs/methods/oauth2/initiate-oauth-integration#scopes)"
           personalAccessKeySetupTitle: "HubSpot Personal Access Key Setup"
-          personalAccessKeyBrowserOpenPrep: "When you're ready, we'll open a secure page in your default browser where you can view and copy your personal access key, which you'll need to complete the next step."
+          personalAccessKeyBrowserOpenPrep: "A personal access key is required to authenticate the CLI to interact with your HubSpot account. We'll open a secure page in your default browser where you can view and copy your personal access key."
+          personalAccessKeyBrowserOpenPrompt: "Open hubspot.com to copy your personal access key?"
           logs:
             openingWebBrowser: "Opening {{ url }} in your web browser"
           errors:

--- a/packages/cli/bin/cli.js
+++ b/packages/cli/bin/cli.js
@@ -59,7 +59,7 @@ const getTerminalWidth = () => {
 };
 
 const argv = yargs
-  .usage('Tools for working with HubSpot')
+  .usage('The command line interface to interact with HubSpot.')
   .middleware([setLogLevel])
   .exitProcess(false)
   .fail((msg, err, yargs) => {

--- a/packages/cli/commands/auth.js
+++ b/packages/cli/commands/auth.js
@@ -88,7 +88,6 @@ const promptToSetDefaultAccount = async accountName => {
 };
 
 exports.command = 'auth [type] [--account]';
-
 exports.describe = i18n(`${i18nKey}.describe`, {
   supportedProtocols: SUPPORTED_AUTHENTICATION_PROTOCOLS_TEXT,
 });
@@ -182,6 +181,13 @@ exports.handler = async options => {
     logger.success(
       i18n(`${i18nKey}.success.setAsDefaultAccount`, {
         accountName,
+      })
+    );
+  } else {
+    const config = getConfig();
+    logger.info(
+      i18n(`${i18nKey}.success.keepingCurrentDefault`, {
+        accountName: config.defaultPortal,
       })
     );
   }

--- a/packages/cli/commands/auth.js
+++ b/packages/cli/commands/auth.js
@@ -160,7 +160,11 @@ exports.handler = async options => {
       accountName: updatedConfig.name,
     })
   );
-  uiFeatureHighlight(['accountsUse', 'accountsList']);
+  uiFeatureHighlight([
+    'accountsUseCommand',
+    'accountOption',
+    'accountsListCommand',
+  ]);
 
   process.exit(EXIT_CODES.SUCCESS);
 };

--- a/packages/cli/commands/auth.js
+++ b/packages/cli/commands/auth.js
@@ -34,7 +34,7 @@ const { logDebugInfo } = require('../lib/debugInfo');
 const { trackCommandUsage } = require('../lib/usageTracking');
 const { authenticateWithOauth } = require('../lib/oauth');
 const { EXIT_CODES } = require('../lib/enums/exitCodes');
-const { uiLine } = require('../lib/ui');
+const { uiFeatureHighlight } = require('../lib/ui');
 
 const i18nKey = 'cli.commands.auth';
 
@@ -152,7 +152,7 @@ exports.handler = async options => {
     process.exit(EXIT_CODES.ERROR);
   }
 
-  uiLine();
+  logger.log('');
   logger.success(
     i18n(`${i18nKey}.success.configFileUpdated`, {
       configFilename: DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME,
@@ -160,12 +160,7 @@ exports.handler = async options => {
       accountName: updatedConfig.name,
     })
   );
-  logger.log('');
-  logger.log(i18n(`${i18nKey}.logs.acccountsUseHelp`));
-  logger.log('');
-  logger.log(i18n(`${i18nKey}.logs.acccountsListHelp`));
-  logger.log('');
-  uiLine();
+  uiFeatureHighlight(['accountsUse', 'accountsList']);
 
   process.exit(EXIT_CODES.SUCCESS);
 };

--- a/packages/cli/commands/init.js
+++ b/packages/cli/commands/init.js
@@ -137,7 +137,7 @@ exports.handler = async options => {
         account: name || accountId,
       })
     );
-    uiFeatureHighlight(['help', 'auth', 'accountsList']);
+    uiFeatureHighlight(['helpCommand', 'authCommand', 'accountsListCommand']);
 
     trackAuthAction('init', authType, TRACKING_STATUS.COMPLETE, accountId);
     process.exit(EXIT_CODES.SUCCESS);

--- a/packages/cli/commands/init.js
+++ b/packages/cli/commands/init.js
@@ -30,9 +30,11 @@ const { promptUser } = require('../lib/prompts/promptUtils');
 const {
   OAUTH_FLOW,
   API_KEY_FLOW,
-  ACCOUNT_NAME,
   personalAccessKeyPrompt,
 } = require('../lib/prompts/personalAccessKeyPrompt');
+const {
+  enterAccountNamePrompt,
+} = require('../lib/prompts/enterAccountNamePrompt');
 const { logDebugInfo } = require('../lib/debugInfo');
 const { authenticateWithOauth } = require('../lib/oauth');
 const { EXIT_CODES } = require('../lib/enums/exitCodes');
@@ -48,7 +50,7 @@ const TRACKING_STATUS = {
 
 const personalAccessKeyConfigCreationFlow = async (env, account) => {
   const configData = await personalAccessKeyPrompt({ env, account });
-  const { name } = await promptUser([ACCOUNT_NAME]);
+  const { name } = await enterAccountNamePrompt();
   const accountConfig = {
     ...configData,
     name,

--- a/packages/cli/commands/init.js
+++ b/packages/cli/commands/init.js
@@ -36,6 +36,7 @@ const {
 const { logDebugInfo } = require('../lib/debugInfo');
 const { authenticateWithOauth } = require('../lib/oauth');
 const { EXIT_CODES } = require('../lib/enums/exitCodes');
+const { uiFeatureHighlight } = require('../lib/ui');
 
 const i18nKey = 'cli.commands.init';
 
@@ -85,6 +86,12 @@ const CONFIG_CREATION_FLOWS = {
   [API_KEY_AUTH_METHOD.value]: apiKeyConfigCreationFlow,
 };
 
+const AUTH_TYPE_NAMES = {
+  [PERSONAL_ACCESS_KEY_AUTH_METHOD.value]: PERSONAL_ACCESS_KEY_AUTH_METHOD.name,
+  [OAUTH_AUTH_METHOD.value]: OAUTH_AUTH_METHOD.name,
+  [API_KEY_AUTH_METHOD.value]: API_KEY_AUTH_METHOD.name,
+};
+
 exports.command = 'init';
 exports.describe = i18n(`${i18nKey}.describe`, {
   configName: DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME,
@@ -106,7 +113,7 @@ exports.handler = async options => {
         configPath,
       })
     );
-    logger.info(i18n(`${i18nKey}.info.updateConfig`));
+    logger.info(i18n(`${i18nKey}.logs.updateConfig`));
     process.exit(EXIT_CODES.ERROR);
   }
 
@@ -118,13 +125,19 @@ exports.handler = async options => {
     const { accountId, name } = await CONFIG_CREATION_FLOWS[authType](env);
     const configPath = getConfigPath();
 
+    logger.log('');
     logger.success(
       i18n(`${i18nKey}.success.configFileCreated`, {
         configPath,
-        authType,
+      })
+    );
+    logger.success(
+      i18n(`${i18nKey}.success.configFileUpdated`, {
+        authType: AUTH_TYPE_NAMES[authType],
         account: name || accountId,
       })
     );
+    uiFeatureHighlight(['help', 'auth', 'accountsList']);
 
     trackAuthAction('init', authType, TRACKING_STATUS.COMPLETE, accountId);
     process.exit(EXIT_CODES.SUCCESS);

--- a/packages/cli/commands/project/create.js
+++ b/packages/cli/commands/project/create.js
@@ -8,14 +8,14 @@ const { trackCommandUsage } = require('../../lib/usageTracking');
 const { loadAndValidateOptions } = require('../../lib/validation');
 const { getCwd } = require('@hubspot/cli-lib/path');
 const path = require('path');
+const chalk = require('chalk');
 const {
   createProjectPrompt,
 } = require('../../lib/prompts/createProjectPrompt');
-const {
-  createProjectConfig,
-  showProjectWelcomeMessage,
-} = require('../../lib/projects');
+const { createProjectConfig } = require('../../lib/projects');
 const { i18n } = require('@hubspot/cli-lib/lib/lang');
+const { uiLine } = require('../../lib/ui');
+const { logger } = require('@hubspot/cli-lib/logger');
 
 const i18nKey = 'cli.commands.project.subcommands.create';
 
@@ -37,7 +37,21 @@ exports.handler = async options => {
     options.template || template
   );
 
-  showProjectWelcomeMessage();
+  logger.log('');
+  logger.log(chalk.bold('Welcome to HubSpot Developer Projects!'));
+  uiLine();
+  logger.log(chalk.bold("What's next?\n"));
+  logger.log('🎨 Add components to your project with `hs create`.\n');
+  logger.log(
+    `🏗  Run \`hs project upload\` to upload your files to HubSpot and trigger builds.\n`
+  );
+  logger.log(
+    `🚀 Ready to take your project live? Run \`hs project deploy\`.\n`
+  );
+  logger.log(
+    `🔗 Use \`hs project --help\` to learn more about available commands.\n`
+  );
+  uiLine();
 };
 
 exports.builder = yargs => {

--- a/packages/cli/commands/project/create.js
+++ b/packages/cli/commands/project/create.js
@@ -38,7 +38,7 @@ exports.handler = async options => {
   );
 
   logger.log('');
-  logger.log(chalk.bold('Welcome to HubSpot Developer Projects!'));
+  logger.log(chalk.bold(i18n(`${i18nKey}.logs.welcomeMessage`)));
   uiFeatureHighlight([
     'createCommand',
     'projectUploadCommand',

--- a/packages/cli/commands/project/create.js
+++ b/packages/cli/commands/project/create.js
@@ -14,7 +14,7 @@ const {
 } = require('../../lib/prompts/createProjectPrompt');
 const { createProjectConfig } = require('../../lib/projects');
 const { i18n } = require('@hubspot/cli-lib/lib/lang');
-const { uiLine } = require('../../lib/ui');
+const { uiFeatureHighlight } = require('../../lib/ui');
 const { logger } = require('@hubspot/cli-lib/logger');
 
 const i18nKey = 'cli.commands.project.subcommands.create';
@@ -39,19 +39,12 @@ exports.handler = async options => {
 
   logger.log('');
   logger.log(chalk.bold('Welcome to HubSpot Developer Projects!'));
-  uiLine();
-  logger.log(chalk.bold("What's next?\n"));
-  logger.log('🎨 Add components to your project with `hs create`.\n');
-  logger.log(
-    `🏗  Run \`hs project upload\` to upload your files to HubSpot and trigger builds.\n`
-  );
-  logger.log(
-    `🚀 Ready to take your project live? Run \`hs project deploy\`.\n`
-  );
-  logger.log(
-    `🔗 Use \`hs project --help\` to learn more about available commands.\n`
-  );
-  uiLine();
+  uiFeatureHighlight([
+    'create',
+    'projectUpload',
+    'projectDeploy',
+    'projectHelp',
+  ]);
 };
 
 exports.builder = yargs => {

--- a/packages/cli/commands/project/create.js
+++ b/packages/cli/commands/project/create.js
@@ -40,10 +40,10 @@ exports.handler = async options => {
   logger.log('');
   logger.log(chalk.bold('Welcome to HubSpot Developer Projects!'));
   uiFeatureHighlight([
-    'create',
-    'projectUpload',
-    'projectDeploy',
-    'projectHelp',
+    'createCommand',
+    'projectUploadCommand',
+    'projectDeployCommand',
+    'projectHelpCommand',
   ]);
 };
 

--- a/packages/cli/lib/projects.js
+++ b/packages/cli/lib/projects.js
@@ -324,26 +324,6 @@ const handleProjectUpload = async (
   archive.finalize();
 };
 
-const showProjectWelcomeMessage = () => {
-  logger.log('');
-  logger.log(chalk.bold('Welcome to HubSpot Developer Projects!'));
-  logger.log('\n');
-  uiLine();
-  logger.log('\n');
-  logger.log(chalk.bold("What's next?\n"));
-  logger.log('🎨 Add components to your project with `hs create`.\n');
-  logger.log(
-    `🏗  Run \`hs project upload\` to upload your files to HubSpot and trigger builds.\n`
-  );
-  logger.log(
-    `🚀 Ready to take your project live? Run \`hs project deploy\`.\n`
-  );
-  logger.log(
-    `🔗 Use \`hs project --help\` to learn more about available commands.\n`
-  );
-  uiLine();
-};
-
 const makePollTaskStatusFunc = ({
   statusFn,
   statusText,
@@ -519,7 +499,6 @@ module.exports = {
   handleProjectUpload,
   createProjectConfig,
   validateProjectConfig,
-  showProjectWelcomeMessage,
   getProjectDetailUrl,
   getProjectBuildDetailUrl,
   pollBuildStatus,

--- a/packages/cli/lib/prompts/enterAccountNamePrompt.js
+++ b/packages/cli/lib/prompts/enterAccountNamePrompt.js
@@ -1,0 +1,33 @@
+const { accountNameExistsInConfig } = require('@hubspot/cli-lib/lib/config');
+const { STRING_WITH_NO_SPACES_REGEX } = require('../regex');
+const { promptUser } = require('./promptUtils');
+const { i18n } = require('@hubspot/cli-lib/lib/lang');
+
+const i18nKey = 'cli.lib.prompts.enterAccountNamePrompt';
+
+const accountNamePrompt = defaultName => ({
+  name: 'name',
+  message: i18n(`${i18nKey}.enterAccountName`),
+  default: defaultName,
+  validate(val) {
+    if (typeof val !== 'string') {
+      return i18n(`${i18nKey}.errors.invalidName`);
+    } else if (!val.length) {
+      return i18n(`${i18nKey}.errors.nameRequired`);
+    } else if (!STRING_WITH_NO_SPACES_REGEX.test(val)) {
+      return i18n(`${i18nKey}.errors.spacesInName`);
+    }
+    return accountNameExistsInConfig(val)
+      ? i18n(`${i18nKey}.errors.accountNameExists`, { name: val })
+      : true;
+  },
+});
+
+const enterAccountNamePrompt = defaultName => {
+  return promptUser(accountNamePrompt(defaultName));
+};
+
+module.exports = {
+  accountNamePrompt,
+  enterAccountNamePrompt,
+};

--- a/packages/cli/lib/prompts/personalAccessKeyPrompt.js
+++ b/packages/cli/lib/prompts/personalAccessKeyPrompt.js
@@ -3,6 +3,7 @@ const {
   OAUTH_SCOPES,
   DEFAULT_OAUTH_SCOPES,
 } = require('@hubspot/cli-lib/lib/constants');
+const { deleteEmptyConfigFile } = require('@hubspot/cli-lib/lib/config');
 const { getHubSpotWebsiteOrigin } = require('@hubspot/cli-lib/lib/urls');
 const { logger } = require('@hubspot/cli-lib/logger');
 const { API_KEY_REGEX, STRING_WITH_NO_SPACES_REGEX } = require('../regex');
@@ -31,6 +32,7 @@ const personalAccessKeyPrompt = async ({ env } = {}) => {
     if (shouldOpen) {
       open(url, { url: true });
     } else {
+      deleteEmptyConfigFile();
       process.exit(EXIT_CODES.SUCCESS);
     }
   }

--- a/packages/cli/lib/prompts/personalAccessKeyPrompt.js
+++ b/packages/cli/lib/prompts/personalAccessKeyPrompt.js
@@ -6,8 +6,9 @@ const {
 const { deleteEmptyConfigFile } = require('@hubspot/cli-lib/lib/config');
 const { getHubSpotWebsiteOrigin } = require('@hubspot/cli-lib/lib/urls');
 const { logger } = require('@hubspot/cli-lib/logger');
-const { API_KEY_REGEX, STRING_WITH_NO_SPACES_REGEX } = require('../regex');
+const { API_KEY_REGEX } = require('../regex');
 const { promptUser } = require('./promptUtils');
+const { accountNamePrompt } = require('./enterAccountNamePrompt');
 const { i18n } = require('@hubspot/cli-lib/lib/lang');
 const { uiInfoSection } = require('../ui');
 const { EXIT_CODES } = require('../enums/exitCodes');
@@ -88,21 +89,6 @@ const CLIENT_SECRET = {
   },
 };
 
-const ACCOUNT_NAME = {
-  name: 'name',
-  message: i18n(`${i18nKey}.enterAccountName`),
-  validate(val) {
-    if (typeof val !== 'string') {
-      return i18n(`${i18nKey}.errors.invalidName`);
-    } else if (!val.length) {
-      return i18n(`${i18nKey}.errors.nameRequired`);
-    } else if (!STRING_WITH_NO_SPACES_REGEX.test(val)) {
-      return i18n(`${i18nKey}.errors.spacesInName`);
-    }
-    return true;
-  },
-};
-
 const ACCOUNT_API_KEY = {
   name: 'apiKey',
   message: i18n(`${i18nKey}.enterApiKey`),
@@ -149,8 +135,14 @@ const SCOPES = {
   choices: OAUTH_SCOPES,
 };
 
-const OAUTH_FLOW = [ACCOUNT_NAME, ACCOUNT_ID, CLIENT_ID, CLIENT_SECRET, SCOPES];
-const API_KEY_FLOW = [ACCOUNT_NAME, ACCOUNT_ID, ACCOUNT_API_KEY];
+const OAUTH_FLOW = [
+  accountNamePrompt(),
+  ACCOUNT_ID,
+  CLIENT_ID,
+  CLIENT_SECRET,
+  SCOPES,
+];
+const API_KEY_FLOW = [accountNamePrompt(), ACCOUNT_ID, ACCOUNT_API_KEY];
 
 module.exports = {
   personalAccessKeyPrompt,
@@ -158,10 +150,8 @@ module.exports = {
   CLIENT_SECRET,
   ACCOUNT_API_KEY,
   ACCOUNT_ID,
-  ACCOUNT_NAME,
   SCOPES,
   PERSONAL_ACCESS_KEY,
-
   // Flows
   API_KEY_FLOW,
   OAUTH_FLOW,

--- a/packages/cli/lib/prompts/personalAccessKeyPrompt.js
+++ b/packages/cli/lib/prompts/personalAccessKeyPrompt.js
@@ -117,7 +117,7 @@ const ACCOUNT_API_KEY = {
 const PERSONAL_ACCESS_KEY_BROWSER_OPEN_PREP = {
   name: 'personalAcessKeyBrowserOpenPrep',
   type: 'confirm',
-  message: 'Continue to open page and generate your personal access key?',
+  message: i18n(`${i18nKey}.personalAccessKeyBrowserOpenPrompt`),
 };
 
 const PERSONAL_ACCESS_KEY = {

--- a/packages/cli/lib/prompts/personalAccessKeyPrompt.js
+++ b/packages/cli/lib/prompts/personalAccessKeyPrompt.js
@@ -118,8 +118,15 @@ const PERSONAL_ACCESS_KEY_BROWSER_OPEN_PREP = {
 
 const PERSONAL_ACCESS_KEY = {
   name: 'personalAccessKey',
-  type: 'password',
   message: i18n(`${i18nKey}.enterPersonalAccessKey`),
+  transformer: val => {
+    if (!val) return val;
+    let res = '';
+    for (let i = 0; i < val.length; i++) {
+      res += '*';
+    }
+    return res;
+  },
   validate(val) {
     if (!val || typeof val !== 'string') {
       return i18n(`${i18nKey}.errors.invalidPersonalAccessKey`);

--- a/packages/cli/lib/prompts/setAsDefaultAccountPrompt.js
+++ b/packages/cli/lib/prompts/setAsDefaultAccountPrompt.js
@@ -1,0 +1,30 @@
+const {
+  getConfig,
+  updateDefaultAccount,
+} = require('@hubspot/cli-lib/lib/config');
+const { promptUser } = require('./promptUtils');
+const { i18n } = require('@hubspot/cli-lib/lib/lang');
+
+const i18nKey = 'cli.lib.prompts.setAsDefaultAccountPrompt';
+
+const setAsDefaultAccountPrompt = async accountName => {
+  const config = getConfig();
+
+  const { setAsDefault } = await promptUser([
+    {
+      name: 'setAsDefault',
+      type: 'confirm',
+      when: config.defaultPortal !== accountName,
+      message: i18n(`${i18nKey}.setAsDefaultAccountMessage`),
+    },
+  ]);
+
+  if (setAsDefault) {
+    updateDefaultAccount(accountName);
+  }
+  return setAsDefault;
+};
+
+module.exports = {
+  setAsDefaultAccountPrompt,
+};

--- a/packages/cli/lib/ui.js
+++ b/packages/cli/lib/ui.js
@@ -66,22 +66,36 @@ const uiAccountDescription = accountId => {
   );
 };
 
-const uiFeatureHighlight = (commands, title) => {
-  const i18nKey = 'cli.lib.ui.featureHighlight';
-
+const uiInfoSection = (title, logContent) => {
   uiLine();
-  logger.log(chalk.bold(title ? title : i18n(`${i18nKey}.defaultTitle`)));
-  commands.forEach(command => {
-    logger.log('');
-    logger.log(i18n(`${i18nKey}.commandKeys.${command}`));
-  });
+  logger.log(chalk.bold(title));
+  logger.log('');
+  logContent();
   logger.log('');
   uiLine();
 };
 
+const uiFeatureHighlight = (commands, title) => {
+  const i18nKey = 'cli.lib.ui.featureHighlight';
+
+  uiInfoSection(title ? title : i18n(`${i18nKey}.defaultTitle`), () => {
+    commands.forEach((c, i) => {
+      const commandKey = `${i18nKey}.commandKeys.${c}`;
+      const message = i18n(`${commandKey}.message`, {
+        command: chalk.bold(i18n(`${commandKey}.command`)),
+      });
+      if (i !== 0) {
+        logger.log('');
+      }
+      logger.log(message);
+    });
+  });
+};
+
 module.exports = {
-  uiLine,
-  uiLink,
   uiAccountDescription,
   uiFeatureHighlight,
+  uiInfoSection,
+  uiLine,
+  uiLink,
 };

--- a/packages/cli/lib/ui.js
+++ b/packages/cli/lib/ui.js
@@ -2,6 +2,7 @@ const chalk = require('chalk');
 const supportsHyperlinks = require('../lib/supportHyperlinks');
 const supportsColor = require('../lib/supportsColor');
 const { getAccountConfig } = require('@hubspot/cli-lib/lib/config');
+const { i18n } = require('@hubspot/cli-lib/lib/lang');
 const { logger } = require('@hubspot/cli-lib/logger');
 
 /**
@@ -65,8 +66,22 @@ const uiAccountDescription = accountId => {
   );
 };
 
+const uiFeatureHighlight = (commands, title) => {
+  const i18nKey = 'cli.lib.ui.featureHighlight';
+
+  uiLine();
+  logger.log(chalk.bold(title ? title : i18n(`${i18nKey}.defaultTitle`)));
+  commands.forEach(command => {
+    logger.log('');
+    logger.log(i18n(`${i18nKey}.commandKeys.${command}`));
+  });
+  logger.log('');
+  uiLine();
+};
+
 module.exports = {
   uiLine,
   uiLink,
   uiAccountDescription,
+  uiFeatureHighlight,
 };


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
This is an idea to help make account switching in the CLI easier to understand and more discoverable:
- After the user runs `hs auth` or `hs init` we log out some additional commands that help make account handling easier. 
- I updated the prompts + copy in the flow to (hopefully) make them easier to understand. 
- The user now has the option to automatically set the newly connected account as the default when running `ha auth`

## Screenshots
### hs init (OLD)
<img width="866" alt="image" src="https://user-images.githubusercontent.com/6654014/167724208-d1163925-e8f3-40e3-b54d-3a79a3dbb241.png">

### hs init (NEW)
<img width="867" alt="image" src="https://user-images.githubusercontent.com/6654014/167724127-5c2b27ad-6646-4ad0-a996-9e0850ff0ac9.png">

### hs auth (OLD)
<img width="867" alt="image" src="https://user-images.githubusercontent.com/6654014/167724369-80b04cb3-484b-4cf4-ba84-cc10e073d125.png">

### hs auth (NEW) w/ setting as default
<img width="868" alt="image" src="https://user-images.githubusercontent.com/6654014/167724487-45e81d04-8e7a-4baf-978f-a18430b0b354.png">

### hs auth (NEW) w/out setting as default
<img width="867" alt="image" src="https://user-images.githubusercontent.com/6654014/167723996-b84aff02-9611-44f7-9116-8a50171acc15.png">

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
