### PR TITLE
Switching `hs account use` arg to an option + deprecation message for `hs config set default-account`

### DIFF
--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -3,6 +3,7 @@ en:
     commands:
       generalErrors:
         srcIsProject: "\"{{ src }}\" is in a project folder. Did you mean \"hs project {{command}}\"?"
+        setDefaultAccountMoved: "This command has moved. Try `hs accounts use` instead"
       accounts:
         describe: "Commands for working with accounts."
         subcommands:
@@ -32,7 +33,7 @@ en:
               default: "Select account to use as the default from a list"
               idBased: "Set the default account to the account in the config with accountId equal to \"1234567\""
               nameBased: "Set the default account to the account in the config with name equal to \"MyAccount\""
-            positionals:
+            options:
               account:
                 describe: "Account name or id to use as the default"
             promptMessage: "Select an account to use as the default"

--- a/packages/cli/commands/accounts/use.js
+++ b/packages/cli/commands/accounts/use.js
@@ -33,7 +33,7 @@ const selectAccountFromConfig = async config => {
   return selectedDefault;
 };
 
-exports.command = 'use [account]';
+exports.command = 'use [--account]';
 exports.describe = i18n(`${i18nKey}.describe`);
 
 exports.handler = async options => {
@@ -68,14 +68,17 @@ exports.handler = async options => {
 };
 
 exports.builder = yargs => {
-  yargs.positional('account', {
-    describe: i18n(`${i18nKey}.positionals.account.describe`),
+  yargs.option('account', {
+    describe: i18n(`${i18nKey}.options.account.describe`),
     type: 'string',
   });
   yargs.example([
     ['$0 accounts use', i18n(`${i18nKey}.examples.default`)],
-    ['$0 accounts use MyAccount', i18n(`${i18nKey}.examples.nameBased`)],
-    ['$0 accounts use 1234567', i18n(`${i18nKey}.examples.idBased`)],
+    [
+      '$0 accounts use --account=MyAccount',
+      i18n(`${i18nKey}.examples.nameBased`),
+    ],
+    ['$0 accounts use --account=1234567', i18n(`${i18nKey}.examples.idBased`)],
   ]);
 
   return yargs;

--- a/packages/cli/commands/config/set.js
+++ b/packages/cli/commands/config/set.js
@@ -89,7 +89,7 @@ exports.builder = yargs => {
 
   yargs.example([['$0 config set', i18n(`${i18nKey}.examples.default`)]]);
 
-  //TODO remove this
+  //TODO remove this when "hs accounts use" is fully rolled out
   yargs.strict(false);
 
   return yargs;

--- a/packages/cli/commands/config/set.js
+++ b/packages/cli/commands/config/set.js
@@ -33,7 +33,7 @@ const selectOptions = async () => {
 };
 
 const handleConfigUpdate = async (accountId, options) => {
-  const { defaultMode, httpTimeout, allowUsageTracking } = options;
+  const { allowUsageTracking, defaultMode, httpTimeout } = options;
 
   if (typeof defaultMode !== 'undefined') {
     await setDefaultMode({ defaultMode, accountId });
@@ -88,6 +88,9 @@ exports.builder = yargs => {
     .conflicts('allowUsageTracking', 'httpTimeout');
 
   yargs.example([['$0 config set', i18n(`${i18nKey}.examples.default`)]]);
+
+  //TODO remove this
+  yargs.strict(false);
 
   return yargs;
 };


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
A follow up to: https://github.com/HubSpot/hubspot-cli/pull/673

We're trying a new pattern where we're representing every arg as an option with a fallback prompt. I'm moving this positional arg back to an option.

Example: `hs accounts use [account]` changed to `hs accounts use [--account]`

Also, I'm adding a warning message to `hs config set default-account` so users know that the functionality has been moved to `hs accounts use` (see screenshot).

## Screenshots
<!-- Provide images of the before and after functionality -->
<img width="776" alt="image" src="https://user-images.githubusercontent.com/6654014/167030475-bad0b4fa-bbbf-4704-a632-812e144e00c2.png">

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
