### PR TITLE
add hs accounts add command

### DIFF
--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -39,6 +39,17 @@ en:
             promptMessage: "Select an account to use as the default"
             success:
               defaultAccountUpdated: "Default account updated to \"{{ accountName }}\""
+          add:
+            describe: "Connect the CLI to a new HubSpot account or refresh an existing connection. Supported authentication protocols are {{ supportedProtocols }}."
+            errors:
+              accountNameExists: "Account name \"{{ name }}\" already exists, please enter a different name."
+              noConfigFileFound: "No config file was found. To create a new config file, use the \"hs init\" command."
+              unsupportedAuthType: "Unsupported auth type: {{ type }}. The only supported authentication protocols are {{ supportedProtocols }}."
+            options:
+              type:
+                describe: "Authentication mechanism"
+            success:
+              configFileUpdated: "{{ configFilename }} updated with {{ authMethod }}."
       auth:
         describe: "Configure authentication for a HubSpot account. Supported authentication protocols are {{ supportedProtocols }}."
         errors:

--- a/packages/cli/commands/accounts.js
+++ b/packages/cli/commands/accounts.js
@@ -3,6 +3,7 @@ const { i18n } = require('@hubspot/cli-lib/lib/lang');
 const list = require('./accounts/list');
 const rename = require('./accounts/rename');
 const use = require('./accounts/use');
+const add = require('./accounts/add');
 
 const i18nKey = 'cli.commands.accounts';
 
@@ -20,6 +21,7 @@ exports.builder = yargs => {
     })
     .command(rename)
     .command(use)
+    .command(add)
     .demandCommand(1, '');
 
   return yargs;

--- a/packages/cli/commands/accounts/add.js
+++ b/packages/cli/commands/accounts/add.js
@@ -1,0 +1,154 @@
+const { loadConfig, checkAndWarnGitInclusion } = require('@hubspot/cli-lib');
+const { logger } = require('@hubspot/cli-lib/logger');
+const {
+  OAUTH_AUTH_METHOD,
+  PERSONAL_ACCESS_KEY_AUTH_METHOD,
+  ENVIRONMENTS,
+  DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME,
+} = require('@hubspot/cli-lib/lib/constants');
+const { i18n } = require('@hubspot/cli-lib/lib/lang');
+const {
+  updateConfigWithPersonalAccessKey,
+} = require('@hubspot/cli-lib/personalAccessKey');
+const {
+  updateAccountConfig,
+  accountNameExistsInConfig,
+  writeConfig,
+  getConfigPath,
+} = require('@hubspot/cli-lib/lib/config');
+const { commaSeparatedValues } = require('@hubspot/cli-lib/lib/text');
+const { promptUser } = require('../../lib/prompts/promptUtils');
+const {
+  personalAccessKeyPrompt,
+  OAUTH_FLOW,
+  ACCOUNT_NAME,
+} = require('../../lib/prompts/personalAccessKeyPrompt');
+const {
+  addConfigOptions,
+  setLogLevel,
+  addTestingOptions,
+} = require('../../lib/commonOpts');
+const { logDebugInfo } = require('../../lib/debugInfo');
+const { trackCommandUsage } = require('../../lib/usageTracking');
+const { authenticateWithOauth } = require('../../lib/oauth');
+const { EXIT_CODES } = require('../../lib/enums/exitCodes');
+
+const i18nKey = 'cli.commands.accounts.subcommands.add';
+
+const ALLOWED_AUTH_METHODS = [
+  OAUTH_AUTH_METHOD.value,
+  PERSONAL_ACCESS_KEY_AUTH_METHOD.value,
+];
+const SUPPORTED_AUTHENTICATION_PROTOCOLS_TEXT = commaSeparatedValues(
+  ALLOWED_AUTH_METHODS
+);
+
+const promptForAccountNameIfNotSet = async updatedConfig => {
+  if (!updatedConfig.name) {
+    let promptAnswer;
+    let validName = null;
+    while (!validName) {
+      promptAnswer = await promptUser([ACCOUNT_NAME]);
+
+      if (!accountNameExistsInConfig(promptAnswer.name)) {
+        validName = promptAnswer.name;
+      } else {
+        logger.log(
+          i18n(`${i18nKey}.errors.accountNameExists`, {
+            name: promptAnswer.name,
+          })
+        );
+      }
+    }
+    return validName;
+  }
+};
+
+exports.command = 'add';
+exports.describe = i18n(`${i18nKey}.describe`, {
+  supportedProtocols: SUPPORTED_AUTHENTICATION_PROTOCOLS_TEXT,
+});
+
+exports.handler = async options => {
+  setLogLevel(options);
+  logDebugInfo(options);
+
+  const { type, config: configPath, qa } = options;
+  const authType =
+    (type && type.toLowerCase()) || PERSONAL_ACCESS_KEY_AUTH_METHOD.value;
+
+  if (!getConfigPath()) {
+    logger.error(i18n(`${i18nKey}.errors.noConfigFileFound`));
+    process.exit(EXIT_CODES.ERROR);
+  }
+
+  const env = qa ? ENVIRONMENTS.QA : ENVIRONMENTS.PROD;
+  loadConfig(configPath);
+  checkAndWarnGitInclusion(getConfigPath());
+
+  trackCommandUsage('accounts-add');
+
+  let configData;
+  let updatedConfig;
+  let validName;
+  switch (authType) {
+    case OAUTH_AUTH_METHOD.value:
+      configData = await promptUser(OAUTH_FLOW);
+      await authenticateWithOauth({
+        ...configData,
+        env,
+      });
+      break;
+    case PERSONAL_ACCESS_KEY_AUTH_METHOD.value:
+      configData = await personalAccessKeyPrompt({ env });
+      updatedConfig = await updateConfigWithPersonalAccessKey(configData);
+
+      if (!updatedConfig) {
+        process.exit(EXIT_CODES.SUCCESS);
+      }
+
+      validName = await promptForAccountNameIfNotSet(updatedConfig);
+
+      updateAccountConfig({
+        ...updatedConfig,
+        environment: updatedConfig.env,
+        tokenInfo: updatedConfig.auth.tokenInfo,
+        name: validName,
+      });
+      writeConfig();
+
+      logger.success(
+        i18n(`${i18nKey}.success.configFileUpdated`, {
+          configFilename: DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME,
+          authMethod: PERSONAL_ACCESS_KEY_AUTH_METHOD.name,
+        })
+      );
+      break;
+    default:
+      logger.error(
+        i18n(`${i18nKey}.errors.unsupportedAuthType`, {
+          supportedProtocols: SUPPORTED_AUTHENTICATION_PROTOCOLS_TEXT,
+          type,
+        })
+      );
+      break;
+  }
+  process.exit(EXIT_CODES.SUCCESS);
+};
+
+exports.builder = yargs => {
+  yargs.positional('type', {
+    describe: i18n(`${i18nKey}.options.type.describe`),
+    type: 'string',
+    choices: [
+      `${PERSONAL_ACCESS_KEY_AUTH_METHOD.value}`,
+      `${OAUTH_AUTH_METHOD.value}`,
+    ],
+    default: PERSONAL_ACCESS_KEY_AUTH_METHOD.value,
+  });
+
+  addConfigOptions(yargs, true);
+  addTestingOptions(yargs, true);
+
+  return yargs;
+};


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
Adding a `hs accounts add` command that will eventually replace `hs auth`. We've been getting feedback lately that `hs accounts add` is more intuitive than `hs auth`. For now, we will support both commands for backwards compatibility. This works the exact same way that `hs auth` works.

Note: As a part of this update, I'm making it so that `hs accounts add` no longer supports auth via api key which is a deprecated auth method that was replaced by personal access tokens.

Questions:
- Should we have a separate command for the scenario where a user wants to refresh a personal access token for a Hubspot account that is already connected to the CLI? "add" makes it sound like this command is only used to connect net-new accounts to the CLI.

## Screenshots
<!-- Provide images of the before and after functionality -->

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
