### PR TITLE
Sandboxes dev platform

### DIFF
--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -553,6 +553,7 @@ en:
         subcommands:
           create:
             describe: "Create a sandbox account"
+            enterAccountName: "Enter a unique name to reference your account: "
             debug:
               creating: "Creating sandbox \"{{ name }}\""
             examples:

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -564,6 +564,7 @@ en:
                 describe: "Name to use for created sandbox"
             success:
               create: "Sandbox \"{{ name }}\" with portalId \"{{ sandboxHubId }}\" created successfully."
+              configFileUpdated: "{{ configFilename }} updated with {{ authMethod }}."
       secrets:
         describe: "Manage HubSpot secrets."
         subcommands:

--- a/packages/cli/commands/sandbox/create.js
+++ b/packages/cli/commands/sandbox/create.js
@@ -3,6 +3,7 @@ const {
   addConfigOptions,
   getAccountId,
   addUseEnvironmentOptions,
+  addTestingOptions,
 } = require('../../lib/commonOpts');
 const { trackCommandUsage } = require('../../lib/usageTracking');
 const { logger } = require('@hubspot/cli-lib/logger');
@@ -11,8 +12,87 @@ const { createSandbox } = require('@hubspot/cli-lib/sandboxes');
 const { loadAndValidateOptions } = require('../../lib/validation');
 const { createSandboxPrompt } = require('../../lib/prompts/sandboxesPrompt');
 const { i18n } = require('@hubspot/cli-lib/lib/lang');
+const { logErrorInstance } = require('@hubspot/cli-lib/errorHandlers');
+const {
+  ENVIRONMENTS,
+  PERSONAL_ACCESS_KEY_AUTH_METHOD,
+  DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME,
+} = require('@hubspot/cli-lib/lib/constants');
+const {
+  personalAccessKeyPrompt,
+} = require('../../lib/prompts/personalAccessKeyPrompt');
+const {
+  updateConfigWithPersonalAccessKey,
+} = require('@hubspot/cli-lib/personalAccessKey');
+const { EXIT_CODES } = require('../../lib/enums/exitCodes');
+const { writeConfig, updateAccountConfig } = require('@hubspot/cli-lib');
+const { promptUser } = require('../../lib/prompts/promptUtils');
+const { accountNameExistsInConfig } = require('@hubspot/cli-lib/lib/config');
+const { STRING_WITH_NO_SPACES_REGEX } = require('../../lib/regex');
 
 const i18nKey = 'cli.commands.sandbox.subcommands.create';
+
+const promptForAccountNameIfNotSet = async (updatedConfig, name) => {
+  if (!updatedConfig.name) {
+    let promptAnswer;
+    let validName = null;
+    while (!validName) {
+      promptAnswer = await promptUser([
+        {
+          name: 'name',
+          message: i18n(`${i18nKey}.enterAccountName`),
+          validate(val) {
+            if (typeof val !== 'string') {
+              return i18n(`${i18nKey}.errors.invalidName`);
+            } else if (!val.length) {
+              return i18n(`${i18nKey}.errors.nameRequired`);
+            } else if (!STRING_WITH_NO_SPACES_REGEX.test(val)) {
+              return i18n(`${i18nKey}.errors.spacesInName`);
+            }
+            return true;
+          },
+          default: name,
+        },
+      ]);
+
+      if (!accountNameExistsInConfig(promptAnswer.name)) {
+        validName = promptAnswer.name;
+      } else {
+        logger.log(
+          i18n(`${i18nKey}.errors.accountNameExists`, {
+            name: promptAnswer.name,
+          })
+        );
+      }
+    }
+    return validName;
+  }
+};
+
+const personalAccessKeyFlow = async (env, accountId, name) => {
+  const configData = await personalAccessKeyPrompt({ env, accountId });
+  const updatedConfig = await updateConfigWithPersonalAccessKey(configData);
+
+  if (!updatedConfig) {
+    process.exit(EXIT_CODES.SUCCESS);
+  }
+
+  const validName = await promptForAccountNameIfNotSet(updatedConfig, name);
+
+  updateAccountConfig({
+    ...updatedConfig,
+    environment: updatedConfig.env,
+    tokenInfo: updatedConfig.auth.tokenInfo,
+    name: validName,
+  });
+  writeConfig();
+  logger.success(
+    i18n(`${i18nKey}.success.configFileUpdated`, {
+      configFilename: DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME,
+      authMethod: PERSONAL_ACCESS_KEY_AUTH_METHOD.name,
+    })
+  );
+};
 
 exports.command = 'create [name]';
 exports.describe = i18n(`${i18nKey}.describe`);
@@ -22,6 +102,7 @@ exports.handler = async options => {
 
   const { name } = options;
   const accountId = getAccountId(options);
+  const env = options.qa ? ENVIRONMENTS.QA : ENVIRONMENTS.PROD;
   let namePrompt;
 
   trackCommandUsage('sandbox-create', {}, accountId);
@@ -38,7 +119,7 @@ exports.handler = async options => {
     })
   );
 
-  return createSandbox(accountId, sandboxName).then(
+  const result = await createSandbox(accountId, sandboxName).then(
     ({ name, sandboxHubId }) => {
       logger.success(
         i18n(`${i18nKey}.success.create`, {
@@ -46,9 +127,15 @@ exports.handler = async options => {
           sandboxHubId,
         })
       );
-      logger.info(i18n(`${i18nKey}.info.auth`));
+      return { name, sandboxHubId };
     }
   );
+  try {
+    await personalAccessKeyFlow(env, result.sandboxHubId, result.name);
+    process.exit(EXIT_CODES.SUCCESS);
+  } catch (err) {
+    logErrorInstance(err);
+  }
 };
 
 exports.builder = yargs => {
@@ -64,6 +151,7 @@ exports.builder = yargs => {
   addConfigOptions(yargs, true);
   addAccountOptions(yargs, true);
   addUseEnvironmentOptions(yargs, true);
+  addTestingOptions(yargs, true);
 
   return yargs;
 };

--- a/packages/cli/lib/prompts/personalAccessKeyPrompt.js
+++ b/packages/cli/lib/prompts/personalAccessKeyPrompt.js
@@ -15,10 +15,13 @@ const i18nKey = 'cli.lib.prompts.personalAccessKeyPrompt';
  * Displays notification to user that we are about to open the browser,
  * then opens their browser to the personal-access-key shortlink
  */
-const personalAccessKeyPrompt = async ({ env } = {}) => {
+const personalAccessKeyPrompt = async ({ env, accountId } = {}) => {
   const websiteOrigin = getHubSpotWebsiteOrigin(env);
-  const url = `${websiteOrigin}/l/personal-access-key`;
+  let url = `${websiteOrigin}/l/personal-access-key`;
   if (process.env.BROWSER !== 'none') {
+    if (accountId) {
+      url = `${websiteOrigin}/personal-access-key/${accountId}`;
+    }
     await promptUser([PERSONAL_ACCESS_KEY_BROWSER_OPEN_PREP]);
     open(url, { url: true });
   }


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->

Updates for `hs sandbox create`
- The CLI auto prompts the user to generate a PAK and add to the config file. 
- The sandbox name is pulled in by default, but gives the user an option to use a custom one. 
- Adds an `accountId` option to the PAK prompt, where we forward the user to the PAK generation page rather than the account picker. 

## Screenshots
<!-- Provide images of the before and after functionality -->
<img width="1183" alt="Screen Shot 2022-05-06 at 12 01 08 PM" src="https://user-images.githubusercontent.com/16788677/167169876-ef8424c2-83d7-477b-b788-46dbf58b1964.png">



## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

Have some updates to `hs init` and `hs auth` that I will put up in a separate PR. Those updates will also use the `accountId` option in the PAK prompt

## Who to Notify
<!-- /cc those you wish to know about the PR -->

