### PR TITLE
POC for showing command shortcuts

### DIFF
--- a/packages/cli/commands/project/logs.js
+++ b/packages/cli/commands/project/logs.js
@@ -25,7 +25,7 @@ const {
 } = require('@hubspot/cli-lib/api/results');
 const { ensureProjectExists } = require('../../lib/projects');
 const { loadAndValidateOptions } = require('../../lib/validation');
-const { uiLine, uiLink } = require('../../lib/ui');
+const { uiLine, uiLink, uiPromptShortcut } = require('../../lib/ui');
 const { projectLogsPrompt } = require('../../lib/prompts/projectsLogsPrompt');
 const { tailLogs } = require('../../lib/serverlessLogs');
 const { i18n } = require('@hubspot/cli-lib/lib/lang');
@@ -168,6 +168,24 @@ exports.handler = async options => {
   }
 
   trackCommandUsage('project-logs', { latest: options.latest }, accountId);
+
+  // Show shortcut if any of the prompt questions were answered
+  const promptUsed =
+    !!promptProjectName ||
+    !!promptAppName ||
+    !!promptFunctionName ||
+    promptEndpointName;
+  if (promptUsed) {
+    let optionShortcut;
+
+    if (endpointName) {
+      optionShortcut = `--project="${projectName}" --endpoint="${endpointName}"`;
+    } else {
+      optionShortcut = `--project="${projectName}" --app="${appName}" --function="${functionName}"`;
+    }
+    uiPromptShortcut(`hs project logs ${optionShortcut}`);
+    logger.log('');
+  }
 
   const logsInfo = [accountId, `"${projectName}"`];
   let tableHeader;

--- a/packages/cli/lib/ui.js
+++ b/packages/cli/lib/ui.js
@@ -65,8 +65,13 @@ const uiAccountDescription = accountId => {
   );
 };
 
+const uiPromptShortcut = command => {
+  logger.log(`Shortcut: ${chalk.bold(command)}`);
+};
+
 module.exports = {
   uiLine,
   uiLink,
   uiAccountDescription,
+  uiPromptShortcut,
 };


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
Showing what it could look like for us to show "shortcuts" (name is WIP) to the user whenever we show them a prompt.

The idea is that it helps the users to work faster. The logic I have in place right now makes it so that we only show the shortcut to users if they answered at least one prompt question. I'll post some screenshots to show how it works.

## Screenshots
<!-- Provide images of the before and after functionality -->
### Example where we show them the shortcut b/c they didn't pass in any options
<img width="608" alt="image" src="https://user-images.githubusercontent.com/6654014/167175019-51345519-26f6-483d-ab06-f8e8cd05f2b5.png">

### Example where we show them the shortcut because we asked one prompt question
<img width="821" alt="image" src="https://user-images.githubusercontent.com/6654014/167175224-4a76caac-48f3-422b-96c1-77743ebcba3d.png">

### Example where we wouldn't show the shortcut because we never showed them the prompt
<img width="866" alt="image" src="https://user-images.githubusercontent.com/6654014/167175050-7f010ee2-df09-4279-b868-415bf849ed92.png">

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
