### PR TITLE
hs sandbox create

### DIFF
--- a/packages/cli-lib/errorHandlers/apiErrors.js
+++ b/packages/cli-lib/errorHandlers/apiErrors.js
@@ -273,4 +273,5 @@ module.exports = {
   logApiErrorInstance,
   logApiUploadErrorInstance,
   logServerlessFunctionApiErrorInstance,
+  isMissingScopeError,
 };

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -553,6 +553,7 @@ en:
         subcommands:
           create:
             describe: "Create a sandbox account"
+            enterAccountName: "Enter a unique name to reference your account: "
             debug:
               creating: "Creating sandbox \"{{ name }}\""
             examples:

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -564,6 +564,7 @@ en:
                 describe: "Name to use for created sandbox"
             success:
               create: "Sandbox \"{{ name }}\" with portalId \"{{ sandboxHubId }}\" created successfully."
+              configFileUpdated: "{{ configFilename }} updated with {{ authMethod }}."
       secrets:
         describe: "Manage HubSpot secrets."
         subcommands:

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -565,7 +565,7 @@ en:
                 describe: "Name to use for created sandbox"
             success:
               create: "Sandbox \"{{ name }}\" with portalId \"{{ sandboxHubId }}\" created successfully."
-              configFileUpdated: "{{ configFilename }} updated with {{ authMethod }}."
+              configFileUpdated: "{{ configFilename }} updated with {{ authMethod }} for account {{ account }}."
       secrets:
         describe: "Manage HubSpot secrets."
         subcommands:

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -573,9 +573,9 @@ en:
               configFileUpdated: "{{ configFilename }} updated with {{ authMethod }} for account {{ account }}."
             failure:
               scopes:
-                message: "The HubSpot CLI doesn’t have permission to create sandboxes under \"{{ accountName }}\"."
+                message: "The personal access key you provided doesn't include sandbox permissions."
                 instructions: "To update CLI permissions for \"{{ accountName }}\":
-                  \n- Visit {{ url }}, deactivate the existing personal access key, and create a new one that includes Sandboxes permissions.
+                  \n- Go to {{ url }}, deactivate the existing personal access key, and create a new one that includes Sandboxes permissions.
                   \n- Update the CLI config for this account by running `hs auth` and entering the new key.\n"
       secrets:
         describe: "Manage HubSpot secrets."

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -570,12 +570,8 @@ en:
               scopes:
                 message: "The HubSpot CLI doesn’t have permission to create sandboxes under \"{{ accountName }}\"."
                 instructions: "To update CLI permissions for \"{{ accountName }}\":
-
-                  - Visit {{ url }}, deactivate the existing personal access key, and create a new one that includes Sandboxes permissions.
-
-                  - Update the CLI config for this account by running `hs auth` and entering the new key.
-
-                "
+                  \n- Visit {{ url }}, deactivate the existing personal access key, and create a new one that includes Sandboxes permissions.
+                  \n- Update the CLI config for this account by running `hs auth` and entering the new key.\n"
       secrets:
         describe: "Manage HubSpot secrets."
         subcommands:

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -565,24 +565,17 @@ en:
                 describe: "Name to use for created sandbox"
             success:
               create: "Sandbox \"{{ name }}\" with portalId \"{{ sandboxHubId }}\" created successfully."
-              prePrompt: "
-
-
-              The following step will prompt you to authenticate with sandbox \"{{ name }}\" and add it to the CLI config.
-
-              "
               configFileUpdated: "{{ configFilename }} updated with {{ authMethod }} for account {{ account }}."
             failure:
-              scopes: "
+              scopes:
+                message: "The HubSpot CLI doesn’t have permission to create sandboxes under \"{{ accountName }}\"."
+                instructions: "To update CLI permissions for \"{{ accountName }}\":
 
+                  - Visit {{ url }}, deactivate the existing personal access key, and create a new one that includes Sandboxes permissions.
 
-              Verify that the personal access key used has the Sandboxes scope by navigating to \"{{ url }}\".
+                  - Update the CLI config for this account by running `hs auth` and entering the new key.
 
-                - If the scope is missing, deactivate the key and generate a new personal access key with Sandboxes permissions.
-
-                - To update the personal access key in the CLI, run \"hs auth\" and enter the new key.
-
-              "
+                "
       secrets:
         describe: "Manage HubSpot secrets."
         subcommands:

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -565,7 +565,24 @@ en:
                 describe: "Name to use for created sandbox"
             success:
               create: "Sandbox \"{{ name }}\" with portalId \"{{ sandboxHubId }}\" created successfully."
+              prePrompt: "
+
+
+              The following step will prompt you to authenticate with sandbox \"{{ name }}\" and add it to the CLI config.
+
+              "
               configFileUpdated: "{{ configFilename }} updated with {{ authMethod }} for account {{ account }}."
+            failure:
+              scopes: "
+
+
+              Verify that the personal access key used has the Sandboxes scope by navigating to \"{{ url }}\".
+
+                - If the scope is missing, deactivate the key and generate a new personal access key with Sandboxes permissions.
+
+                - To update the personal access key in the CLI, run \"hs auth\" and enter the new key.
+
+              "
       secrets:
         describe: "Manage HubSpot secrets."
         subcommands:

--- a/packages/cli-lib/sandboxes.js
+++ b/packages/cli-lib/sandboxes.js
@@ -13,7 +13,7 @@ async function createSandbox(accountId, name) {
     resp = await _createSandbox(accountId, name);
   } catch (err) {
     logger.error(err.error.message);
-    process.exit(1);
+    throw err;
   }
 
   return {

--- a/packages/cli-lib/sandboxes.js
+++ b/packages/cli-lib/sandboxes.js
@@ -1,5 +1,5 @@
+/* eslint-disable no-useless-catch */
 const { createSandbox: _createSandbox } = require('./api/sandbox-hubs');
-const { logger } = require('./logger');
 
 /**
  * Creates a new Sandbox portal instance.
@@ -12,7 +12,6 @@ async function createSandbox(accountId, name) {
   try {
     resp = await _createSandbox(accountId, name);
   } catch (err) {
-    logger.error(err.error.message);
     throw err;
   }
 

--- a/packages/cli/commands/sandbox/create.js
+++ b/packages/cli/commands/sandbox/create.js
@@ -3,6 +3,7 @@ const {
   addConfigOptions,
   getAccountId,
   addUseEnvironmentOptions,
+  addTestingOptions,
 } = require('../../lib/commonOpts');
 const { trackCommandUsage } = require('../../lib/usageTracking');
 const { logger } = require('@hubspot/cli-lib/logger');
@@ -11,8 +12,87 @@ const { createSandbox } = require('@hubspot/cli-lib/sandboxes');
 const { loadAndValidateOptions } = require('../../lib/validation');
 const { createSandboxPrompt } = require('../../lib/prompts/sandboxesPrompt');
 const { i18n } = require('@hubspot/cli-lib/lib/lang');
+const { logErrorInstance } = require('@hubspot/cli-lib/errorHandlers');
+const {
+  ENVIRONMENTS,
+  PERSONAL_ACCESS_KEY_AUTH_METHOD,
+  DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME,
+} = require('@hubspot/cli-lib/lib/constants');
+const {
+  personalAccessKeyPrompt,
+} = require('../../lib/prompts/personalAccessKeyPrompt');
+const {
+  updateConfigWithPersonalAccessKey,
+} = require('@hubspot/cli-lib/personalAccessKey');
+const { EXIT_CODES } = require('../../lib/enums/exitCodes');
+const { writeConfig, updateAccountConfig } = require('@hubspot/cli-lib');
+const { promptUser } = require('../../lib/prompts/promptUtils');
+const { accountNameExistsInConfig } = require('@hubspot/cli-lib/lib/config');
+const { STRING_WITH_NO_SPACES_REGEX } = require('../../lib/regex');
 
 const i18nKey = 'cli.commands.sandbox.subcommands.create';
+
+const promptForAccountNameIfNotSet = async (updatedConfig, name) => {
+  if (!updatedConfig.name) {
+    let promptAnswer;
+    let validName = null;
+    while (!validName) {
+      promptAnswer = await promptUser([
+        {
+          name: 'name',
+          message: i18n(`${i18nKey}.enterAccountName`),
+          validate(val) {
+            if (typeof val !== 'string') {
+              return i18n(`${i18nKey}.errors.invalidName`);
+            } else if (!val.length) {
+              return i18n(`${i18nKey}.errors.nameRequired`);
+            } else if (!STRING_WITH_NO_SPACES_REGEX.test(val)) {
+              return i18n(`${i18nKey}.errors.spacesInName`);
+            }
+            return true;
+          },
+          default: name,
+        },
+      ]);
+
+      if (!accountNameExistsInConfig(promptAnswer.name)) {
+        validName = promptAnswer.name;
+      } else {
+        logger.log(
+          i18n(`${i18nKey}.errors.accountNameExists`, {
+            name: promptAnswer.name,
+          })
+        );
+      }
+    }
+    return validName;
+  }
+};
+
+const personalAccessKeyFlow = async (env, accountId, name) => {
+  const configData = await personalAccessKeyPrompt({ env, accountId });
+  const updatedConfig = await updateConfigWithPersonalAccessKey(configData);
+
+  if (!updatedConfig) {
+    process.exit(EXIT_CODES.SUCCESS);
+  }
+
+  const validName = await promptForAccountNameIfNotSet(updatedConfig, name);
+
+  updateAccountConfig({
+    ...updatedConfig,
+    environment: updatedConfig.env,
+    tokenInfo: updatedConfig.auth.tokenInfo,
+    name: validName,
+  });
+  writeConfig();
+  logger.success(
+    i18n(`${i18nKey}.success.configFileUpdated`, {
+      configFilename: DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME,
+      authMethod: PERSONAL_ACCESS_KEY_AUTH_METHOD.name,
+    })
+  );
+};
 
 exports.command = 'create [name]';
 exports.describe = i18n(`${i18nKey}.describe`);
@@ -22,6 +102,7 @@ exports.handler = async options => {
 
   const { name } = options;
   const accountId = getAccountId(options);
+  const env = options.qa ? ENVIRONMENTS.QA : ENVIRONMENTS.PROD;
   let namePrompt;
 
   trackCommandUsage('sandbox-create', {}, accountId);
@@ -38,7 +119,7 @@ exports.handler = async options => {
     })
   );
 
-  return createSandbox(accountId, sandboxName).then(
+  const result = await createSandbox(accountId, sandboxName).then(
     ({ name, sandboxHubId }) => {
       logger.success(
         i18n(`${i18nKey}.success.create`, {
@@ -46,9 +127,15 @@ exports.handler = async options => {
           sandboxHubId,
         })
       );
-      logger.info(i18n(`${i18nKey}.info.auth`));
+      return { name, sandboxHubId };
     }
   );
+  try {
+    await personalAccessKeyFlow(env, result.sandboxHubId, result.name);
+    process.exit(EXIT_CODES.SUCCESS);
+  } catch (err) {
+    logErrorInstance(err);
+  }
 };
 
 exports.builder = yargs => {
@@ -64,6 +151,7 @@ exports.builder = yargs => {
   addConfigOptions(yargs, true);
   addAccountOptions(yargs, true);
   addUseEnvironmentOptions(yargs, true);
+  addTestingOptions(yargs, true);
 
   return yargs;
 };

--- a/packages/cli/commands/sandbox/create.js
+++ b/packages/cli/commands/sandbox/create.js
@@ -132,10 +132,9 @@ exports.handler = async options => {
             name,
             sandboxHubId,
           }),
-          `
-
-The following step will prompt you to authenticate with sandbox "${name}" and add it to the CLI config.
-          `
+          i18n(`${i18nKey}.success.prePrompt`, {
+            name,
+          })
         );
         return { name, sandboxHubId };
       }
@@ -145,11 +144,9 @@ The following step will prompt you to authenticate with sandbox "${name}" and ad
       const websiteOrigin = getHubSpotWebsiteOrigin(env);
       const url = `${websiteOrigin}/personal-access-key/${accountId}`;
       logger.info(
-        `
-          Verify that the personal access key used has the Sandboxes scope by navigating to "${url}".
-          - If the scope is missing, deactivate the key and generate a new personal access key with Sandboxes permissions.
-          - To update the personal access key in the CLI, run "hs auth" and enter the new key.
-        `
+        i18n(`${i18nKey}.failure.scopes`, {
+          url,
+        })
       );
     }
     process.exit(EXIT_CODES.ERROR);

--- a/packages/cli/commands/sandbox/create.js
+++ b/packages/cli/commands/sandbox/create.js
@@ -77,8 +77,8 @@ const promptForAccountNameIfNotSet = async (updatedConfig, name) => {
   }
 };
 
-const personalAccessKeyFlow = async (env, accountId, name) => {
-  const configData = await personalAccessKeyPrompt({ env, accountId });
+const personalAccessKeyFlow = async (env, account, name) => {
+  const configData = await personalAccessKeyPrompt({ env, account });
   const updatedConfig = await updateConfigWithPersonalAccessKey(configData);
 
   if (!updatedConfig) {

--- a/packages/cli/commands/sandbox/create.js
+++ b/packages/cli/commands/sandbox/create.js
@@ -128,7 +128,11 @@ exports.handler = async options => {
           i18n(`${i18nKey}.success.create`, {
             name,
             sandboxHubId,
-          })
+          }),
+          `
+
+The following step will prompt you to authenticate with sandbox "${name}" and add it to the CLI config.
+          `
         );
         return { name, sandboxHubId };
       }

--- a/packages/cli/commands/sandbox/create.js
+++ b/packages/cli/commands/sandbox/create.js
@@ -30,6 +30,9 @@ const { promptUser } = require('../../lib/prompts/promptUtils');
 const { accountNameExistsInConfig } = require('@hubspot/cli-lib/lib/config');
 const { STRING_WITH_NO_SPACES_REGEX } = require('../../lib/regex');
 const { getHubSpotWebsiteOrigin } = require('@hubspot/cli-lib/lib/urls');
+const {
+  isMissingScopeError,
+} = require('@hubspot/cli-lib/errorHandlers/apiErrors');
 
 const i18nKey = 'cli.commands.sandbox.subcommands.create';
 
@@ -138,11 +141,7 @@ The following step will prompt you to authenticate with sandbox "${name}" and ad
       }
     );
   } catch (err) {
-    if (
-      err.error &&
-      err.error.category &&
-      err.error.category === 'MISSING_SCOPES'
-    ) {
+    if (isMissingScopeError(err)) {
       const websiteOrigin = getHubSpotWebsiteOrigin(env);
       const url = `${websiteOrigin}/personal-access-key/${accountId}`;
       logger.info(

--- a/packages/cli/commands/sandbox/create.js
+++ b/packages/cli/commands/sandbox/create.js
@@ -25,7 +25,11 @@ const {
   updateConfigWithPersonalAccessKey,
 } = require('@hubspot/cli-lib/personalAccessKey');
 const { EXIT_CODES } = require('../../lib/enums/exitCodes');
-const { writeConfig, updateAccountConfig } = require('@hubspot/cli-lib');
+const {
+  writeConfig,
+  updateAccountConfig,
+  getAccountConfig,
+} = require('@hubspot/cli-lib');
 const { promptUser } = require('../../lib/prompts/promptUtils');
 const { accountNameExistsInConfig } = require('@hubspot/cli-lib/lib/config');
 const { STRING_WITH_NO_SPACES_REGEX } = require('../../lib/regex');
@@ -107,6 +111,7 @@ exports.handler = async options => {
 
   const { name } = options;
   const accountId = getAccountId(options);
+  const accountConfig = getAccountConfig(accountId);
   const env = options.qa ? ENVIRONMENTS.QA : ENVIRONMENTS.PROD;
   let namePrompt;
 
@@ -131,9 +136,6 @@ exports.handler = async options => {
           i18n(`${i18nKey}.success.create`, {
             name,
             sandboxHubId,
-          }),
-          i18n(`${i18nKey}.success.prePrompt`, {
-            name,
           })
         );
         return { name, sandboxHubId };
@@ -141,10 +143,16 @@ exports.handler = async options => {
     );
   } catch (err) {
     if (isMissingScopeError(err)) {
+      logger.error(
+        i18n(`${i18nKey}.failure.scopes.message`, {
+          accountName: accountConfig.name || accountId,
+        })
+      );
       const websiteOrigin = getHubSpotWebsiteOrigin(env);
       const url = `${websiteOrigin}/personal-access-key/${accountId}`;
       logger.info(
-        i18n(`${i18nKey}.failure.scopes`, {
+        i18n(`${i18nKey}.failure.scopes.instructions`, {
+          accountName: accountConfig.name || accountId,
           url,
         })
       );

--- a/packages/cli/lib/prompts/personalAccessKeyPrompt.js
+++ b/packages/cli/lib/prompts/personalAccessKeyPrompt.js
@@ -15,10 +15,13 @@ const i18nKey = 'cli.lib.prompts.personalAccessKeyPrompt';
  * Displays notification to user that we are about to open the browser,
  * then opens their browser to the personal-access-key shortlink
  */
-const personalAccessKeyPrompt = async ({ env } = {}) => {
+const personalAccessKeyPrompt = async ({ env, accountId } = {}) => {
   const websiteOrigin = getHubSpotWebsiteOrigin(env);
-  const url = `${websiteOrigin}/l/personal-access-key`;
+  let url = `${websiteOrigin}/l/personal-access-key`;
   if (process.env.BROWSER !== 'none') {
+    if (accountId) {
+      url = `${websiteOrigin}/personal-access-key/${accountId}`;
+    }
     await promptUser([PERSONAL_ACCESS_KEY_BROWSER_OPEN_PREP]);
     open(url, { url: true });
   }


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->

Updates for `hs sandbox create`
- The CLI auto prompts the user to generate a PAK and add to the config file. 
- The sandbox name is pulled in by default, but gives the user an option to use a custom one. 
- Adds an `account` option to the PAK prompt, where we forward the user to the PAK generation page rather than the account picker. 
- Adds an error message specific to missing scopes when creating a sandbox

## Screenshots
<!-- Provide images of the before and after functionality -->
<img width="1188" alt="Screen Shot 2022-05-06 at 5 06 47 PM" src="https://user-images.githubusercontent.com/16788677/167216618-e843077a-8628-4c22-9fc7-cd516bd4a908.png">

<img width="1185" alt="Screen Shot 2022-05-06 at 5 03 28 PM" src="https://user-images.githubusercontent.com/16788677/167216625-b35b3e16-ac65-4bd5-a6c4-8a43821952d0.png">




## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

Have some updates to `hs init` and `hs auth` that I will put up in a separate PR. Those updates will also use the `accountId` option in the PAK prompt

## Who to Notify
<!-- /cc those you wish to know about the PR -->

