### PR TITLE
Init and auth options

### DIFF
--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -50,8 +50,8 @@ en:
             describe: "Authentication mechanism"
             defaultDescription: "\"{{ authMethod }}\": \nAn access token tied to a specific user account. This is the recommended way of authenticating with local development tools."
         options:
-          accountId:
-            describe: "Account id to authenticate to"
+          account:
+            describe: "HubSpot account to authenticate"
         success:
           configFileUpdated: "{{ configFilename }} updated with {{ authMethod }}."
       config:
@@ -335,8 +335,8 @@ en:
           auth:
             describe: "Specify auth method to use [\"personalaccesskey\", \"oauth2\", \"apikey\"]"
             defaultDescription: "\"{{ defaultType }}\": \nAn access token tied to a specific user account. This is the recommended way of authenticating with local development tools."
-          accountId:
-            describe: "Account id to authenticate to"
+          account:
+            describe: "HubSpot account to authenticate"
         success:
           configFileCreated: "The config file \"{{ configPath }}\" was created using \"{{ authType }}\" for account {{ account }}."
         info:

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -49,6 +49,9 @@ en:
           type:
             describe: "Authentication mechanism"
             defaultDescription: "\"{{ authMethod }}\": \nAn access token tied to a specific user account. This is the recommended way of authenticating with local development tools."
+        options:
+          accountId:
+            describe: "Account id to authenticate to"
         success:
           configFileUpdated: "{{ configFilename }} updated with {{ authMethod }}."
       config:
@@ -332,6 +335,8 @@ en:
           auth:
             describe: "Specify auth method to use [\"personalaccesskey\", \"oauth2\", \"apikey\"]"
             defaultDescription: "\"{{ defaultType }}\": \nAn access token tied to a specific user account. This is the recommended way of authenticating with local development tools."
+          accountId:
+            describe: "Account id to authenticate to"
         success:
           configFileCreated: "The config file \"{{ configPath }}\" was created using \"{{ authType }}\" for account {{ account }}."
         info:

--- a/packages/cli/commands/auth.js
+++ b/packages/cli/commands/auth.js
@@ -66,13 +66,13 @@ const promptForAccountNameIfNotSet = async updatedConfig => {
   }
 };
 
-exports.command = 'auth [--type] [--accountId]';
+exports.command = 'auth [type] [--account]';
 exports.describe = i18n(`${i18nKey}.describe`, {
   supportedProtocols: SUPPORTED_AUTHENTICATION_PROTOCOLS_TEXT,
 });
 
 exports.handler = async options => {
-  const { type, config: configPath, qa, accountId } = options;
+  const { type, config: configPath, qa, account } = options;
   const authType =
     (type && type.toLowerCase()) || PERSONAL_ACCESS_KEY_AUTH_METHOD.value;
   setLogLevel(options);
@@ -121,7 +121,7 @@ exports.handler = async options => {
       });
       break;
     case PERSONAL_ACCESS_KEY_AUTH_METHOD.value:
-      configData = await personalAccessKeyPrompt({ env, accountId });
+      configData = await personalAccessKeyPrompt({ env, account });
       updatedConfig = await updateConfigWithPersonalAccessKey(configData);
 
       if (!updatedConfig) {
@@ -158,25 +158,23 @@ exports.handler = async options => {
 };
 
 exports.builder = yargs => {
+  yargs.positional('type', {
+    describe: i18n(`${i18nKey}.positionals.type.describe`),
+    type: 'string',
+    choices: [
+      `${PERSONAL_ACCESS_KEY_AUTH_METHOD.value}`,
+      `${OAUTH_AUTH_METHOD.value}`,
+      `${API_KEY_AUTH_METHOD.value}`,
+    ],
+    default: PERSONAL_ACCESS_KEY_AUTH_METHOD.value,
+    defaultDescription: i18n(`${i18nKey}.positionals.type.defaultDescription`, {
+      authMethod: PERSONAL_ACCESS_KEY_AUTH_METHOD.value,
+    }),
+  });
+
   yargs.options({
-    type: {
-      describe: i18n(`${i18nKey}.positionals.type.describe`),
-      type: 'string',
-      choices: [
-        `${PERSONAL_ACCESS_KEY_AUTH_METHOD.value}`,
-        `${OAUTH_AUTH_METHOD.value}`,
-        `${API_KEY_AUTH_METHOD.value}`,
-      ],
-      default: PERSONAL_ACCESS_KEY_AUTH_METHOD.value,
-      defaultDescription: i18n(
-        `${i18nKey}.positionals.type.defaultDescription`,
-        {
-          authMethod: PERSONAL_ACCESS_KEY_AUTH_METHOD.value,
-        }
-      ),
-    },
-    accountId: {
-      describe: i18n(`${i18nKey}.options.accountId.describe`),
+    account: {
+      describe: i18n(`${i18nKey}.options.account.describe`),
       type: 'string',
     },
   });

--- a/packages/cli/commands/auth.js
+++ b/packages/cli/commands/auth.js
@@ -66,13 +66,13 @@ const promptForAccountNameIfNotSet = async updatedConfig => {
   }
 };
 
-exports.command = 'auth [type]';
+exports.command = 'auth [--type] [--accountId]';
 exports.describe = i18n(`${i18nKey}.describe`, {
   supportedProtocols: SUPPORTED_AUTHENTICATION_PROTOCOLS_TEXT,
 });
 
 exports.handler = async options => {
-  const { type, config: configPath, qa } = options;
+  const { type, config: configPath, qa, accountId } = options;
   const authType =
     (type && type.toLowerCase()) || PERSONAL_ACCESS_KEY_AUTH_METHOD.value;
   setLogLevel(options);
@@ -121,7 +121,7 @@ exports.handler = async options => {
       });
       break;
     case PERSONAL_ACCESS_KEY_AUTH_METHOD.value:
-      configData = await personalAccessKeyPrompt({ env });
+      configData = await personalAccessKeyPrompt({ env, accountId });
       updatedConfig = await updateConfigWithPersonalAccessKey(configData);
 
       if (!updatedConfig) {
@@ -158,18 +158,27 @@ exports.handler = async options => {
 };
 
 exports.builder = yargs => {
-  yargs.positional('type', {
-    describe: i18n(`${i18nKey}.positionals.type.describe`),
-    type: 'string',
-    choices: [
-      `${PERSONAL_ACCESS_KEY_AUTH_METHOD.value}`,
-      `${OAUTH_AUTH_METHOD.value}`,
-      `${API_KEY_AUTH_METHOD.value}`,
-    ],
-    default: PERSONAL_ACCESS_KEY_AUTH_METHOD.value,
-    defaultDescription: i18n(`${i18nKey}.positionals.type.defaultDescription`, {
-      authMethod: PERSONAL_ACCESS_KEY_AUTH_METHOD.value,
-    }),
+  yargs.options({
+    type: {
+      describe: i18n(`${i18nKey}.positionals.type.describe`),
+      type: 'string',
+      choices: [
+        `${PERSONAL_ACCESS_KEY_AUTH_METHOD.value}`,
+        `${OAUTH_AUTH_METHOD.value}`,
+        `${API_KEY_AUTH_METHOD.value}`,
+      ],
+      default: PERSONAL_ACCESS_KEY_AUTH_METHOD.value,
+      defaultDescription: i18n(
+        `${i18nKey}.positionals.type.defaultDescription`,
+        {
+          authMethod: PERSONAL_ACCESS_KEY_AUTH_METHOD.value,
+        }
+      ),
+    },
+    accountId: {
+      describe: i18n(`${i18nKey}.options.accountId.describe`),
+      type: 'string',
+    },
   });
 
   addConfigOptions(yargs, true);

--- a/packages/cli/commands/init.js
+++ b/packages/cli/commands/init.js
@@ -45,8 +45,8 @@ const TRACKING_STATUS = {
   COMPLETE: 'complete',
 };
 
-const personalAccessKeyConfigCreationFlow = async env => {
-  const configData = await personalAccessKeyPrompt({ env });
+const personalAccessKeyConfigCreationFlow = async (env, accountId) => {
+  const configData = await personalAccessKeyPrompt({ env, accountId });
   const { name } = await promptUser([ACCOUNT_NAME]);
   const accountConfig = {
     ...configData,
@@ -85,13 +85,17 @@ const CONFIG_CREATION_FLOWS = {
   [API_KEY_AUTH_METHOD.value]: apiKeyConfigCreationFlow,
 };
 
-exports.command = 'init';
+exports.command = 'init [--auth] [--accountId]';
 exports.describe = i18n(`${i18nKey}.describe`, {
   configName: DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME,
 });
 
 exports.handler = async options => {
-  const { auth: authType = PERSONAL_ACCESS_KEY_AUTH_METHOD.value, c } = options;
+  const {
+    auth: authType = PERSONAL_ACCESS_KEY_AUTH_METHOD.value,
+    c,
+    accountId: optionalAccountId,
+  } = options;
   const configPath = (c && path.join(getCwd(), c)) || getConfigPath();
   setLogLevel(options);
   logDebugInfo(options);
@@ -115,7 +119,10 @@ exports.handler = async options => {
   handleExit(deleteEmptyConfigFile);
 
   try {
-    const { accountId, name } = await CONFIG_CREATION_FLOWS[authType](env);
+    const { accountId, name } = await CONFIG_CREATION_FLOWS[authType](
+      env,
+      optionalAccountId
+    );
     const configPath = getConfigPath();
 
     logger.success(
@@ -135,18 +142,24 @@ exports.handler = async options => {
 };
 
 exports.builder = yargs => {
-  yargs.option('auth', {
-    describe: i18n(`${i18nKey}.options.auth.describe`),
-    type: 'string',
-    choices: [
-      `${PERSONAL_ACCESS_KEY_AUTH_METHOD.value}`,
-      `${OAUTH_AUTH_METHOD.value}`,
-      `${API_KEY_AUTH_METHOD.value}`,
-    ],
-    default: PERSONAL_ACCESS_KEY_AUTH_METHOD.value,
-    defaultDescription: i18n(`${i18nKey}.options.auth.defaultDescription`, {
-      defaultType: PERSONAL_ACCESS_KEY_AUTH_METHOD.value,
-    }),
+  yargs.options({
+    auth: {
+      describe: i18n(`${i18nKey}.options.auth.describe`),
+      type: 'string',
+      choices: [
+        `${PERSONAL_ACCESS_KEY_AUTH_METHOD.value}`,
+        `${OAUTH_AUTH_METHOD.value}`,
+        `${API_KEY_AUTH_METHOD.value}`,
+      ],
+      default: PERSONAL_ACCESS_KEY_AUTH_METHOD.value,
+      defaultDescription: i18n(`${i18nKey}.options.auth.defaultDescription`, {
+        defaultType: PERSONAL_ACCESS_KEY_AUTH_METHOD.value,
+      }),
+    },
+    accountId: {
+      describe: i18n(`${i18nKey}.options.accountId.describe`),
+      type: 'string',
+    },
   });
 
   addConfigOptions(yargs, true);

--- a/packages/cli/commands/init.js
+++ b/packages/cli/commands/init.js
@@ -45,8 +45,8 @@ const TRACKING_STATUS = {
   COMPLETE: 'complete',
 };
 
-const personalAccessKeyConfigCreationFlow = async (env, accountId) => {
-  const configData = await personalAccessKeyPrompt({ env, accountId });
+const personalAccessKeyConfigCreationFlow = async (env, account) => {
+  const configData = await personalAccessKeyPrompt({ env, account });
   const { name } = await promptUser([ACCOUNT_NAME]);
   const accountConfig = {
     ...configData,
@@ -85,7 +85,7 @@ const CONFIG_CREATION_FLOWS = {
   [API_KEY_AUTH_METHOD.value]: apiKeyConfigCreationFlow,
 };
 
-exports.command = 'init [--auth] [--accountId]';
+exports.command = 'init [--auth] [--account]';
 exports.describe = i18n(`${i18nKey}.describe`, {
   configName: DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME,
 });
@@ -94,7 +94,7 @@ exports.handler = async options => {
   const {
     auth: authType = PERSONAL_ACCESS_KEY_AUTH_METHOD.value,
     c,
-    accountId: optionalAccountId,
+    account: optionalAccount,
   } = options;
   const configPath = (c && path.join(getCwd(), c)) || getConfigPath();
   setLogLevel(options);
@@ -121,7 +121,7 @@ exports.handler = async options => {
   try {
     const { accountId, name } = await CONFIG_CREATION_FLOWS[authType](
       env,
-      optionalAccountId
+      optionalAccount
     );
     const configPath = getConfigPath();
 
@@ -156,8 +156,8 @@ exports.builder = yargs => {
         defaultType: PERSONAL_ACCESS_KEY_AUTH_METHOD.value,
       }),
     },
-    accountId: {
-      describe: i18n(`${i18nKey}.options.accountId.describe`),
+    account: {
+      describe: i18n(`${i18nKey}.options.account.describe`),
       type: 'string',
     },
   });

--- a/packages/cli/lib/prompts/personalAccessKeyPrompt.js
+++ b/packages/cli/lib/prompts/personalAccessKeyPrompt.js
@@ -15,10 +15,13 @@ const i18nKey = 'cli.lib.prompts.personalAccessKeyPrompt';
  * Displays notification to user that we are about to open the browser,
  * then opens their browser to the personal-access-key shortlink
  */
-const personalAccessKeyPrompt = async ({ env } = {}) => {
+const personalAccessKeyPrompt = async ({ env, accountId } = {}) => {
   const websiteOrigin = getHubSpotWebsiteOrigin(env);
-  const url = `${websiteOrigin}/l/personal-access-key`;
+  let url = `${websiteOrigin}/l/personal-access-key`;
   if (process.env.BROWSER !== 'none') {
+    if (accountId) {
+      url = `${websiteOrigin}/personal-access-key/${accountId}`;
+    }
     await promptUser([PERSONAL_ACCESS_KEY_BROWSER_OPEN_PREP]);
     open(url, { url: true });
   }

--- a/packages/cli/lib/prompts/personalAccessKeyPrompt.js
+++ b/packages/cli/lib/prompts/personalAccessKeyPrompt.js
@@ -15,12 +15,12 @@ const i18nKey = 'cli.lib.prompts.personalAccessKeyPrompt';
  * Displays notification to user that we are about to open the browser,
  * then opens their browser to the personal-access-key shortlink
  */
-const personalAccessKeyPrompt = async ({ env, accountId } = {}) => {
+const personalAccessKeyPrompt = async ({ env, account } = {}) => {
   const websiteOrigin = getHubSpotWebsiteOrigin(env);
   let url = `${websiteOrigin}/l/personal-access-key`;
   if (process.env.BROWSER !== 'none') {
-    if (accountId) {
-      url = `${websiteOrigin}/personal-access-key/${accountId}`;
+    if (account) {
+      url = `${websiteOrigin}/personal-access-key/${account}`;
     }
     await promptUser([PERSONAL_ACCESS_KEY_BROWSER_OPEN_PREP]);
     open(url, { url: true });


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->

- Adds `--account` option to both `hs auth` and `hs init` which will change the PAK prompt link and forward the user directly to the PAK generation page. 
- Changes the `hs auth` `[type]` positional to an optional. Updated command help text to reflect

## Screenshots
<!-- Provide images of the before and after functionality -->
<img width="1181" alt="Screen Shot 2022-05-06 at 12 38 05 PM" src="https://user-images.githubusercontent.com/16788677/167175276-a153be57-906a-49b7-b96b-8ead7a150b4e.png">

<img width="1067" alt="Screen Shot 2022-05-06 at 12 38 41 PM" src="https://user-images.githubusercontent.com/16788677/167175520-473c528d-9922-432e-b726-b705f56532c1.png">

<img width="1183" alt="Screen Shot 2022-05-06 at 12 39 34 PM" src="https://user-images.githubusercontent.com/16788677/167175540-7177f254-79c0-4f49-aeae-0873d07f90ef.png">


## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
