### PR TITLE
Allow .hubl extension

### DIFF
--- a/packages/cli-lib/lib/constants.js
+++ b/packages/cli-lib/lib/constants.js
@@ -21,8 +21,9 @@ const ALLOWED_EXTENSIONS = new Set([
   'woff',
   'woff2',
   'graphql',
+  'hubl',
 ]);
-const HUBL_EXTENSIONS = new Set(['css', 'html', 'js']);
+const HUBL_EXTENSIONS = new Set(['css', 'html', 'js', 'hubl']);
 const MODULE_EXTENSION = 'module';
 const FUNCTIONS_EXTENSION = 'functions';
 


### PR DESCRIPTION
## Description and Context

Allow `.hubl` extension files, used for example to store macros to be shared between HTML and CSS files.
Changed the `ALLOWED_EXTENSIONS` and `HUBL_EXTENSIONS` variables.