### PR TITLE
Delete sandbox placeholder message

### DIFF
--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -590,6 +590,8 @@ en:
             options:
               account:
                 describe: "Account name or id to delete"
+            temporaryMessage: "The CLI currently does not support deleting sandboxes.
+              \n\nTo delete a sandbox, go to https://app.hubspot.com and navigate to the Sandboxes accounts page to delete your sandbox.\n"
       secrets:
         describe: "Manage HubSpot secrets."
         subcommands:

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -578,6 +578,18 @@ en:
                 instructions: "To update CLI permissions for \"{{ accountName }}\":
                   \n- Go to {{ url }}, deactivate the existing personal access key, and create a new one that includes Sandboxes permissions.
                   \n- Update the CLI config for this account by running `hs auth` and entering the new key.\n"
+          delete:
+            describe: "Delete a sandbox account"
+            examples:
+              default: "Deletes the sandbox account named MySandboxAccount."
+            success:
+              delete: "Sandbox \"{{ name }}\" with portalId \"{{ sandboxHubId }}\" deleted successfully."
+              configFileUpdated: "Removed account {{ account }} from {{ configFilename }}."
+            failure:
+              delete: "Unable to delete sandbox account {{ account }}."
+            options:
+              account:
+                describe: "Account name or id to delete"
       secrets:
         describe: "Manage HubSpot secrets."
         subcommands:

--- a/packages/cli/commands/sandbox.js
+++ b/packages/cli/commands/sandbox.js
@@ -1,5 +1,6 @@
 const { addConfigOptions, addAccountOptions } = require('../lib/commonOpts');
 const create = require('./sandbox/create');
+const del = require('./sandbox/delete');
 
 // const i18nKey = 'cli.commands.sandbox';
 
@@ -10,7 +11,10 @@ exports.builder = yargs => {
   addConfigOptions(yargs, true);
   addAccountOptions(yargs, true);
 
-  yargs.command(create).demandCommand(1, '');
+  yargs
+    .command(create)
+    .command(del)
+    .demandCommand(1, '');
 
   return yargs;
 };

--- a/packages/cli/commands/sandbox/delete.js
+++ b/packages/cli/commands/sandbox/delete.js
@@ -1,0 +1,44 @@
+const {
+  addAccountOptions,
+  addConfigOptions,
+  addUseEnvironmentOptions,
+} = require('../../lib/commonOpts');
+const { logger } = require('@hubspot/cli-lib/logger');
+
+const { loadAndValidateOptions } = require('../../lib/validation');
+const { i18n } = require('@hubspot/cli-lib/lib/lang');
+
+const i18nKey = 'cli.commands.sandbox.subcommands.delete';
+
+exports.command = 'delete';
+exports.describe = i18n(`${i18nKey}.describe`);
+
+exports.handler = async options => {
+  await loadAndValidateOptions(options);
+
+  logger.log('');
+  logger.log(
+    `The CLI currently does not support deleting sandboxes.
+    \nTo delete a sandbox, go to your HubSpot portal and navigate to the Sandboxes accounts page to delete your sandbox.\n`
+  );
+};
+
+exports.builder = yargs => {
+  yargs.option('account', {
+    describe: i18n(`${i18nKey}.options.account.describe`),
+    type: 'string',
+  });
+
+  yargs.example([
+    [
+      '$0 sandbox delete --account=MySandboxAccount',
+      i18n(`${i18nKey}.examples.default`),
+    ],
+  ]);
+
+  addConfigOptions(yargs, true);
+  addAccountOptions(yargs, true);
+  addUseEnvironmentOptions(yargs, true);
+
+  return yargs;
+};

--- a/packages/cli/commands/sandbox/delete.js
+++ b/packages/cli/commands/sandbox/delete.js
@@ -17,10 +17,7 @@ exports.handler = async options => {
   await loadAndValidateOptions(options);
 
   logger.log('');
-  logger.log(
-    `The CLI currently does not support deleting sandboxes.
-    \nTo delete a sandbox, go to your HubSpot portal and navigate to the Sandboxes accounts page to delete your sandbox.\n`
-  );
+  logger.log(i18n(`${i18nKey}.temporaryMessage`));
 };
 
 exports.builder = yargs => {


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->

Add a placeholder command for `hs sandbox delete` where we display a message telling the user to go to their HubSpot portal to delete the account. 

## Screenshots
<!-- Provide images of the before and after functionality -->
<img width="594" alt="Screen Shot 2022-05-17 at 6 39 48 PM" src="https://user-images.githubusercontent.com/16788677/168924507-ef4b3960-bf2b-464c-bb2d-07a31835e954.png">

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

We will eventually replace this with an actual delete command once `LocalDevAuth` is updated to include hubTypes. Issue tracked here: https://git.hubteam.com/HubSpot/hubspot-cli-issues/issues/327


## Who to Notify
<!-- /cc those you wish to know about the PR -->

@brandenrodgers @erincouse
