### PR TITLE
Prevent max event listener warning on watch

### DIFF
--- a/packages/cli-lib/lib/process.js
+++ b/packages/cli-lib/lib/process.js
@@ -27,6 +27,8 @@ const handleKeypress = callback => {
     process.stdin.setRawMode(true);
   }
 
+  process.stdin.removeAllListeners('keypress');
+
   process.stdin.on('keypress', (str, key) => {
     if (key) {
       callback(key);


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
There was an issue where running the watch command for a while would cause a "max event listener limit exceeded" warning to show (See screenshot).

## Screenshots
<!-- Provide images of the before and after functionality -->
<img width="865" alt="image" src="https://user-images.githubusercontent.com/6654014/169876109-3cfdb086-bfe7-4e4d-abd1-6f626100590f.png">

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
