### PR TITLE
Log nested errors for project build failures

### DIFF
--- a/packages/cli/lib/projects.js
+++ b/packages/cli/lib/projects.js
@@ -449,6 +449,14 @@ const makePollTaskStatusFunc = ({
                   } with the following error ---`
                 );
                 logger.error(subTask.errorMessage);
+
+                // Log nested errors
+                if (subTask.standardError && subTask.standardError.errors) {
+                  logger.log();
+                  subTask.standardError.errors.forEach(error => {
+                    logger.log(error.message);
+                  });
+                }
               });
             }
 


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
We weren't logging out the nested build errors on project upload. This made it tricky to debug issues without having to go into hubspot.com.

## Screenshots
<!-- Provide images of the before and after functionality -->
#### Before
<img width="867" alt="image" src="https://user-images.githubusercontent.com/6654014/172503687-bdbbf088-7a87-4a87-8ede-849c9d231dd4.png">

#### After
<img width="867" alt="image" src="https://user-images.githubusercontent.com/6654014/172503704-9085e713-787e-4d85-bd4f-a0ebb029d9d4.png">

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->
- [x] Verify that it's safe to always log the contents of `subTask.standardError.errors`

## Who to Notify
<!-- /cc those you wish to know about the PR -->
