### PR TITLE
Improved --use-env errors

### DIFF
--- a/packages/cli-lib/lib/config.js
+++ b/packages/cli-lib/lib/config.js
@@ -261,7 +261,7 @@ const loadConfig = (
     environmentVariableConfigLoaded = true;
     return;
   } else {
-    logger.debug(`Loaded config from ${path}`);
+    logger.debug(`Loading config from ${path}`);
     loadConfigFromFile(path, options);
     environmentVariableConfigLoaded = false;
   }
@@ -660,6 +660,7 @@ const loadConfigFromEnvironment = () => {
   } else if (apiKey) {
     return generateApiKeyConfig(portalId, apiKey, env);
   } else {
+    logger.error('Unable to load config from environment variables.');
     return;
   }
 };

--- a/packages/cli-lib/lib/config.js
+++ b/packages/cli-lib/lib/config.js
@@ -641,8 +641,11 @@ const loadConfigFromEnvironment = () => {
     refreshToken,
     env,
   } = getConfigVariablesFromEnv();
+  const unableToLoadEnvConfigError =
+    'Unable to load config from environment variables.';
 
   if (!portalId) {
+    logger.error(unableToLoadEnvConfigError);
     return;
   }
 
@@ -660,7 +663,7 @@ const loadConfigFromEnvironment = () => {
   } else if (apiKey) {
     return generateApiKeyConfig(portalId, apiKey, env);
   } else {
-    logger.error('Unable to load config from environment variables.');
+    logger.error(unableToLoadEnvConfigError);
     return;
   }
 };


### PR DESCRIPTION
## Description and Context
When running a command with `--use-env` option, there are no useful errors displayed if a config cannot be loaded using the environment variables that are supplied.

This adds an error that states `Unable to load config from environment variables.` if this is the case.

## Screenshots
![image](https://user-images.githubusercontent.com/6472448/172928764-0f1f7afa-e786-42d3-96b5-aadf1cbb1348.png)

## Who to Notify
@bmatto 
