### PR TITLE
Update link to the private app logs

### DIFF
--- a/packages/cli-lib/api/dfs.js
+++ b/packages/cli-lib/api/dfs.js
@@ -183,19 +183,16 @@ async function fetchProjectSettings(accountId, projectName) {
 }
 
 /**
- * Fetch deploy components and sub components metadata
+ * Fetch top-level deploy components metadata
  *
  * @async
  * @param {number} accountId
  * @param {number} projectId
  * @returns {Promise}
  */
-async function fetchDeployComponentsAndSubComponentsMetadata(
-  accountId,
-  projectId
-) {
+async function fetchDeployComponentsMetadata(accountId, projectId) {
   return http.get(accountId, {
-    uri: `${PROJECTS_API_PATH}/by-id/${projectId}/deploy-components-and-sub-components-metadata`,
+    uri: `${PROJECTS_API_PATH}/by-id/${projectId}/deploy-components-metadata`,
   });
 }
 
@@ -297,7 +294,7 @@ module.exports = {
   fetchProjectBuilds,
   fetchProjects,
   fetchProjectSettings,
-  fetchDeployComponentsAndSubComponentsMetadata,
+  fetchDeployComponentsMetadata,
   getBuildStatus,
   getDeployStatus,
   provisionBuild,

--- a/packages/cli-lib/api/dfs.js
+++ b/packages/cli-lib/api/dfs.js
@@ -183,6 +183,23 @@ async function fetchProjectSettings(accountId, projectName) {
 }
 
 /**
+ * Fetch deploy components and sub components metadata
+ *
+ * @async
+ * @param {number} accountId
+ * @param {number} projectId
+ * @returns {Promise}
+ */
+async function fetchDeployComponentsAndSubComponentsMetadata(
+  accountId,
+  projectId
+) {
+  return http.get(accountId, {
+    uri: `${PROJECTS_API_PATH}/by-id/${projectId}/deploy-components-and-sub-components-metadata`,
+  });
+}
+
+/**
  * Provision new project build
  *
  * @async
@@ -280,6 +297,7 @@ module.exports = {
   fetchProjectBuilds,
   fetchProjects,
   fetchProjectSettings,
+  fetchDeployComponentsAndSubComponentsMetadata,
   getBuildStatus,
   getDeployStatus,
   provisionBuild,

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -441,6 +441,7 @@ en:
             logs:
               showingLogs: "Showing logs for:"
               hubspotLogsLink: "View private apps in HubSpot"
+              hubspotLogsDirectLink: "View logs in HubSpot"
               noLogsFound: "No logs were found for \"{{ name }}\""
             table:
               accountHeader: "Account"

--- a/packages/cli/commands/project/logs.js
+++ b/packages/cli/commands/project/logs.js
@@ -217,12 +217,15 @@ exports.handler = async options => {
   );
 
   logger.log(
-    uiLink(
-      i18n(`${i18nKey}.logs.hubspotLogsLink`),
-      appId
-        ? `${getPrivateAppsUrl(accountId)}/${appId}`
-        : getPrivateAppsUrl(accountId)
-    )
+    appId
+      ? uiLink(
+          i18n(`${i18nKey}.logs.hubspotLogsDirectLink`),
+          `${getPrivateAppsUrl(accountId)}/${appId}/logs/extensions`
+        )
+      : uiLink(
+          i18n(`${i18nKey}.logs.hubspotLogsLink`),
+          getPrivateAppsUrl(accountId)
+        )
   );
   logger.log();
   uiLine();

--- a/packages/cli/commands/project/logs.js
+++ b/packages/cli/commands/project/logs.js
@@ -12,7 +12,7 @@ const { logger } = require('@hubspot/cli-lib/logger');
 const { outputLogs } = require('@hubspot/cli-lib/lib/logs');
 const {
   fetchProject,
-  fetchDeployComponentsAndSubComponentsMetadata,
+  fetchDeployComponentsMetadata,
 } = require('@hubspot/cli-lib/api/dfs');
 const {
   getTableContents,
@@ -157,14 +157,14 @@ exports.handler = async options => {
       projectName
     );
 
-    const {
-      results: components,
-    } = await fetchDeployComponentsAndSubComponentsMetadata(
+    const { results: deployComponents } = await fetchDeployComponentsMetadata(
       accountId,
       projectId
     );
 
-    const appComponent = components.find(s => s.componentName === appName);
+    const appComponent = deployComponents.find(
+      c => c.componentName === appName
+    );
 
     if (appComponent) {
       appId = appComponent.componentIdentifier;


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
Currently, when running `hs project logs --follow`, there is a link to view all of the private apps in HubSpot that goes to: `app.hubspot.com/private-apps/{portalId}`

This PR updates the link to go directly to the app's logs: `app.hubspot.com/private-apps/{portalId}/{appId}/logs/extensions` when the `appId` can be found from the `fetchDeployComponentsMetadata` endpoint.

## Screenshots
<!-- Provide images of the before and after functionality -->
### Before
<img width="896" alt="image" src="https://user-images.githubusercontent.com/25800753/176790252-eabf1b69-bfb0-47e9-a104-a6baadc3de9c.png">

### After
<img width="896" alt="image" src="https://user-images.githubusercontent.com/25800753/176790299-4ea63809-1e9b-4c4d-ae63-a037eee6ccf2.png">


## Who to Notify
<!-- /cc those you wish to know about the PR -->
@brandenrodgers