### PR TITLE
Fixing the error output for project watch command

### DIFF
--- a/packages/cli-lib/projectsWatch.js
+++ b/packages/cli-lib/projectsWatch.js
@@ -120,7 +120,12 @@ const createNewBuild = async (accountId, projectName) => {
     const { buildId } = await provisionBuild(accountId, projectName);
     return buildId;
   } catch (err) {
-    if (err.error.subCategory === 'PipelineErrors.PROJECT_LOCKED') {
+    if (
+      err.error.subCategory === 'PipelineErrors.PROJECT_MANAGED_THROUGH_GITHUB'
+    ) {
+      logApiErrorInstance(err, new ApiErrorContext({ accountId, projectName }));
+      process.exit(1);
+    } else if (err.error.subCategory === 'PipelineErrors.PROJECT_LOCKED') {
       logger.error(i18n(`${i18nKey}.errors.projectLocked`));
     } else {
       logApiErrorInstance(err, new ApiErrorContext({ accountId, projectName }));


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
Catching the scenario where we attempt to create a staged build, but the project is connected to a github repo. We were unintentionally spitting out the error twice.

## Screenshots
<!-- Provide images of the before and after functionality -->
#### Before
<img width="866" alt="image (5)" src="https://user-images.githubusercontent.com/6654014/176960592-a78f62d2-9760-40a8-992d-5fca5acdeca8.png">

#### After
<img width="869" alt="image" src="https://user-images.githubusercontent.com/6654014/176960632-0abd9bc6-516d-4ea2-ab2f-1bb583a5e6cc.png">

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
