### PR TITLE
hs sandbox delete

### DIFF
--- a/packages/cli-lib/api/sandbox-hubs.js
+++ b/packages/cli-lib/api/sandbox-hubs.js
@@ -8,6 +8,13 @@ async function createSandbox(accountId, name) {
   });
 }
 
+async function deleteSandbox(parentAccountId, sandboxAccountId) {
+  return http.delete(parentAccountId, {
+    uri: `${SANDBOX_API_PATH}/${sandboxAccountId}`,
+  });
+}
+
 module.exports = {
   createSandbox,
+  deleteSandbox,
 };

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -591,6 +591,8 @@ en:
                   \n- Update the CLI config for this account by running `hs auth` and entering the new key.\n"
           delete:
             describe: "Delete a sandbox account"
+            debug:
+              deleting: "Deleting sandbox account \"{{ account }}\""
             examples:
               default: "Deletes the sandbox account named MySandboxAccount."
             success:
@@ -849,6 +851,8 @@ en:
           enterName: "Enter a name to use for the sandbox: "
           errors:
             invalidName: "You entered an invalid name. Please try again."
+          selectAccountName: "Select the sandbox account you want to delete"
+          selectParentAccountName: "Select the account that the sandbox belongs to"
         uploadPrompt:
           enterDest: "[--dest] Enter the destination path: "
           enterSrc: "[--src] Enter the source path: "

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -602,6 +602,7 @@ en:
               delete: "Sandbox \"{{ account }}\" with portalId \"{{ sandboxHubId }}\" deleted successfully."
               configFileUpdated: "Removed account {{ account }} from {{ configFilename }}."
             objectNotFound: "Sandbox {{#bold}}{{ account }}{{/bold}} not found, it may have already been deleted."
+            noParentPortalAvailable: "This sandbox can't be deleted from the CLI because you haven't given the CLI access to its parent account. To do this, run {{#bold}}{{ command }}{{/bold}}. You can also delete the sandbox from HubSpot management tool: {{#bold}}{{ url }}{{/bold}}."
             options:
               account:
                 describe: "Account name or id to delete"

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -600,11 +600,10 @@ en:
             success:
               delete: "Sandbox \"{{ account }}\" with portalId \"{{ sandboxHubId }}\" deleted successfully."
               configFileUpdated: "Removed account {{ account }} from {{ configFilename }}."
+            objectNotFound: "Sandbox {{#bold}}{{ account }}{{/bold}} not found, it may have already been deleted."
             options:
               account:
                 describe: "Account name or id to delete"
-            temporaryMessage: "The CLI currently does not support deleting sandboxes.
-              \n\nTo delete a sandbox, go to https://app.hubspot.com and navigate to the Sandboxes accounts page to delete your sandbox.\n"
       secrets:
         describe: "Manage HubSpot secrets."
         subcommands:

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -602,7 +602,7 @@ en:
               delete: "Sandbox \"{{ account }}\" with portalId \"{{ sandboxHubId }}\" deleted successfully."
               configFileUpdated: "Removed account {{ account }} from {{ configFilename }}."
             objectNotFound: "Sandbox {{#bold}}{{ account }}{{/bold}} not found, it may have already been deleted."
-            noParentPortalAvailable: "This sandbox can't be deleted from the CLI because you haven't given the CLI access to its parent account. To do this, run {{#bold}}{{ command }}{{/bold}}. You can also delete the sandbox from HubSpot management tool: {{#bold}}{{ url }}{{/bold}}."
+            noParentPortalAvailable: "This sandbox can't be deleted from the CLI because you haven't given the CLI access to its parent account. To do this, run {{#bold}}{{ command }}{{/bold}}. You can also delete the sandbox from the HubSpot management tool: {{#bold}}{{ url }}{{/bold}}."
             options:
               account:
                 describe: "Account name or id to delete"

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -598,8 +598,6 @@ en:
             success:
               delete: "Sandbox \"{{ account }}\" with portalId \"{{ sandboxHubId }}\" deleted successfully."
               configFileUpdated: "Removed account {{ account }} from {{ configFilename }}."
-            failure:
-              delete: "Unable to delete sandbox account {{ account }}."
             options:
               account:
                 describe: "Account name or id to delete"

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -571,8 +571,6 @@ en:
         subcommands:
           create:
             describe: "Create a sandbox account"
-            debug:
-              creating: "Creating sandbox \"{{ name }}\""
             examples:
               default: "Creates a sandbox account named MySandboxAccount."
             info:
@@ -580,8 +578,11 @@ en:
             positionals:
               name:
                 describe: "Name to use for created sandbox"
+            loading:
+              add: "Creating sandbox {{#bold}}{{ sandboxName }}{{/bold}}"
+              fail: "Failed to create sandbox {{#bold}}{{ sandboxName }}{{/bold}}."
+              succeed: "Successfully created sandbox {{#bold}}{{ name }}{{/bold}} with portalId {{#bold}}{{ sandboxHubId }}{{/bold}}."
             success:
-              create: "Sandbox \"{{ name }}\" with portalId \"{{ sandboxHubId }}\" created successfully."
               configFileUpdated: "{{ configFilename }} updated with {{ authMethod }} for account {{ account }}."
             failure:
               scopes:
@@ -595,6 +596,7 @@ en:
               deleting: "Deleting sandbox account \"{{ account }}\""
             examples:
               default: "Deletes the sandbox account named MySandboxAccount."
+            confirm: "Delete sandbox {{#bold}}{{ account }}{{/bold}}? All data for this sandbox will be permanently deleted."
             success:
               delete: "Sandbox \"{{ account }}\" with portalId \"{{ sandboxHubId }}\" deleted successfully."
               configFileUpdated: "Removed account {{ account }} from {{ configFilename }}."

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -596,7 +596,7 @@ en:
             examples:
               default: "Deletes the sandbox account named MySandboxAccount."
             success:
-              delete: "Sandbox \"{{ name }}\" with portalId \"{{ sandboxHubId }}\" deleted successfully."
+              delete: "Sandbox \"{{ account }}\" with portalId \"{{ sandboxHubId }}\" deleted successfully."
               configFileUpdated: "Removed account {{ account }} from {{ configFilename }}."
             failure:
               delete: "Unable to delete sandbox account {{ account }}."

--- a/packages/cli-lib/lib/config.js
+++ b/packages/cli-lib/lib/config.js
@@ -368,7 +368,7 @@ const removeAccountFromConfig = nameOrId => {
   let promptDefaultAccount = false;
 
   if (!accountId) {
-    throw new Error(`No account found with ${nameOrId}.`);
+    throw new Error(`Unable to find account for ${nameOrId}.`);
   }
 
   const accountConfig = getAccountConfig(accountId);
@@ -411,7 +411,7 @@ const updateAccountConfig = configOptions => {
   } = configOptions;
 
   if (!portalId) {
-    throw new Error('An portalId is required to update the config');
+    throw new Error('A portalId is required to update the config');
   }
 
   const config = getAndLoadConfigIfNeeded();

--- a/packages/cli-lib/lib/config.js
+++ b/packages/cli-lib/lib/config.js
@@ -362,6 +362,37 @@ const getAccountId = nameOrId => {
 /**
  * @throws {Error}
  */
+const removeAccountFromConfig = nameOrId => {
+  const config = getAndLoadConfigIfNeeded();
+  const accountId = getAccountId(nameOrId);
+  let promptDefaultAccount = false;
+
+  if (!accountId) {
+    throw new Error(`No account found with ${nameOrId}.`);
+  }
+
+  const accountConfig = getAccountConfig(accountId);
+
+  if (config.defaultPortal === accountConfig.name) {
+    promptDefaultAccount = true;
+  }
+
+  let accounts = getConfigAccounts(config);
+
+  if (accountConfig) {
+    logger.debug(`Deleting config for ${accountId}`);
+    const index = accounts.indexOf(accountConfig);
+    accounts.splice(index, 1);
+  }
+
+  writeConfig();
+
+  return promptDefaultAccount;
+};
+
+/**
+ * @throws {Error}
+ */
 const updateAccountConfig = configOptions => {
   const {
     portalId,
@@ -715,6 +746,7 @@ module.exports = {
   loadConfigFromEnvironment,
   getAccountConfig,
   getAccountId,
+  removeAccountFromConfig,
   updateAccountConfig,
   updateDefaultAccount,
   updateDefaultMode,

--- a/packages/cli-lib/sandboxes.js
+++ b/packages/cli-lib/sandboxes.js
@@ -1,10 +1,8 @@
 /* eslint-disable no-useless-catch */
-const { EXIT_CODES } = require('../cli/lib/enums/exitCodes');
 const {
   createSandbox: _createSandbox,
   deleteSandbox: _deleteSandbox,
 } = require('./api/sandbox-hubs');
-const { logger } = require('./logger');
 
 /**
  * Creates a new Sandbox portal instance.
@@ -32,8 +30,7 @@ async function deleteSandbox(parentAccountId, sandboxAccountId) {
   try {
     resp = await _deleteSandbox(parentAccountId, sandboxAccountId);
   } catch (err) {
-    logger.error(err.error.message);
-    process.exit(EXIT_CODES.ERROR);
+    throw err;
   }
 
   return {

--- a/packages/cli-lib/sandboxes.js
+++ b/packages/cli-lib/sandboxes.js
@@ -32,7 +32,6 @@ async function deleteSandbox(parentAccountId, sandboxAccountId) {
   try {
     resp = await _deleteSandbox(parentAccountId, sandboxAccountId);
   } catch (err) {
-    console.log('err: ', err.error);
     logger.error(err.error.message);
     process.exit(EXIT_CODES.ERROR);
   }

--- a/packages/cli-lib/sandboxes.js
+++ b/packages/cli-lib/sandboxes.js
@@ -1,5 +1,10 @@
 /* eslint-disable no-useless-catch */
-const { createSandbox: _createSandbox } = require('./api/sandbox-hubs');
+const { EXIT_CODES } = require('../cli/lib/enums/exitCodes');
+const {
+  createSandbox: _createSandbox,
+  deleteSandbox: _deleteSandbox,
+} = require('./api/sandbox-hubs');
+const { logger } = require('./logger');
 
 /**
  * Creates a new Sandbox portal instance.
@@ -21,6 +26,25 @@ async function createSandbox(accountId, name) {
   };
 }
 
+async function deleteSandbox(parentAccountId, sandboxAccountId) {
+  let resp;
+
+  try {
+    resp = await _deleteSandbox(parentAccountId, sandboxAccountId);
+  } catch (err) {
+    console.log('err: ', err.error);
+    logger.error(err.error.message);
+    process.exit(EXIT_CODES.ERROR);
+  }
+
+  return {
+    parentAccountId,
+    sandboxAccountId,
+    ...resp,
+  };
+}
+
 module.exports = {
   createSandbox,
+  deleteSandbox,
 };

--- a/packages/cli/commands/accounts/use.js
+++ b/packages/cli/commands/accounts/use.js
@@ -6,17 +6,10 @@ const {
   getAccountId: getAccountIdFromConfig,
 } = require('@hubspot/cli-lib/lib/config');
 
-const { setLogLevel } = require('../../lib/commonOpts');
 const { trackCommandUsage } = require('../../lib/usageTracking');
 const { i18n } = require('@hubspot/cli-lib/lib/lang');
 const { selectAccountFromConfig } = require('../../lib/prompts/accountsPrompt');
-const { logDebugInfo } = require('../../lib/debugInfo');
-const {
-  loadConfig,
-  checkAndWarnGitInclusion,
-  validateConfig,
-} = require('@hubspot/cli-lib');
-const { EXIT_CODES } = require('../../lib/enums/exitCodes');
+const { loadAndValidateOptions } = require('../../lib/validation');
 
 const i18nKey = 'cli.commands.accounts.subcommands.use';
 
@@ -24,19 +17,7 @@ exports.command = 'use [--account]';
 exports.describe = i18n(`${i18nKey}.describe`);
 
 exports.handler = async options => {
-  /*
-    Extracted loadAndValidateOptions for cases where
-    the set default account does not exist
-  */
-
-  setLogLevel(options);
-  logDebugInfo(options);
-  const { config: configPath } = options;
-  loadConfig(configPath, options);
-  checkAndWarnGitInclusion(getConfigPath());
-  if (!validateConfig()) {
-    process.exit(EXIT_CODES.ERROR);
-  }
+  await loadAndValidateOptions(options, false);
 
   const config = getConfig();
 

--- a/packages/cli/commands/accounts/use.js
+++ b/packages/cli/commands/accounts/use.js
@@ -37,7 +37,7 @@ exports.command = 'use [--account]';
 exports.describe = i18n(`${i18nKey}.describe`);
 
 exports.handler = async options => {
-  await loadAndValidateOptions({ debug: options.debug });
+  await loadAndValidateOptions(options);
 
   const accountId = getAccountId(options);
   const config = getConfig();

--- a/packages/cli/commands/accounts/use.js
+++ b/packages/cli/commands/accounts/use.js
@@ -11,7 +11,12 @@ const { trackCommandUsage } = require('../../lib/usageTracking');
 const { i18n } = require('@hubspot/cli-lib/lib/lang');
 const { selectAccountFromConfig } = require('../../lib/prompts/accountsPrompt');
 const { logDebugInfo } = require('../../lib/debugInfo');
-const { loadConfig, checkAndWarnGitInclusion } = require('@hubspot/cli-lib');
+const {
+  loadConfig,
+  checkAndWarnGitInclusion,
+  validateConfig,
+} = require('@hubspot/cli-lib');
+const { EXIT_CODES } = require('../../lib/enums/exitCodes');
 
 const i18nKey = 'cli.commands.accounts.subcommands.use';
 
@@ -29,6 +34,9 @@ exports.handler = async options => {
   const { config: configPath } = options;
   loadConfig(configPath, options);
   checkAndWarnGitInclusion(getConfigPath());
+  if (!validateConfig()) {
+    process.exit(EXIT_CODES.ERROR);
+  }
 
   const config = getConfig();
 

--- a/packages/cli/commands/accounts/use.js
+++ b/packages/cli/commands/accounts/use.js
@@ -9,35 +9,16 @@ const { loadAndValidateOptions } = require('../../lib/validation');
 
 const { getAccountId } = require('../../lib/commonOpts');
 const { trackCommandUsage } = require('../../lib/usageTracking');
-const { promptUser } = require('../../lib/prompts/promptUtils');
 const { i18n } = require('@hubspot/cli-lib/lib/lang');
+const { selectAccountFromConfig } = require('../../lib/prompts/accountsPrompt');
 
 const i18nKey = 'cli.commands.accounts.subcommands.use';
-
-const selectAccountFromConfig = async config => {
-  const { default: selectedDefault } = await promptUser([
-    {
-      type: 'list',
-      look: false,
-      name: 'default',
-      pageSize: 20,
-      message: i18n(`${i18nKey}.promptMessage`),
-      choices: config.portals.map(p => ({
-        name: `${p.name} (${p.portalId})`,
-        value: p.name || p.portalId,
-      })),
-      default: config.defaultPortal,
-    },
-  ]);
-
-  return selectedDefault;
-};
 
 exports.command = 'use [--account]';
 exports.describe = i18n(`${i18nKey}.describe`);
 
 exports.handler = async options => {
-  await loadAndValidateOptions(options);
+  await loadAndValidateOptions({ debug: options.debug });
 
   const accountId = getAccountId(options);
   const config = getConfig();

--- a/packages/cli/commands/sandbox/create.js
+++ b/packages/cli/commands/sandbox/create.js
@@ -129,6 +129,14 @@ exports.handler = async options => {
     })
   );
   let result;
+  const twirlTimer = (function() {
+    var P = ['\\', '|', '/', '-'];
+    var x = 0;
+    return setInterval(function() {
+      process.stdout.write('\r' + P[x++]);
+      x &= 3;
+    }, 250);
+  })();
   try {
     result = await createSandbox(accountId, sandboxName).then(
       ({ name, sandboxHubId }) => {
@@ -142,7 +150,9 @@ exports.handler = async options => {
         return { name, sandboxHubId };
       }
     );
+    clearInterval(twirlTimer);
   } catch (err) {
+    clearInterval(twirlTimer);
     if (isMissingScopeError(err)) {
       logger.error(
         i18n(`${i18nKey}.failure.scopes.message`, {
@@ -167,6 +177,7 @@ exports.handler = async options => {
     process.exit(EXIT_CODES.SUCCESS);
   } catch (err) {
     logErrorInstance(err);
+    process.exit(EXIT_CODES.ERROR);
   }
 };
 

--- a/packages/cli/commands/sandbox/create.js
+++ b/packages/cli/commands/sandbox/create.js
@@ -7,7 +7,7 @@ const {
 } = require('../../lib/commonOpts');
 const { trackCommandUsage } = require('../../lib/usageTracking');
 const { logger } = require('@hubspot/cli-lib/logger');
-
+const Spinnies = require('spinnies');
 const { createSandbox } = require('@hubspot/cli-lib/sandboxes');
 const { loadAndValidateOptions } = require('../../lib/validation');
 const { createSandboxPrompt } = require('../../lib/prompts/sandboxesPrompt');
@@ -113,6 +113,10 @@ exports.handler = async options => {
   const accountId = getAccountId(options);
   const accountConfig = getAccountConfig(accountId);
   const env = options.qa ? ENVIRONMENTS.QA : ENVIRONMENTS.PROD;
+  const spinnies = new Spinnies({
+    succeedColor: 'white',
+  });
+
   let namePrompt;
 
   trackCommandUsage('sandbox-create', {}, accountId);
@@ -123,36 +127,30 @@ exports.handler = async options => {
 
   const sandboxName = name || namePrompt.name;
 
-  logger.debug(
-    i18n(`${i18nKey}.debug.creating`, {
-      name: sandboxName,
-    })
-  );
   let result;
-  const twirlTimer = (function() {
-    var P = ['\\', '|', '/', '-'];
-    var x = 0;
-    return setInterval(function() {
-      process.stdout.write('\r' + P[x++]);
-      x &= 3;
-    }, 250);
-  })();
+
   try {
-    result = await createSandbox(accountId, sandboxName).then(
-      ({ name, sandboxHubId }) => {
-        logger.log('');
-        logger.success(
-          i18n(`${i18nKey}.success.create`, {
-            name,
-            sandboxHubId,
-          })
-        );
-        return { name, sandboxHubId };
-      }
-    );
-    clearInterval(twirlTimer);
+    spinnies.add('sandboxCreate', {
+      text: i18n(`${i18nKey}.loading.add`, {
+        sandboxName,
+      }),
+    });
+
+    result = await createSandbox(accountId, sandboxName);
+
+    logger.log('');
+    spinnies.succeed('sandboxCreate', {
+      text: i18n(`${i18nKey}.loading.succeed`, {
+        name: result.name,
+        sandboxHubId: result.sandboxHubId,
+      }),
+    });
   } catch (err) {
-    clearInterval(twirlTimer);
+    spinnies.fail('sandboxCreate', {
+      text: i18n(`${i18nKey}.loading.fail`, {
+        sandboxName,
+      }),
+    });
     if (isMissingScopeError(err)) {
       logger.error(
         i18n(`${i18nKey}.failure.scopes.message`, {

--- a/packages/cli/commands/sandbox/delete.js
+++ b/packages/cli/commands/sandbox/delete.js
@@ -18,6 +18,7 @@ const {
   selectAndSetAsDefaultAccountPrompt,
 } = require('../../lib/prompts/accountsPrompt');
 const { EXIT_CODES } = require('../../lib/enums/exitCodes');
+const { promptUser } = require('../../lib/prompts/promptUtils');
 
 const i18nKey = 'cli.commands.sandbox.subcommands.delete';
 
@@ -61,6 +62,19 @@ exports.handler = async options => {
   );
 
   try {
+    const { confirmSandboxDeletePrompt: confirmed } = await promptUser([
+      {
+        name: 'confirmSandboxDeletePrompt',
+        type: 'confirm',
+        message: i18n(`${i18nKey}.confirm`, {
+          account: account || accountPrompt.account,
+        }),
+      },
+    ]);
+    if (!confirmed) {
+      process.exit(EXIT_CODES.SUCCESS);
+    }
+
     await deleteSandbox(parentAccountId, sandboxAccountId);
 
     logger.log('');

--- a/packages/cli/commands/sandbox/delete.js
+++ b/packages/cli/commands/sandbox/delete.js
@@ -2,11 +2,17 @@ const {
   addAccountOptions,
   addConfigOptions,
   addUseEnvironmentOptions,
+  getAccountId,
+  addTestingOptions,
 } = require('../../lib/commonOpts');
 const { logger } = require('@hubspot/cli-lib/logger');
-
+const { trackCommandUsage } = require('../../lib/usageTracking');
 const { loadAndValidateOptions } = require('../../lib/validation');
+
+const { deleteSandbox } = require('@hubspot/cli-lib/sandboxes');
 const { i18n } = require('@hubspot/cli-lib/lib/lang');
+const { getConfig } = require('@hubspot/cli-lib');
+const { deleteSandboxPrompt } = require('../../lib/prompts/sandboxesPrompt');
 
 const i18nKey = 'cli.commands.sandbox.subcommands.delete';
 
@@ -16,8 +22,47 @@ exports.describe = i18n(`${i18nKey}.describe`);
 exports.handler = async options => {
   await loadAndValidateOptions(options);
 
-  logger.log('');
-  logger.log(i18n(`${i18nKey}.temporaryMessage`));
+  const { account } = options;
+  const config = getConfig();
+
+  let accountPrompt;
+  if (!account) {
+    accountPrompt = await deleteSandboxPrompt(config);
+  }
+  const sandboxAccountId = getAccountId({
+    account: account || accountPrompt.account,
+  });
+
+  trackCommandUsage('sandbox-delete', {}, sandboxAccountId);
+
+  let parentAccountId;
+  for (const portal of config.portals) {
+    if (portal.portalId === sandboxAccountId) {
+      if (portal.parentAccountId) {
+        parentAccountId = portal.parentAccountId;
+      } else {
+        const parentAccountPrompt = await deleteSandboxPrompt(config, true);
+        parentAccountId = getAccountId({
+          account: parentAccountPrompt.account,
+        });
+      }
+    }
+  }
+
+  logger.debug(
+    i18n(`${i18nKey}.debug.deleting`, {
+      account: account || accountPrompt.account,
+    })
+  );
+
+  return deleteSandbox(parentAccountId, sandboxAccountId).then(() => {
+    logger.success(
+      i18n(`${i18nKey}.success.delete`, {
+        account,
+        sandboxHubId: sandboxAccountId,
+      })
+    );
+  });
 };
 
 exports.builder = yargs => {
@@ -36,6 +81,7 @@ exports.builder = yargs => {
   addConfigOptions(yargs, true);
   addAccountOptions(yargs, true);
   addUseEnvironmentOptions(yargs, true);
+  addTestingOptions(yargs, true);
 
   return yargs;
 };

--- a/packages/cli/commands/sandbox/delete.js
+++ b/packages/cli/commands/sandbox/delete.js
@@ -73,7 +73,7 @@ exports.handler = async options => {
     logger.log('');
 
     const promptDefaultAccount = removeAccountFromConfig(sandboxAccountId);
-    if (promptDefaultAccount && config.portals.length > 0) {
+    if (promptDefaultAccount) {
       await selectAndSetAsDefaultAccountPrompt(config);
     }
     process.exit(EXIT_CODES.SUCCESS);

--- a/packages/cli/commands/sandbox/delete.js
+++ b/packages/cli/commands/sandbox/delete.js
@@ -22,7 +22,7 @@ const { promptUser } = require('../../lib/prompts/promptUtils');
 
 const i18nKey = 'cli.commands.sandbox.subcommands.delete';
 
-exports.command = 'delete';
+exports.command = 'delete [--account]';
 exports.describe = i18n(`${i18nKey}.describe`);
 
 exports.handler = async options => {

--- a/packages/cli/lib/prompts/accountsPrompt.js
+++ b/packages/cli/lib/prompts/accountsPrompt.js
@@ -1,0 +1,47 @@
+const { updateDefaultAccount } = require('@hubspot/cli-lib/lib/config');
+const { promptUser } = require('./promptUtils');
+const { i18n } = require('@hubspot/cli-lib/lib/lang');
+
+const i18nKey = 'cli.commands.accounts.subcommands.use';
+
+const selectAccountFromConfig = async config => {
+  const { default: selectedDefault } = await promptUser([
+    {
+      type: 'list',
+      look: false,
+      name: 'default',
+      pageSize: 20,
+      message: i18n(`${i18nKey}.promptMessage`),
+      choices: config.portals.map(p => ({
+        name: `${p.name} (${p.portalId})`,
+        value: p.name || p.portalId,
+      })),
+      default: config.defaultPortal,
+    },
+  ]);
+
+  return selectedDefault;
+};
+
+const selectAndSetAsDefaultAccountPrompt = async config => {
+  const { default: selectedDefault } = await promptUser([
+    {
+      type: 'list',
+      look: false,
+      name: 'default',
+      pageSize: 20,
+      message: i18n(`${i18nKey}.promptMessage`),
+      choices: config.portals.map(p => ({
+        name: `${p.name} (${p.portalId})`,
+        value: p.name || p.portalId,
+      })),
+      default: config.defaultPortal,
+    },
+  ]);
+  updateDefaultAccount(selectedDefault);
+};
+
+module.exports = {
+  selectAndSetAsDefaultAccountPrompt,
+  selectAccountFromConfig,
+};

--- a/packages/cli/lib/prompts/sandboxesPrompt.js
+++ b/packages/cli/lib/prompts/sandboxesPrompt.js
@@ -19,6 +19,25 @@ const createSandboxPrompt = () => {
   ]);
 };
 
+const deleteSandboxPrompt = (config, promptParentAccount = false) => {
+  return promptUser([
+    {
+      name: 'account',
+      message: i18n(
+        promptParentAccount
+          ? `${i18nKey}.selectParentAccountName`
+          : `${i18nKey}.selectAccountName`
+      ),
+      type: 'list',
+      look: false,
+      pageSize: 20,
+      choices: config.portals.map(p => p.name || p.portalId),
+      default: config.defaultPortal,
+    },
+  ]);
+};
+
 module.exports = {
   createSandboxPrompt,
+  deleteSandboxPrompt,
 };

--- a/packages/cli/lib/validation.js
+++ b/packages/cli/lib/validation.js
@@ -26,14 +26,19 @@ const fs = require('fs');
 const path = require('path');
 const { EXIT_CODES } = require('./enums/exitCodes');
 
-async function loadAndValidateOptions(options) {
+async function loadAndValidateOptions(options, shouldValidateAccount = true) {
   setLogLevel(options);
   logDebugInfo(options);
   const { config: configPath } = options;
   loadConfig(configPath, options);
   checkAndWarnGitInclusion(getConfigPath());
 
-  if (!(validateConfig() && (await validateAccount(options)))) {
+  let validAccount = true;
+  if (shouldValidateAccount) {
+    validAccount = await validateAccount(options);
+  }
+
+  if (!(validateConfig() && validAccount)) {
     process.exit(EXIT_CODES.ERROR);
   }
 }


### PR DESCRIPTION
## Description and Context

Adds functionality to delete sandboxes using the `hs sandbox delete` command. This is the follow up PR to https://github.com/HubSpot/hubspot-cli/pull/706 where sandbox account types and parent portal IDs are saved into the config file. 

- Selecting an account to delete from the picker will pull the account from the config, verify a `parentAccountId` exists, and send delete request
- On successful delete, remove the account entry from the config file
- If the account removed was the default account, prompt user to set a new default
- As a bonus, I added a loading animation to the create sandbox step so users don't think its broken (could take a little while during create).
  - Do we maybe want to add the cli-spinner package to have better progress/loading animations? 

## Screenshots

Loom: https://www.loom.com/share/1338b9d3bcb54b17af6f45aa8caae9d2

<img width="563" alt="Screen Shot 2022-07-12 at 5 51 13 PM" src="https://user-images.githubusercontent.com/16788677/178601899-9cdb7469-d236-4fa8-bc10-5ed51f0e4bf2.png">

This only shows if the default account was the one that was deleted
<img width="565" alt="Screen Shot 2022-07-12 at 5 52 19 PM" src="https://user-images.githubusercontent.com/16788677/178601896-d9e7531f-3773-45c6-a2fb-a482cec34d7a.png">



## TODO

There is an interesting edge case/bug here. Since `hs sandbox delete` uses the parent account access token to delete the sandbox, there is a chance a user uses `hs auth` to add a sandbox without adding the parent account. While we do have access to the parent portal, I don't think we have any way to fetch the PAK of the parent portal, nor generate an access token, so the delete will break. Since we know at delete time whether or not the parent is in the config or not, we could print a message saying the parent account must be in the config or something? 

## Who to Notify
<!-- /cc those you wish to know about the PR -->

@brandenrodgers @markhazlewood @miketalley 
