### PR TITLE
Automatically generate a .gitignore file to protect the hubspot config file

### DIFF
--- a/packages/cli/commands/init.js
+++ b/packages/cli/commands/init.js
@@ -10,6 +10,7 @@ const {
 } = require('@hubspot/cli-lib/lib/config');
 const { addConfigOptions } = require('../lib/commonOpts');
 const { handleExit } = require('@hubspot/cli-lib/lib/process');
+const { checkAndUpdateGitignore } = require('@hubspot/cli-lib/lib/git');
 const { logErrorInstance } = require('@hubspot/cli-lib/errorHandlers');
 const {
   DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME,
@@ -133,6 +134,8 @@ exports.handler = async options => {
       optionalAccount
     );
     const configPath = getConfigPath();
+
+    checkAndUpdateGitignore(configPath);
 
     logger.log('');
     logger.success(


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
There are a handful of instances where users (presumably unintentionally) committed their hubspot config files into public github. This is an issue because the config files contain access keys to their HubSpot accounts. This PR updates the `hs init` command to automatically create or update a gitignore file.

## Screenshots
<!-- Provide images of the before and after functionality -->

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
