### PR TITLE
Add version param to fetch

### DIFF
--- a/packages/cli-lib/fileMapper.js
+++ b/packages/cli-lib/fileMapper.js
@@ -108,6 +108,19 @@ function getFileMapperQueryValues({ mode, options = {} }) {
 }
 
 /**
+* Determines API param based on mode an options
+*
+* @property {Object} options
+* @returns {string}
+*/
+function getAssetVersionIdentifier(options) {
+  if (options.assetVersion && options.src.startsWith("@hubspot/")) {
+    return " v" +options.assetVersion;
+  }
+ return "";
+}
+
+/**
  * TODO: Replace with TypeScript interface.
  * @typedef {Object} FileMapperNode A tree node from the filemapper API.
  * @property {string} path - Directory or file path.
@@ -378,9 +391,10 @@ async function downloadFile(input) {
     await fetchAndWriteFileStream(input, input.src, localFsPath);
     await queue.onIdle();
     logger.success(
-      'Completed fetch of file "%s" to "%s" from the Design Manager',
+      'Completed fetch of file "%s"%s to "%s" from the Design Manager',
       input.src,
-      localFsPath
+      getAssetVersionIdentifier(input.options),
+      input.dest
     );
   } catch (err) {
     if (isHubspot && isTimeout(err)) {
@@ -476,8 +490,9 @@ async function downloadFolder(input) {
 
     if (success) {
       logger.success(
-        'Completed fetch of folder "%s" to "%s" from the Design Manager',
+        'Completed fetch of folder "%s"%s to "%s" from the Design Manager',
         input.src,
+        getAssetVersionIdentifier(input.options),
         input.dest
       );
     } else {

--- a/packages/cli-lib/fileMapper.js
+++ b/packages/cli-lib/fileMapper.js
@@ -102,6 +102,7 @@ function getFileMapperQueryValues({ mode, options = {} }) {
     qs: {
       buffer: useApiBuffer(mode),
       environmentId: options.staging ? 2 : 1,
+      version: options.assetVersion,
     },
   };
 }

--- a/packages/cli-lib/fileMapper.js
+++ b/packages/cli-lib/fileMapper.js
@@ -108,16 +108,16 @@ function getFileMapperQueryValues({ mode, options = {} }) {
 }
 
 /**
-* Determines API param based on mode an options
-*
-* @property {Object} options
-* @returns {string}
-*/
+ * Determines API param based on mode an options
+ *
+ * @property {Object} options
+ * @returns {string}
+ */
 function getAssetVersionIdentifier(options) {
-  if (options.assetVersion && options.src.startsWith("@hubspot/")) {
-    return " v" +options.assetVersion;
+  if (options.assetVersion && options.src.startsWith('@hubspot/')) {
+    return ' v' + options.assetVersion;
   }
- return "";
+  return '';
 }
 
 /**

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -218,6 +218,8 @@ en:
         options:
           staging:
             describe: "Retrieve staged changes for project"
+          assetVersion:
+            describe: "Specify what version of a default asset to fetch"
         positionals:
           dest:
             describe: "Local directory you would like the files to be placed in, relative to your current working directory"

--- a/packages/cli/commands/fetch.js
+++ b/packages/cli/commands/fetch.js
@@ -80,7 +80,7 @@ exports.builder = yargs => {
     assetVersion: {
       type: 'number',
       describe: i18n(`${i18nKey}.options.assetVersion.describe`),
-    }
+    },
   });
 
   return yargs;

--- a/packages/cli/commands/fetch.js
+++ b/packages/cli/commands/fetch.js
@@ -76,5 +76,12 @@ exports.builder = yargs => {
     },
   });
 
+  yargs.options({
+    assetVersion: {
+      type: 'number',
+      describe: i18n(`${i18nKey}.options.assetVersion.describe`),
+    }
+  });
+
   return yargs;
 };


### PR DESCRIPTION
## Description and Context
When downloading a default asset, we want to allow developers to pass in an `assetVersion` argument like so:

```
hs fetch @hubspot/button.module --assetVersion 1
```

to download a specific version of the default asset. Without this parameter the `hs fetch` command will behave as it does currently, where it simply downloads the version of the asset your portal has

## Screenshots
<img width="991" alt="Screen Shot 2022-07-21 at 4 13 49 PM" src="https://user-images.githubusercontent.com/109760479/180306901-102e6d22-9a80-4d64-bf52-461f12ae3be6.png">


## TODO

## Who to Notify
@brandenrodgers 
