### PR TITLE
fix logging version number

### DIFF
--- a/packages/cli-lib/fileMapper.js
+++ b/packages/cli-lib/fileMapper.js
@@ -108,13 +108,13 @@ function getFileMapperQueryValues({ mode, options = {} }) {
 }
 
 /**
- * Determines API param based on mode an options
+ * Determines version number to log based on options
  *
  * @property {Object} options
  * @returns {string}
  */
 function getAssetVersionIdentifier(options) {
-  if (options.assetVersion && options.src.startsWith('@hubspot/')) {
+  if (options.assetVersion !== null && options.src.startsWith('@hubspot/')) {
     return ' v' + options.assetVersion;
   }
   return '';


### PR DESCRIPTION
## Description and Context
When passing in 0 as a version number, JS resolves 0 as falsey and so it doesnt log the version number being specified

## Screenshots
<img width="865" alt="Screen Shot 2022-08-03 at 2 23 52 PM" src="https://user-images.githubusercontent.com/109760479/182681465-1b55b070-6620-4059-888f-dbe70ffedd4f.png">


## TODO
N/A

## Who to Notify
<!-- /cc those you wish to know about the PR -->
