### PR TITLE
Fix for theme fetch in new lighthouse command

### DIFF
--- a/packages/cli/commands/cms/lighthouseScore.js
+++ b/packages/cli/commands/cms/lighthouseScore.js
@@ -50,7 +50,7 @@ const selectTheme = async accountId => {
       choices: async () => {
         try {
           const result = await fetchThemes(accountId, {
-            limit: 50,
+            limit: 500,
             sorting: 'MOST_USED',
           });
           if (result && result.objects) {

--- a/packages/cli/commands/cms/lighthouseScore.js
+++ b/packages/cli/commands/cms/lighthouseScore.js
@@ -49,7 +49,10 @@ const selectTheme = async accountId => {
       message: i18n(`${i18nKey}.info.promptMessage`),
       choices: async () => {
         try {
-          const result = await fetchThemes(accountId);
+          const result = await fetchThemes(accountId, {
+            limit: 50,
+            sorting: 'MOST_USED',
+          });
           if (result && result.objects) {
             return result.objects
               .map(({ theme }) => theme.path)


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
There's an issue where not all of the themes are being fetched correctly. Ideally we add pagination to this fetch so that the user can see all of their available themes, but in the meantime I think a passable solution is to increase the limit and to sort by most used.

## Screenshots
<!-- Provide images of the before and after functionality -->

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
cc/ @ssethia2 