### PR TITLE
Let users know that they can run hs init to generate a config file

### DIFF
--- a/packages/cli-lib/lib/config.js
+++ b/packages/cli-lib/lib/config.js
@@ -227,7 +227,7 @@ const loadConfigFromFile = (path, options = {}) => {
   if (!_configPath) {
     if (!options.silenceErrors) {
       logger.error(
-        `A ${DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME} file could not be found`
+        `A ${DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME} file could not be found. To create a new config file, use the "hs init" command.`
       );
     } else {
       logger.debug(


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
This makes it so that we always let the user know that they can run the `hs init` command to generate a config file whenever a command detects that one doesn't exist.
## Screenshots
<!-- Provide images of the before and after functionality -->
<img width="868" alt="image" src="https://user-images.githubusercontent.com/6654014/182938427-d4d45af5-5253-4223-ae87-b2f3766bc40c.png">## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
