### PR TITLE
Move tracking to ensure success before emitting event

### DIFF
--- a/packages/cli/commands/sandbox/create.js
+++ b/packages/cli/commands/sandbox/create.js
@@ -122,8 +122,6 @@ exports.handler = async options => {
 
   let namePrompt;
 
-  trackCommandUsage('sandbox-create', {}, accountId);
-
   if (!name) {
     namePrompt = await createSandboxPrompt();
   }
@@ -140,6 +138,8 @@ exports.handler = async options => {
     });
 
     result = await createSandbox(accountId, sandboxName);
+
+    trackCommandUsage('sandbox-create', {}, accountId);
 
     logger.log('');
     spinnies.succeed('sandboxCreate', {

--- a/packages/cli/commands/sandbox/create.js
+++ b/packages/cli/commands/sandbox/create.js
@@ -120,6 +120,8 @@ exports.handler = async options => {
     succeedColor: 'white',
   });
 
+  trackCommandUsage('sandbox-create', {}, accountId);
+
   let namePrompt;
 
   if (!name) {
@@ -139,8 +141,6 @@ exports.handler = async options => {
 
     result = await createSandbox(accountId, sandboxName);
 
-    trackCommandUsage('sandbox-create', {}, accountId);
-
     logger.log('');
     spinnies.succeed('sandboxCreate', {
       text: i18n(`${i18nKey}.loading.succeed`, {
@@ -150,6 +150,8 @@ exports.handler = async options => {
     });
   } catch (err) {
     debugErrorAndContext(err);
+
+    trackCommandUsage('sandbox-create', { success: false }, accountId);
 
     spinnies.fail('sandboxCreate', {
       text: i18n(`${i18nKey}.loading.fail`, {

--- a/packages/cli/commands/sandbox/delete.js
+++ b/packages/cli/commands/sandbox/delete.js
@@ -47,8 +47,6 @@ exports.handler = async options => {
     account: account || accountPrompt.account,
   });
 
-  trackCommandUsage('sandbox-delete', {}, sandboxAccountId);
-
   let parentAccountId;
   for (const portal of config.portals) {
     if (portal.portalId === sandboxAccountId) {
@@ -104,6 +102,8 @@ exports.handler = async options => {
     }
 
     await deleteSandbox(parentAccountId, sandboxAccountId);
+
+    trackCommandUsage('sandbox-delete', {}, sandboxAccountId);
 
     logger.log('');
     logger.success(

--- a/packages/cli/commands/sandbox/delete.js
+++ b/packages/cli/commands/sandbox/delete.js
@@ -47,6 +47,8 @@ exports.handler = async options => {
     account: account || accountPrompt.account,
   });
 
+  trackCommandUsage('sandbox-delete', {}, sandboxAccountId);
+
   let parentAccountId;
   for (const portal of config.portals) {
     if (portal.portalId === sandboxAccountId) {
@@ -103,8 +105,6 @@ exports.handler = async options => {
 
     await deleteSandbox(parentAccountId, sandboxAccountId);
 
-    trackCommandUsage('sandbox-delete', {}, sandboxAccountId);
-
     logger.log('');
     logger.success(
       i18n(`${i18nKey}.success.delete`, {
@@ -121,6 +121,8 @@ exports.handler = async options => {
     process.exit(EXIT_CODES.SUCCESS);
   } catch (err) {
     debugErrorAndContext(err);
+
+    trackCommandUsage('sandbox-delete', { success: false }, sandboxAccountId);
 
     if (
       err.error &&


### PR DESCRIPTION
## Description and Context

Sandboxes has identified some discrepancies when looking at amplitude tracking, and we want to ensure successful sandbox actions before emitting a tracking event. 

This PR addresses that and moves tracking events further down in the flow. 

## TODO

We'll need to have a broader discussion on this with the CLI team, but Sandboxes may want to start tracking sandbox sub types, eg Development sandbox vs Standard sandbox. 


## Who to Notify
@brandenrodgers @kemmerle 
