### PR TITLE
Sandboxes CLI: prevent removing non-sandbox portal from config on attempted delete

### DIFF
--- a/packages/cli-lib/lib/config.js
+++ b/packages/cli-lib/lib/config.js
@@ -389,6 +389,7 @@ const removeSandboxAccountFromConfig = nameOrId => {
   }
 
   writeConfig();
+
   return promptDefaultAccount;
 };
 

--- a/packages/cli-lib/lib/config.js
+++ b/packages/cli-lib/lib/config.js
@@ -363,7 +363,7 @@ const getAccountId = nameOrId => {
 /**
  * @throws {Error}
  */
-const removeAccountFromConfig = nameOrId => {
+const removeSandboxAccountFromConfig = nameOrId => {
   const config = getAndLoadConfigIfNeeded();
   const accountId = getAccountId(nameOrId);
   let promptDefaultAccount = false;
@@ -373,6 +373,8 @@ const removeAccountFromConfig = nameOrId => {
   }
 
   const accountConfig = getAccountConfig(accountId);
+
+  if (accountConfig.sandboxAccountType === null) return promptDefaultAccount;
 
   if (config.defaultPortal === accountConfig.name) {
     promptDefaultAccount = true;
@@ -387,7 +389,6 @@ const removeAccountFromConfig = nameOrId => {
   }
 
   writeConfig();
-
   return promptDefaultAccount;
 };
 
@@ -747,7 +748,7 @@ module.exports = {
   loadConfigFromEnvironment,
   getAccountConfig,
   getAccountId,
-  removeAccountFromConfig,
+  removeSandboxAccountFromConfig,
   updateAccountConfig,
   updateDefaultAccount,
   updateDefaultMode,

--- a/packages/cli/commands/sandbox/delete.js
+++ b/packages/cli/commands/sandbox/delete.js
@@ -16,7 +16,9 @@ const { deleteSandbox } = require('@hubspot/cli-lib/sandboxes');
 const { i18n } = require('@hubspot/cli-lib/lib/lang');
 const { getConfig, getEnv } = require('@hubspot/cli-lib');
 const { deleteSandboxPrompt } = require('../../lib/prompts/sandboxesPrompt');
-const { removeAccountFromConfig } = require('@hubspot/cli-lib/lib/config');
+const {
+  removeSandboxAccountFromConfig,
+} = require('@hubspot/cli-lib/lib/config');
 const {
   selectAndSetAsDefaultAccountPrompt,
 } = require('../../lib/prompts/accountsPrompt');
@@ -114,7 +116,9 @@ exports.handler = async options => {
     );
     logger.log('');
 
-    const promptDefaultAccount = removeAccountFromConfig(sandboxAccountId);
+    const promptDefaultAccount = removeSandboxAccountFromConfig(
+      sandboxAccountId
+    );
     if (promptDefaultAccount) {
       await selectAndSetAsDefaultAccountPrompt(config);
     }
@@ -135,7 +139,9 @@ exports.handler = async options => {
       );
       logger.log('');
 
-      const promptDefaultAccount = removeAccountFromConfig(sandboxAccountId);
+      const promptDefaultAccount = removeSandboxAccountFromConfig(
+        sandboxAccountId
+      );
       if (promptDefaultAccount) {
         await selectAndSetAsDefaultAccountPrompt(config);
       }


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
We introduced the command to allow a user to delete a sandbox from the CLI (hs sandbox delete). 
Following deletion the sandbox is removed from the config regardless of if the delete failed or not.
This PR is to prevent non-sandbbox account types from being removed from the config file on attempted delete

## Screenshots
<!-- Provide images of the before and after functionality -->
before:
![Screen Shot 2022-08-16 at 3 53 22 PM](https://user-images.githubusercontent.com/52754081/184991954-9dffcd6d-9d29-498a-af3b-1feac6d68939.png)

after:
![Screen Shot 2022-08-16 at 3 52 49 PM](https://user-images.githubusercontent.com/52754081/184991967-5f264bca-34d5-4d02-80f9-978d4d3351dd.png)

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@adamawang 