### PR TITLE
Add links to deploys

### DIFF
--- a/packages/cli/lib/projects.js
+++ b/packages/cli/lib/projects.js
@@ -354,7 +354,9 @@ const makePollTaskStatusFunc = ({
     const displayId = deployedBuildId || taskId;
 
     if (linkToHubSpot) {
-      logger.log(`\n${linkToHubSpot(taskName, taskId, accountId)}\n`);
+      logger.log(
+        `\n${linkToHubSpot(accountId, taskName, taskId, deployedBuildId)}\n`
+      );
     }
 
     const spinnies = new Spinnies({
@@ -478,10 +480,10 @@ const makePollTaskStatusFunc = ({
 };
 
 const pollBuildStatus = makePollTaskStatusFunc({
-  linkToHubSpot: (projectName, buildId, accountId) =>
+  linkToHubSpot: (accountId, taskName, taskId) =>
     uiLink(
-      `View build #${buildId} in HubSpot`,
-      getProjectBuildDetailUrl(projectName, buildId, accountId)
+      `View build #${taskId} in HubSpot`,
+      getProjectBuildDetailUrl(taskName, taskId, accountId)
     ),
   statusFn: getBuildStatus,
   statusText: PROJECT_BUILD_TEXT,
@@ -497,10 +499,10 @@ const pollBuildStatus = makePollTaskStatusFunc({
 });
 
 const pollDeployStatus = makePollTaskStatusFunc({
-  linkToHubSpot: (projectName, deployId, accountId) =>
+  linkToHubSpot: (accountId, taskName, taskId, deployedBuildId) =>
     uiLink(
-      `View deploy in HubSpot`,
-      getProjectDeployDetailUrl(projectName, deployId, accountId)
+      `View deploy of build #${deployedBuildId} in HubSpot`,
+      getProjectDeployDetailUrl(taskName, taskId, accountId)
     ),
   statusFn: getDeployStatus,
   statusText: PROJECT_DEPLOY_TEXT,

--- a/packages/cli/lib/projects.js
+++ b/packages/cli/lib/projects.js
@@ -224,6 +224,13 @@ const getProjectBuildDetailUrl = (projectName, buildId, accountId) => {
   return `${getProjectDetailUrl(projectName, accountId)}/build/${buildId}`;
 };
 
+const getProjectDeployDetailUrl = (projectName, buildId, accountId) => {
+  if (!projectName || !buildId || !accountId) return;
+  return `${getProjectDetailUrl(
+    projectName,
+    accountId
+  )}/activity/deploy/${buildId}`;
+};
 const uploadProjectFiles = async (accountId, projectName, filePath) => {
   const i18nKey = 'cli.commands.project.subcommands.upload';
   const spinnies = new Spinnies({
@@ -490,6 +497,11 @@ const pollBuildStatus = makePollTaskStatusFunc({
 });
 
 const pollDeployStatus = makePollTaskStatusFunc({
+  linkToHubSpot: (projectName, buildId, accountId) =>
+    uiLink(
+      `View deploy of build #${buildId} in HubSpot`,
+      getProjectDeployDetailUrl(projectName, buildId, accountId)
+    ),
   statusFn: getDeployStatus,
   statusText: PROJECT_DEPLOY_TEXT,
   statusStrings: {

--- a/packages/cli/lib/projects.js
+++ b/packages/cli/lib/projects.js
@@ -224,12 +224,12 @@ const getProjectBuildDetailUrl = (projectName, buildId, accountId) => {
   return `${getProjectDetailUrl(projectName, accountId)}/build/${buildId}`;
 };
 
-const getProjectDeployDetailUrl = (projectName, buildId, accountId) => {
-  if (!projectName || !buildId || !accountId) return;
+const getProjectDeployDetailUrl = (projectName, deployId, accountId) => {
+  if (!projectName || !deployId || !accountId) return;
   return `${getProjectDetailUrl(
     projectName,
     accountId
-  )}/activity/deploy/${buildId}`;
+  )}/activity/deploy/${deployId}`;
 };
 const uploadProjectFiles = async (accountId, projectName, filePath) => {
   const i18nKey = 'cli.commands.project.subcommands.upload';
@@ -497,10 +497,10 @@ const pollBuildStatus = makePollTaskStatusFunc({
 });
 
 const pollDeployStatus = makePollTaskStatusFunc({
-  linkToHubSpot: (projectName, buildId, accountId) =>
+  linkToHubSpot: (projectName, deployId, accountId) =>
     uiLink(
-      `View deploy of build #${buildId} in HubSpot`,
-      getProjectDeployDetailUrl(projectName, buildId, accountId)
+      `View deploy in HubSpot`,
+      getProjectDeployDetailUrl(projectName, deployId, accountId)
     ),
   statusFn: getDeployStatus,
   statusText: PROJECT_DEPLOY_TEXT,


### PR DESCRIPTION
## Description and Context
CLI now logs a link to deploys for any commands that can deploy builds (`watch`, `upload`, `deploy`)

## Screenshots
Before:
<img width="515" alt="Screen Shot 2022-08-17 at 1 05 14 PM" src="https://user-images.githubusercontent.com/10413161/185200084-cba9a86a-1cb4-498e-a2a5-f22036c8fbd9.png">

After:
<img width="619" alt="Screen Shot 2022-08-17 at 1 04 02 PM" src="https://user-images.githubusercontent.com/10413161/185200025-00d2f8d2-579d-4f0b-b51e-ef87002583bb.png">


## TODO
~We may want to update the copy for the link here. I opted not to specify a deploy # because it looks like deploys are only ever referred to by build number in the projects app, but could also tweak the `linkToHubSpot` function a bit so we can show what build the deploy is for~ Going with "deploy of build n"

## Who to Notify
@brandenrodgers @kemmerle 
