### PR TITLE
Updating options for some project commands

### DIFF
--- a/packages/cli-lib/api/functions.js
+++ b/packages/cli-lib/api/functions.js
@@ -38,7 +38,7 @@ async function getProjectAppFunctionLogs(
   appPath,
   query = {}
 ) {
-  const { limit = 5 } = query;
+  const { limit = 10 } = query;
 
   return http.get(accountId, {
     uri: `${FUNCTION_API_PATH}/app-function/logs/project/${encodeURIComponent(

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -869,8 +869,6 @@ en:
           enterName: "[--name] Give your project a name: "
           enterLocation: "[--location] Where should the project be created?"
           selectTemplate: "[--template] Start from a template?"
-          templateOptions:
-            noTemplate: "No template"
           errors:
             nameRequired: "A project name is required"
             locationRequired: "A project location is required"

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -448,7 +448,7 @@ en:
               name:
                 describe: "Project name (cannot be changed)"
               template:
-                describe: "Which template?"
+                describe: "The starting template"
           deploy:
             describe: "Deploy a project build"
             debug:
@@ -487,8 +487,8 @@ en:
                 describe: "App name"
               compact:
                 describe: "Output compact logs"
-              follow:
-                describe: "Follow logs"
+              tail:
+                describe: "Tail logs"
               latest:
                 describe: "Retrieve most recent log only"
               limit:

--- a/packages/cli-lib/lib/constants.js
+++ b/packages/cli-lib/lib/constants.js
@@ -114,8 +114,12 @@ const MIN_HTTP_TIMEOUT = 3000;
 
 const PROJECT_TEMPLATES = [
   {
+    name: 'no-template',
+    label: 'No template',
+  },
+  {
     name: 'getting-started',
-    label: 'Getting Started',
+    label: 'Getting started',
     repo: 'getting-started-project-template',
   },
 ];

--- a/packages/cli/commands/list.js
+++ b/packages/cli/commands/list.js
@@ -35,7 +35,6 @@ exports.handler = async options => {
   const { path } = options;
   const directoryPath = path || '/';
   const accountId = getAccountId(options);
-  logger.log(accountId);
   let contentsResp;
 
   trackCommandUsage('list', {}, accountId);

--- a/packages/cli/commands/list.js
+++ b/packages/cli/commands/list.js
@@ -35,6 +35,7 @@ exports.handler = async options => {
   const { path } = options;
   const directoryPath = path || '/';
   const accountId = getAccountId(options);
+  logger.log(accountId);
   let contentsResp;
 
   trackCommandUsage('list', {}, accountId);

--- a/packages/cli/commands/project/create.js
+++ b/packages/cli/commands/project/create.js
@@ -14,6 +14,7 @@ const {
 } = require('../../lib/prompts/createProjectPrompt');
 const { createProjectConfig } = require('../../lib/projects');
 const { i18n } = require('@hubspot/cli-lib/lib/lang');
+const { PROJECT_TEMPLATES } = require('@hubspot/cli-lib/lib/constants');
 const { uiFeatureHighlight } = require('../../lib/ui');
 const { logger } = require('@hubspot/cli-lib/logger');
 
@@ -60,6 +61,7 @@ exports.builder = yargs => {
     template: {
       describe: i18n(`${i18nKey}.options.template.describe`),
       type: 'string',
+      choices: PROJECT_TEMPLATES.map(template => template.name),
     },
   });
 

--- a/packages/cli/commands/project/logs.js
+++ b/packages/cli/commands/project/logs.js
@@ -276,18 +276,18 @@ exports.builder = yargs => {
         describe: i18n(`${i18nKey}.options.compact.describe`),
         type: 'boolean',
       },
-      follow: {
-        alias: ['t', 'tail', 'f'],
-        describe: i18n(`${i18nKey}.options.follow.describe`),
+      tail: {
+        alias: ['t'],
+        describe: i18n(`${i18nKey}.options.tail.describe`),
         type: 'boolean',
       },
       limit: {
-        alias: ['limit', 'n', 'max-count'],
         describe: i18n(`${i18nKey}.options.limit.describe`),
         type: 'number',
+        default: 10,
       },
     })
-    .conflicts('follow', 'limit');
+    .conflicts('tail', 'limit');
 
   yargs.example([['$0 project logs', i18n(`${i18nKey}.examples.default`)]]);
   yargs.example([

--- a/packages/cli/commands/project/logs.js
+++ b/packages/cli/commands/project/logs.js
@@ -277,7 +277,7 @@ exports.builder = yargs => {
         type: 'boolean',
       },
       tail: {
-        alias: ['t'],
+        alias: ['t', 'follow'],
         describe: i18n(`${i18nKey}.options.tail.describe`),
         type: 'boolean',
       },

--- a/packages/cli/lib/projects.js
+++ b/packages/cli/lib/projects.js
@@ -115,7 +115,7 @@ const createProjectConfig = async (projectPath, projectName, template) => {
     }`
   );
 
-  if (template === 'none') {
+  if (template === 'no-template') {
     fs.ensureDirSync(path.join(projectPath, 'src'));
 
     writeProjectConfig(projectConfigPath, {

--- a/packages/cli/lib/prompts/createProjectPrompt.js
+++ b/packages/cli/lib/prompts/createProjectPrompt.js
@@ -47,18 +47,12 @@ const createProjectPrompt = (promptOptions = {}) => {
         !promptOptions.template ||
         !PROJECT_TEMPLATES.find(t => t.name === promptOptions.template),
       type: 'list',
-      choices: [
-        {
-          name: i18n(`${i18nKey}.templateOptions.noTemplate`),
-          value: 'none',
-        },
-        ...PROJECT_TEMPLATES.map(template => {
-          return {
-            name: template.label,
-            value: template.name,
-          };
-        }),
-      ],
+      choices: PROJECT_TEMPLATES.map(template => {
+        return {
+          name: template.label,
+          value: template.name,
+        };
+      }),
     },
   ]);
 };


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
Making a handful of small changes to the options of some projects-related commands:
- Enumerating the options for `--template` in the create command
- `--limit` now shows as an option in the output of `hs project logs --help`
- Bumping the default limit in the logs command from 5 to 10

## Screenshots
<!-- Provide images of the before and after functionality -->

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
