### PR TITLE
Prevent creation of /src and hsproject.json for projects that dont exist

### DIFF
--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -573,6 +573,7 @@ en:
               downloadSucceeded: "Downloaded build \"{{ buildId }}\" from project \"{{ projectName }}\""
             errors:
               downloadFailed: "Something went wrong downloading the project"
+              projectNotFound: "Your project {{ projectName }} could not be found in {{ accountId }}"
             positionals:
               name:
                 describe: "The name of the project to download"

--- a/packages/cli/commands/project/download.js
+++ b/packages/cli/commands/project/download.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const chalk = require('chalk');
 
 const {
   getAccountId,
@@ -37,7 +38,20 @@ exports.handler = async options => {
 
   trackCommandUsage('project-download', { projectName }, accountId);
 
-  await ensureProjectExists(accountId, projectName, { allowCreate: false });
+  const projectExists = await ensureProjectExists(accountId, projectName, {
+    allowCreate: false,
+    noLogs: true,
+  });
+
+  if (!projectExists) {
+    logger.error(
+      i18n(`${i18nKey}.errors.projectNotFound`, {
+        projectName: chalk.bold(projectName),
+        accountId: chalk.bold(accountId),
+      })
+    );
+    process.exit(EXIT_CODES.ERROR);
+  }
 
   const absoluteDestPath = dest ? path.resolve(getCwd(), dest) : getCwd();
 


### PR DESCRIPTION
Currently, `hs project download` still create a config file and empty `src` directory if a user tries to download a project that doesn't exist. This prevents that from happening, and adds an explicit error message.

See https://git.hubteam.com/HubSpot/hubspot-cli-issues/issues/335

Before:
<img width="708" alt="Screen Shot 2022-08-22 at 3 53 37 PM" src="https://user-images.githubusercontent.com/10413161/186007089-ddc6cec6-fd83-4fe9-b376-dcd7a88156f9.png">

After
<img width="714" alt="Screen Shot 2022-08-22 at 3 52 43 PM" src="https://user-images.githubusercontent.com/10413161/186006938-6943638e-e46f-4d5c-9a63-f3dcf2250bf1.png">

cc @kemmerle 
