### PR TITLE
Encode URLs in UI Links

### DIFF
--- a/packages/cli/lib/ui.js
+++ b/packages/cli/lib/ui.js
@@ -37,10 +37,11 @@ const getTerminalUISupport = () => {
  */
 const uiLink = (linkText, url) => {
   const terminalUISupport = getTerminalUISupport();
+  const encodedUrl = encodeURI(url);
   if (terminalUISupport.hyperlinks) {
     const result = [
       '\u001B]8;;',
-      url,
+      encodedUrl,
       '\u0007',
       linkText,
       '\u001B]8;;\u0007',
@@ -48,8 +49,8 @@ const uiLink = (linkText, url) => {
     return terminalUISupport.color ? chalk.cyan(result) : result;
   } else {
     return terminalUISupport.color
-      ? `${linkText}: ${chalk.cyan(url)}`
-      : `${linkText}: ${url}`;
+      ? `${linkText}: ${chalk.cyan(encodedUrl)}`
+      : `${linkText}: ${encodedUrl}`;
   }
 };
 


### PR DESCRIPTION
In terminals that don't support actual links, we print the URL to projects when they build and deploy (this probably happens in other places too). These urls weren't being encoded properly, so projects with spaces in their names would end up with broken URLs. This fixes that. See https://git.hubteam.com/HubSpot/hubspot-cli-issues/issues/330

Before:
<img width="716" alt="Screen Shot 2022-08-22 at 4 29 40 PM" src="https://user-images.githubusercontent.com/10413161/186013635-21bd9271-bc6f-4102-8836-e77649b8d530.png">

After:
<img width="718" alt="Screen Shot 2022-08-22 at 4 29 52 PM" src="https://user-images.githubusercontent.com/10413161/186013620-d525f594-dce6-4834-97cb-53e891c6fdfe.png">

cc @kemmerle 