### PR TITLE
JS Fields: Resolve promises correctly & Add tracking

### DIFF
--- a/packages/cli-lib/lib/__tests__/handleFieldsJs.js
+++ b/packages/cli-lib/lib/__tests__/handleFieldsJs.js
@@ -120,7 +120,7 @@ describe('handleFieldsJs', () => {
   });
 
   describe('fieldsArrayToJson()', () => {
-    it('flattens nested arrays', () => {
+    it('flattens nested arrays', async () => {
       let input = [
         [
           {
@@ -181,12 +181,12 @@ describe('handleFieldsJs', () => {
         },
       ];
 
-      const json = fieldsArrayToJson(input).replace(/\s/g, '');
+      const json = (await fieldsArrayToJson(input)).replace(/\s/g, '');
 
       expect(json).toEqual(JSON.stringify(expected));
     });
 
-    it('handles objects with toJSON methods', () => {
+    it('handles objects with toJSON methods', async () => {
       const obj = {
         type: 'link',
         name: 'test',
@@ -213,7 +213,7 @@ describe('handleFieldsJs', () => {
           label: 'test',
         },
       ];
-      const json = fieldsArrayToJson(array).replace(/\s/g, '');
+      const json = (await fieldsArrayToJson(array)).replace(/\s/g, '');
       expect(json).toEqual(JSON.stringify(expected));
     });
   });

--- a/packages/cli-lib/lib/dynamicImport.js
+++ b/packages/cli-lib/lib/dynamicImport.js
@@ -1,5 +1,6 @@
 const semver = require('semver');
 const { getExt } = require('../path');
+const { logger } = require('../logger');
 // This is pulled into it's own file because it must be added to the esignore. Dynamics imports cause eslint _parser_ errors, which cannot be ignored.
 
 /**

--- a/packages/cli-lib/lib/handleFieldsJs.js
+++ b/packages/cli-lib/lib/handleFieldsJs.js
@@ -41,7 +41,7 @@ class FieldsJs {
    * @param {string} writeDir - The directory to write the file to.
    * @returns {Promise} finalPath - Promise that returns path of the written fields.json file.
    */
-  async convertFieldsJs(writeDir) {
+  convertFieldsJs(writeDir) {
     const filePath = this.filePath;
     const baseName = path.basename(filePath);
     const dirName = path.dirname(filePath);

--- a/packages/cli/bin/cli.js
+++ b/packages/cli/bin/cli.js
@@ -7,7 +7,10 @@ const chalk = require('chalk');
 const { logger } = require('@hubspot/cli-lib/logger');
 const { logErrorInstance } = require('@hubspot/cli-lib/errorHandlers');
 const { setLogLevel, getCommandName } = require('../lib/commonOpts');
-const { trackHelpUsage } = require('../lib/usageTracking');
+const {
+  trackHelpUsage,
+  trackProcessFieldsUsage,
+} = require('../lib/usageTracking');
 const { getIsInProject } = require('../lib/projects');
 const pkg = require('../package.json');
 const { i18n } = require('@hubspot/cli-lib/lib/lang');
@@ -165,4 +168,8 @@ const argv = yargs
 
 if (argv.help) {
   trackHelpUsage(getCommandName(argv));
+}
+
+if (argv.processFieldsJs) {
+  trackProcessFieldsUsage(getCommandName(argv));
 }

--- a/packages/cli/commands/process.js
+++ b/packages/cli/commands/process.js
@@ -10,6 +10,8 @@ const {
   FieldsJs,
   isProcessableFieldsJs,
 } = require('@hubspot/cli-lib/lib/handleFieldsJs');
+
+const { trackProcessFieldsUsage } = require('../lib/usageTracking');
 const i18nKey = 'cli.commands.process';
 
 exports.command = 'process';
@@ -36,6 +38,8 @@ exports.handler = async options => {
   } catch (e) {
     invalidPath(src);
   }
+
+  trackProcessFieldsUsage('process');
 
   if (stats.isFile()) {
     const fieldsJs = await new FieldsJs(

--- a/packages/cli/commands/process.js
+++ b/packages/cli/commands/process.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const fs = require('fs');
 const { createIgnoreFilter } = require('@hubspot/cli-lib/ignoreRules');
-const { isAllowedExtension } = require('@hubspot/cli-lib//path');
+const { isAllowedExtension, getCwd } = require('@hubspot/cli-lib/path');
 const { logger } = require('@hubspot/cli-lib/logger');
 const { walk } = require('@hubspot/cli-lib/lib/walk');
 const { getThemeJSONPath } = require('@hubspot/cli-lib/lib/files');
@@ -24,7 +24,7 @@ const invalidPath = src => {
 };
 
 exports.handler = async options => {
-  const src = options.src;
+  const src = path.resolve(getCwd(), options.src);
   const projectRoot = path.dirname(getThemeJSONPath(src));
   let stats;
   try {

--- a/packages/cli/lib/usageTracking.js
+++ b/packages/cli/lib/usageTracking.js
@@ -78,6 +78,24 @@ async function trackHelpUsage(command) {
   }
 }
 
+async function trackProcessFieldsUsage(command) {
+  if (!isTrackingAllowed()) {
+    return;
+  }
+  try {
+    logger.debug('Attempting to track usage of "%s" command', command);
+    await trackUsage('cli-interaction', EventClass.INTERACTION, {
+      action: 'cli-process-fields',
+      os: getPlatform(),
+      ...getNodeVersionData(),
+      version,
+      command,
+    });
+  } catch (e) {
+    logger.debug('Usage tracking failed: %s', e.message);
+  }
+}
+
 const addHelpUsageTracking = (program, command) => {
   program.on('--help', () => {
     setLogLevel(program);
@@ -118,5 +136,6 @@ module.exports = {
   trackCommandUsage,
   trackHelpUsage,
   addHelpUsageTracking,
+  trackProcessFieldsUsage,
   trackAuthAction,
 };


### PR DESCRIPTION
## Description and Context
This PR fixes three things:
- When a Fields array is returned from a JS fields function, it wraps it in a `Promise.all()` and waits, so that each Promise will resolve before proceeding. Previously, this would not happen, making any Promises in the returned Array be written as a blank object.
- Makes the `process` command work with relative paths.
- Adds some tracking to the processing
- I forgot to require `logger` in `dynamicImport` in #712 


Checks:
For `node -v = v10.24.1`:
- Passes `yarn test`
- Passes `yarn test-cli`
- Passes `yarn check-deps`

cc/ @miketalley 