### PR TITLE
[BUGFIX] send the entire input to the getAssetVersionIdentifier function instead of just an options

### DIFF
--- a/packages/cli-lib/fileMapper.js
+++ b/packages/cli-lib/fileMapper.js
@@ -114,7 +114,7 @@ function getFileMapperQueryValues({ mode, options = {} }) {
  * @returns {string}
  */
  function getAssetVersionIdentifier(input) {
-  if (input.options.assetVersion !== null && input.src.startsWith('@hubspot/')) {
+  if (input.options.hasOwnProperty('assetVersion') && input.hasOwnProperty('src') && input.src.startsWith('@hubspot/')) {
     return ' v' + input.options.assetVersion;
   }
   return '';

--- a/packages/cli-lib/fileMapper.js
+++ b/packages/cli-lib/fileMapper.js
@@ -108,14 +108,14 @@ function getFileMapperQueryValues({ mode, options = {} }) {
 }
 
 /**
- * Determines version number to log based on options
+ * Determines version number to log based on input.options
  *
- * @property {Object} options
+ * @property {Object} input
  * @returns {string}
  */
-function getAssetVersionIdentifier(options) {
-  if (options.assetVersion !== null && options.src.startsWith('@hubspot/')) {
-    return ' v' + options.assetVersion;
+ function getAssetVersionIdentifier(input) {
+  if (input.options.assetVersion !== null && input.src.startsWith('@hubspot/')) {
+    return ' v' + input.options.assetVersion;
   }
   return '';
 }
@@ -393,7 +393,7 @@ async function downloadFile(input) {
     logger.success(
       'Completed fetch of file "%s"%s to "%s" from the Design Manager',
       input.src,
-      getAssetVersionIdentifier(input.options),
+      getAssetVersionIdentifier(input),
       input.dest
     );
   } catch (err) {
@@ -492,7 +492,7 @@ async function downloadFolder(input) {
       logger.success(
         'Completed fetch of folder "%s"%s to "%s" from the Design Manager',
         input.src,
-        getAssetVersionIdentifier(input.options),
+        getAssetVersionIdentifier(input),
         input.dest
       );
     } else {

--- a/packages/cli-lib/fileMapper.js
+++ b/packages/cli-lib/fileMapper.js
@@ -113,7 +113,7 @@ function getFileMapperQueryValues({ mode, options = {} }) {
  * @property {Object} input
  * @returns {string}
  */
- function getAssetVersionIdentifier(input) {
+function getAssetVersionIdentifier(input) {
   if (input.options.hasOwnProperty('assetVersion') && input.hasOwnProperty('src') && input.src.startsWith('@hubspot/')) {
     return ' v' + input.options.assetVersion;
   }


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
It seems that there shouldn't be an `src` key in the `options` object, and without `src` the code below will throw an error.
```
function getAssetVersionIdentifier(options) {
  if (options.assetVersion !== null && options.src.startsWith('@hubspot/')) {
    return ' v' + options.assetVersion;
  }
  return '';
}
```
by default `options.src = undefined`

`startsWith` will not work with `undefined` properties and throw a js `TypeError`

***

The solution is to send the entire `input` to the `getAssetVersionIdentifier` function instead of just an `options`
```
 function getAssetVersionIdentifier(input) {
  if (input.options.assetVersion !== null && input.src.startsWith('@hubspot/')) {
    return ' v' + input.options.assetVersion;
  }
  return '';
}
```
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->

## Screenshots
<!-- Provide images of the before and after functionality -->

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
