### PR TITLE
Add sandbox type to project tracking commands

### DIFF
--- a/packages/cli/commands/project/deploy.js
+++ b/packages/cli/commands/project/deploy.js
@@ -15,6 +15,7 @@ const { loadAndValidateOptions } = require('../../lib/validation');
 const { getProjectConfig, pollDeployStatus } = require('../../lib/projects');
 const { projectNamePrompt } = require('../../lib/prompts/projectNamePrompt');
 const { i18n } = require('@hubspot/cli-lib/lib/lang');
+const { getAccountConfig } = require('@hubspot/cli-lib');
 
 const i18nKey = 'cli.commands.project.subcommands.deploy';
 const { EXIT_CODES } = require('../../lib/enums/exitCodes');
@@ -26,9 +27,12 @@ exports.handler = async options => {
   await loadAndValidateOptions(options);
 
   const accountId = getAccountId(options);
+  const accountConfig = getAccountConfig(accountId);
   const { project, buildId } = options;
+  const sandboxType = accountConfig && accountConfig.sandboxAccountType;
+  console.log('account config: ', accountConfig);
 
-  trackCommandUsage('project-deploy', { project }, accountId);
+  trackCommandUsage('project-deploy', { project, sandboxType }, accountId);
 
   const { projectConfig } = await getProjectConfig();
 

--- a/packages/cli/commands/project/deploy.js
+++ b/packages/cli/commands/project/deploy.js
@@ -30,7 +30,6 @@ exports.handler = async options => {
   const accountConfig = getAccountConfig(accountId);
   const { project, buildId } = options;
   const sandboxType = accountConfig && accountConfig.sandboxAccountType;
-  console.log('account config: ', accountConfig);
 
   trackCommandUsage('project-deploy', { project, sandboxType }, accountId);
 

--- a/packages/cli/commands/project/upload.js
+++ b/packages/cli/commands/project/upload.js
@@ -18,6 +18,7 @@ const {
   validateProjectConfig,
 } = require('../../lib/projects');
 const { i18n } = require('@hubspot/cli-lib/lib/lang');
+const { getAccountConfig } = require('@hubspot/cli-lib');
 const { EXIT_CODES } = require('../../lib/enums/exitCodes');
 
 const i18nKey = 'cli.commands.project.subcommands.upload';
@@ -30,8 +31,10 @@ exports.handler = async options => {
 
   const { forceCreate, path: projectPath } = options;
   const accountId = getAccountId(options);
+  const accountConfig = getAccountConfig(accountId);
+  const sandboxType = accountConfig && accountConfig.sandboxAccountType;
 
-  trackCommandUsage('project-upload', { projectPath }, accountId);
+  trackCommandUsage('project-upload', { projectPath, sandboxType }, accountId);
 
   const { projectConfig, projectDir } = await getProjectConfig(projectPath);
 


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->

Sandboxes would like to start tracking which type of sandbox users are using while uploading or deploying projects. This PR adds an extra `sandboxType` meta property to the tracking events for both `projects upload` and `projects deploy`

## Screenshots
<!-- Provide images of the before and after functionality -->
<img width="478" alt="Screen Shot 2022-09-07 at 15 11 18" src="https://user-images.githubusercontent.com/16788677/188958459-e2bb63a0-d42d-46cf-b01c-0c6f2f6da04b.png">
<img width="1057" alt="Screen Shot 2022-09-07 at 15 11 24" src="https://user-images.githubusercontent.com/16788677/188958462-760c63c4-aa3e-4139-bf06-62ae5770a9ac.png">

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

Sandboxes may identify more areas to add a sandbox type property, but these are all we have for now. 

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@brandenrodgers @kemmerle 
