### PR TITLE
Cleaning usage tracking metadata

### DIFF
--- a/packages/cli-lib/fileMapper.js
+++ b/packages/cli-lib/fileMapper.js
@@ -114,7 +114,11 @@ function getFileMapperQueryValues({ mode, options = {} }) {
  * @returns {string}
  */
 function getAssetVersionIdentifier(input) {
-  if (input.options.hasOwnProperty('assetVersion') && input.hasOwnProperty('src') && input.src.startsWith('@hubspot/')) {
+  if (
+    typeof input.options.assetVersion !== 'undefined' &&
+    typeof input.src !== 'undefined' &&
+    input.src.startsWith('@hubspot/')
+  ) {
     return ' v' + input.options.assetVersion;
   }
   return '';

--- a/packages/cli/commands/accounts/list.js
+++ b/packages/cli/commands/accounts/list.js
@@ -72,7 +72,7 @@ exports.handler = async options => {
 
   const accountId = getAccountId(options);
 
-  trackCommandUsage('accounts-list', {}, accountId);
+  trackCommandUsage('accounts-list', null, accountId);
 
   const config = getConfig();
   const configPath = getConfigPath();

--- a/packages/cli/commands/accounts/rename.js
+++ b/packages/cli/commands/accounts/rename.js
@@ -21,7 +21,7 @@ exports.handler = async options => {
   const { accountName, newName } = options;
   const accountId = getAccountId(options);
 
-  trackCommandUsage('accounts-rename', {}, accountId);
+  trackCommandUsage('accounts-rename', null, accountId);
 
   await renameAccount(accountName, newName);
 

--- a/packages/cli/commands/accounts/use.js
+++ b/packages/cli/commands/accounts/use.js
@@ -37,7 +37,7 @@ exports.handler = async options => {
 
   trackCommandUsage(
     'accounts-use',
-    {},
+    null,
     getAccountIdFromConfig(newDefaultAccount)
   );
 

--- a/packages/cli/commands/config/set.js
+++ b/packages/cli/commands/config/set.js
@@ -54,7 +54,7 @@ exports.handler = async options => {
 
   const accountId = getAccountId(options);
 
-  trackCommandUsage('config-set', {}, accountId);
+  trackCommandUsage('config-set', null, accountId);
 
   const configUpdated = await handleConfigUpdate(accountId, options);
 

--- a/packages/cli/commands/config/set/allowUsageTracking.js
+++ b/packages/cli/commands/config/set/allowUsageTracking.js
@@ -33,7 +33,7 @@ const enableOrDisableUsageTracking = async () => {
 };
 
 const setAllowUsageTracking = async ({ accountId, allowUsageTracking }) => {
-  trackCommandUsage('config-set-allow-usage-tracking', {}, accountId);
+  trackCommandUsage('config-set-allow-usage-tracking', null, accountId);
 
   let isEnabled;
 

--- a/packages/cli/commands/config/set/defaultMode.js
+++ b/packages/cli/commands/config/set/defaultMode.js
@@ -27,7 +27,7 @@ const selectMode = async () => {
 };
 
 const setDefaultMode = async ({ accountId, defaultMode }) => {
-  trackCommandUsage('config-set-default-mode', {}, accountId);
+  trackCommandUsage('config-set-default-mode', null, accountId);
 
   let newDefault;
 

--- a/packages/cli/commands/config/set/httpTimeout.js
+++ b/packages/cli/commands/config/set/httpTimeout.js
@@ -20,7 +20,7 @@ const enterTimeout = async () => {
 };
 
 const setHttpTimeout = async ({ accountId, httpTimeout }) => {
-  trackCommandUsage('config-set-http-timeout', {}, accountId);
+  trackCommandUsage('config-set-http-timeout', null, accountId);
 
   let newHttpTimeout;
 

--- a/packages/cli/commands/create.js
+++ b/packages/cli/commands/create.js
@@ -93,6 +93,8 @@ exports.handler = async options => {
 
   if (asset.validate && !asset.validate(argsToPass)) return;
 
+  await asset.execute(argsToPass);
+
   trackCommandUsage('create', { assetType }, getAccountId(options));
 };
 

--- a/packages/cli/commands/create.js
+++ b/packages/cli/commands/create.js
@@ -93,13 +93,7 @@ exports.handler = async options => {
 
   if (asset.validate && !asset.validate(argsToPass)) return;
 
-  const additionalTracking = (await asset.execute(argsToPass)) || {};
-
-  trackCommandUsage(
-    'create',
-    { assetType, ...additionalTracking },
-    getAccountId(options)
-  );
+  trackCommandUsage('create', { assetType }, getAccountId(options));
 };
 
 exports.builder = yargs => {

--- a/packages/cli/commands/filemanager/fetch.js
+++ b/packages/cli/commands/filemanager/fetch.js
@@ -32,7 +32,7 @@ exports.handler = async options => {
 
   const accountId = getAccountId(options);
 
-  trackCommandUsage('filemanager-fetch', {}, accountId);
+  trackCommandUsage('filemanager-fetch', null, accountId);
 
   // Fetch and write file/folder.
   await downloadFileOrFolder(accountId, src, dest, options);

--- a/packages/cli/commands/functions/deploy.js
+++ b/packages/cli/commands/functions/deploy.js
@@ -50,7 +50,7 @@ exports.handler = async options => {
   const splitFunctionPath = functionPath.split('.');
   let spinner;
 
-  trackCommandUsage('functions-deploy', { functionPath }, accountId);
+  trackCommandUsage('functions-deploy', null, accountId);
 
   if (
     !splitFunctionPath.length ||

--- a/packages/cli/commands/functions/list.js
+++ b/packages/cli/commands/functions/list.js
@@ -29,10 +29,9 @@ exports.describe = i18n(`${i18nKey}.describe`);
 exports.handler = async options => {
   loadAndValidateOptions(options);
 
-  const { json, compact } = options;
   const accountId = getAccountId(options);
 
-  trackCommandUsage('functions-list', { json, compact }, accountId);
+  trackCommandUsage('functions-list', null, accountId);
 
   logger.debug(i18n(`${i18nKey}.debug.gettingFunctions`));
 

--- a/packages/cli/commands/functions/server.js
+++ b/packages/cli/commands/functions/server.js
@@ -21,7 +21,7 @@ exports.handler = async options => {
   const { path: functionPath } = options;
   const accountId = getAccountId(options);
 
-  trackCommandUsage('functions-server', { functionPath }, accountId);
+  trackCommandUsage('functions-server', null, accountId);
 
   logger.debug(
     i18n(`${i18nKey}.debug.startingServer`, {

--- a/packages/cli/commands/hubdb/clear.js
+++ b/packages/cli/commands/hubdb/clear.js
@@ -26,7 +26,7 @@ exports.handler = async options => {
 
   const accountId = getAccountId(options);
 
-  trackCommandUsage('hubdb-clear', {}, accountId);
+  trackCommandUsage('hubdb-clear', null, accountId);
 
   try {
     const { deletedRowCount } = await clearHubDbTableRows(accountId, tableId);

--- a/packages/cli/commands/hubdb/create.js
+++ b/packages/cli/commands/hubdb/create.js
@@ -31,7 +31,7 @@ exports.handler = async options => {
 
   const accountId = getAccountId(options);
 
-  trackCommandUsage('hubdb-create', {}, accountId);
+  trackCommandUsage('hubdb-create', null, accountId);
 
   try {
     const filePath = path.resolve(getCwd(), src);

--- a/packages/cli/commands/hubdb/delete.js
+++ b/packages/cli/commands/hubdb/delete.js
@@ -24,7 +24,7 @@ exports.handler = async options => {
 
   const accountId = getAccountId(options);
 
-  trackCommandUsage('hubdb-delete', {}, accountId);
+  trackCommandUsage('hubdb-delete', null, accountId);
 
   try {
     await deleteTable(accountId, tableId);

--- a/packages/cli/commands/hubdb/fetch.js
+++ b/packages/cli/commands/hubdb/fetch.js
@@ -25,7 +25,7 @@ exports.handler = async options => {
 
   const accountId = getAccountId(options);
 
-  trackCommandUsage('hubdb-fetch', {}, accountId);
+  trackCommandUsage('hubdb-fetch', null, accountId);
 
   try {
     const { filePath } = await downloadHubDbTable(accountId, tableId, dest);

--- a/packages/cli/commands/lint.js
+++ b/packages/cli/commands/lint.js
@@ -33,7 +33,7 @@ exports.handler = async options => {
     path: localPath,
   });
 
-  trackCommandUsage('lint', {}, accountId);
+  trackCommandUsage('lint', null, accountId);
 
   logger.group(groupName);
   let count = 0;

--- a/packages/cli/commands/list.js
+++ b/packages/cli/commands/list.js
@@ -37,7 +37,7 @@ exports.handler = async options => {
   const accountId = getAccountId(options);
   let contentsResp;
 
-  trackCommandUsage('list', {}, accountId);
+  trackCommandUsage('list', null, accountId);
 
   logger.debug(
     i18n(`${i18nKey}.gettingPathContents`, {

--- a/packages/cli/commands/module/marketplace-validate.js
+++ b/packages/cli/commands/module/marketplace-validate.js
@@ -38,7 +38,7 @@ exports.handler = async options => {
       })
     );
   }
-  trackCommandUsage('validate', {}, accountId);
+  trackCommandUsage('validate', null, accountId);
 
   applyRelativeValidators(
     MARKETPLACE_VALIDATORS.module,

--- a/packages/cli/commands/mv.js
+++ b/packages/cli/commands/mv.js
@@ -36,7 +36,7 @@ exports.handler = async options => {
   const { srcPath, destPath } = options;
   const accountId = getAccountId(options);
 
-  trackCommandUsage('mv', {}, accountId);
+  trackCommandUsage('mv', null, accountId);
 
   try {
     await moveFile(accountId, srcPath, getCorrectedDestPath(srcPath, destPath));

--- a/packages/cli/commands/open.js
+++ b/packages/cli/commands/open.js
@@ -34,7 +34,7 @@ exports.handler = async options => {
   const { shortcut, list } = options;
   const accountId = getAccountId(options);
 
-  trackCommandUsage('open', { shortcut }, accountId);
+  trackCommandUsage('open', null, accountId);
 
   if (shortcut === undefined && !list) {
     const choice = await createListPrompt(accountId);

--- a/packages/cli/commands/project/create.js
+++ b/packages/cli/commands/project/create.js
@@ -30,7 +30,7 @@ exports.handler = async options => {
 
   const { name, template, location } = await createProjectPrompt(options);
 
-  trackCommandUsage('project-create', { projectName: name }, accountId);
+  trackCommandUsage('project-create', null, accountId);
 
   await createProjectConfig(
     path.resolve(getCwd(), options.location || location),

--- a/packages/cli/commands/project/deploy.js
+++ b/packages/cli/commands/project/deploy.js
@@ -15,7 +15,7 @@ const { loadAndValidateOptions } = require('../../lib/validation');
 const { getProjectConfig, pollDeployStatus } = require('../../lib/projects');
 const { projectNamePrompt } = require('../../lib/prompts/projectNamePrompt');
 const { i18n } = require('@hubspot/cli-lib/lib/lang');
-const { getAccountConfig } = require('@hubspot/cli-lib');
+// const { getAccountConfig } = require('@hubspot/cli-lib');
 
 const i18nKey = 'cli.commands.project.subcommands.deploy';
 const { EXIT_CODES } = require('../../lib/enums/exitCodes');
@@ -27,11 +27,11 @@ exports.handler = async options => {
   await loadAndValidateOptions(options);
 
   const accountId = getAccountId(options);
-  const accountConfig = getAccountConfig(accountId);
+  // const accountConfig = getAccountConfig(accountId);
   const { project, buildId } = options;
-  const sandboxType = accountConfig && accountConfig.sandboxAccountType;
+  // const sandboxType = accountConfig && accountConfig.sandboxAccountType;
 
-  trackCommandUsage('project-deploy', { sandboxType }, accountId);
+  trackCommandUsage('project-deploy', null, accountId);
 
   const { projectConfig } = await getProjectConfig();
 

--- a/packages/cli/commands/project/deploy.js
+++ b/packages/cli/commands/project/deploy.js
@@ -31,7 +31,7 @@ exports.handler = async options => {
   const { project, buildId } = options;
   const sandboxType = accountConfig && accountConfig.sandboxAccountType;
 
-  trackCommandUsage('project-deploy', { project, sandboxType }, accountId);
+  trackCommandUsage('project-deploy', { sandboxType }, accountId);
 
   const { projectConfig } = await getProjectConfig();
 

--- a/packages/cli/commands/project/download.js
+++ b/packages/cli/commands/project/download.js
@@ -36,7 +36,7 @@ exports.handler = async options => {
   const { name: projectName, dest, buildNumber } = options;
   const accountId = getAccountId(options);
 
-  trackCommandUsage('project-download', { projectName }, accountId);
+  trackCommandUsage('project-download', null, accountId);
 
   const projectExists = await ensureProjectExists(accountId, projectName, {
     allowCreate: false,

--- a/packages/cli/commands/project/listBuilds.js
+++ b/packages/cli/commands/project/listBuilds.js
@@ -40,7 +40,7 @@ exports.handler = async options => {
   const { path: projectPath, limit } = options;
   const accountId = getAccountId(options);
 
-  trackCommandUsage('project-list-builds', { projectPath }, accountId);
+  trackCommandUsage('project-list-builds', null, accountId);
 
   const cwd = projectPath ? path.resolve(getCwd(), projectPath) : getCwd();
   const { projectConfig, projectDir } = await getProjectConfig(cwd);

--- a/packages/cli/commands/project/logs.js
+++ b/packages/cli/commands/project/logs.js
@@ -188,7 +188,7 @@ exports.handler = async options => {
     }
   }
 
-  trackCommandUsage('project-logs', { latest: options.latest }, accountId);
+  trackCommandUsage('project-logs', null, accountId);
 
   const logsInfo = [accountId, `"${projectName}"`];
   let tableHeader;

--- a/packages/cli/commands/project/open.js
+++ b/packages/cli/commands/project/open.js
@@ -29,7 +29,7 @@ exports.handler = async options => {
   const accountId = getAccountId(options);
   const { project } = options;
 
-  trackCommandUsage('project-open', { project }, accountId);
+  trackCommandUsage('project-open', null, accountId);
 
   const { projectConfig } = await getProjectConfig();
 

--- a/packages/cli/commands/project/upload.js
+++ b/packages/cli/commands/project/upload.js
@@ -18,7 +18,7 @@ const {
   validateProjectConfig,
 } = require('../../lib/projects');
 const { i18n } = require('@hubspot/cli-lib/lib/lang');
-const { getAccountConfig } = require('@hubspot/cli-lib');
+// const { getAccountConfig } = require('@hubspot/cli-lib');
 const { EXIT_CODES } = require('../../lib/enums/exitCodes');
 
 const i18nKey = 'cli.commands.project.subcommands.upload';
@@ -31,10 +31,10 @@ exports.handler = async options => {
 
   const { forceCreate, path: projectPath } = options;
   const accountId = getAccountId(options);
-  const accountConfig = getAccountConfig(accountId);
-  const sandboxType = accountConfig && accountConfig.sandboxAccountType;
+  // const accountConfig = getAccountConfig(accountId);
+  // const sandboxType = accountConfig && accountConfig.sandboxAccountType;
 
-  trackCommandUsage('project-upload', { sandboxType }, accountId);
+  trackCommandUsage('project-upload', null, accountId);
 
   const { projectConfig, projectDir } = await getProjectConfig(projectPath);
 

--- a/packages/cli/commands/project/upload.js
+++ b/packages/cli/commands/project/upload.js
@@ -34,7 +34,7 @@ exports.handler = async options => {
   const accountConfig = getAccountConfig(accountId);
   const sandboxType = accountConfig && accountConfig.sandboxAccountType;
 
-  trackCommandUsage('project-upload', { projectPath, sandboxType }, accountId);
+  trackCommandUsage('project-upload', { sandboxType }, accountId);
 
   const { projectConfig, projectDir } = await getProjectConfig(projectPath);
 

--- a/packages/cli/commands/project/watch.js
+++ b/packages/cli/commands/project/watch.js
@@ -83,7 +83,7 @@ exports.handler = async options => {
   const { initialUpload, path: projectPath } = options;
   const accountId = getAccountId(options);
 
-  trackCommandUsage('project-watch', { projectPath }, accountId);
+  trackCommandUsage('project-watch', null, accountId);
 
   const { projectConfig, projectDir } = await getProjectConfig(projectPath);
 

--- a/packages/cli/commands/remove.js
+++ b/packages/cli/commands/remove.js
@@ -27,7 +27,7 @@ exports.handler = async options => {
 
   const accountId = getAccountId(options);
 
-  trackCommandUsage('remove', {}, accountId);
+  trackCommandUsage('remove', null, accountId);
 
   try {
     await deleteFile(accountId, hsPath);

--- a/packages/cli/commands/sandbox/create.js
+++ b/packages/cli/commands/sandbox/create.js
@@ -151,8 +151,6 @@ exports.handler = async options => {
   } catch (err) {
     debugErrorAndContext(err);
 
-    trackCommandUsage('sandbox-create', null, accountId);
-
     spinnies.fail('sandboxCreate', {
       text: i18n(`${i18nKey}.loading.fail`, {
         sandboxName,

--- a/packages/cli/commands/sandbox/create.js
+++ b/packages/cli/commands/sandbox/create.js
@@ -151,7 +151,7 @@ exports.handler = async options => {
   } catch (err) {
     debugErrorAndContext(err);
 
-    trackCommandUsage('sandbox-create', { success: false }, accountId);
+    trackCommandUsage('sandbox-create', null, accountId);
 
     spinnies.fail('sandboxCreate', {
       text: i18n(`${i18nKey}.loading.fail`, {

--- a/packages/cli/commands/sandbox/create.js
+++ b/packages/cli/commands/sandbox/create.js
@@ -120,7 +120,7 @@ exports.handler = async options => {
     succeedColor: 'white',
   });
 
-  trackCommandUsage('sandbox-create', {}, accountId);
+  trackCommandUsage('sandbox-create', null, accountId);
 
   let namePrompt;
 

--- a/packages/cli/commands/sandbox/delete.js
+++ b/packages/cli/commands/sandbox/delete.js
@@ -49,7 +49,7 @@ exports.handler = async options => {
     account: account || accountPrompt.account,
   });
 
-  trackCommandUsage('sandbox-delete', {}, sandboxAccountId);
+  trackCommandUsage('sandbox-delete', null, sandboxAccountId);
 
   let parentAccountId;
   for (const portal of config.portals) {

--- a/packages/cli/commands/sandbox/delete.js
+++ b/packages/cli/commands/sandbox/delete.js
@@ -126,7 +126,7 @@ exports.handler = async options => {
   } catch (err) {
     debugErrorAndContext(err);
 
-    trackCommandUsage('sandbox-delete', { success: false }, sandboxAccountId);
+    trackCommandUsage('sandbox-delete', null, sandboxAccountId);
 
     if (
       err.error &&

--- a/packages/cli/commands/sandbox/delete.js
+++ b/packages/cli/commands/sandbox/delete.js
@@ -126,8 +126,6 @@ exports.handler = async options => {
   } catch (err) {
     debugErrorAndContext(err);
 
-    trackCommandUsage('sandbox-delete', null, sandboxAccountId);
-
     if (
       err.error &&
       err.error.category === OBJECT_NOT_FOUND &&

--- a/packages/cli/commands/secrets/addSecret.js
+++ b/packages/cli/commands/secrets/addSecret.js
@@ -28,7 +28,7 @@ exports.handler = async options => {
   await loadAndValidateOptions(options);
 
   const accountId = getAccountId(options);
-  trackCommandUsage('secrets-add', {}, accountId);
+  trackCommandUsage('secrets-add', null, accountId);
 
   try {
     const { secretValue } = await secretValuePrompt();

--- a/packages/cli/commands/secrets/deleteSecret.js
+++ b/packages/cli/commands/secrets/deleteSecret.js
@@ -27,7 +27,7 @@ exports.handler = async options => {
   await loadAndValidateOptions(options);
 
   const accountId = getAccountId(options);
-  trackCommandUsage('secrets-delete', {}, accountId);
+  trackCommandUsage('secrets-delete', null, accountId);
 
   try {
     await deleteSecret(accountId, secretName);

--- a/packages/cli/commands/secrets/listSecrets.js
+++ b/packages/cli/commands/secrets/listSecrets.js
@@ -25,7 +25,7 @@ exports.handler = async options => {
   await loadAndValidateOptions(options);
 
   const accountId = getAccountId(options);
-  trackCommandUsage('secrets-list', {}, accountId);
+  trackCommandUsage('secrets-list', null, accountId);
 
   try {
     const { results } = await fetchSecrets(accountId);

--- a/packages/cli/commands/secrets/updateSecret.js
+++ b/packages/cli/commands/secrets/updateSecret.js
@@ -28,7 +28,7 @@ exports.handler = async options => {
   await loadAndValidateOptions(options);
 
   const accountId = getAccountId(options);
-  trackCommandUsage('secrets-update', {}, accountId);
+  trackCommandUsage('secrets-update', null, accountId);
 
   try {
     const { secretValue } = await secretValuePrompt();

--- a/packages/cli/commands/theme/marketplace-validate.js
+++ b/packages/cli/commands/theme/marketplace-validate.js
@@ -63,7 +63,7 @@ exports.handler = async options => {
       })
     );
   }
-  trackCommandUsage('validate', {}, accountId);
+  trackCommandUsage('validate', null, accountId);
 
   const themeFiles = await walk(absoluteSrcPath);
 


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
Our usage tracking proxies through one of our BE services. That service has a set of hardcoded usage tracking fields that we allow. Any fields that aren't in the list will get filtered out. I'm cleaning up all of those fields that aren't ever making it into our usage tracking tool.

As a follow up to this, we will need to make some updates to the BE service:
- Support `sandboxType`
- Support `success`
- Remove `latest` because it's not used anymore. IMO it's not necessary to track this one

## Screenshots
<!-- Provide images of the before and after functionality -->

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
cc/ @adamawang 