### PR TITLE
Hs feedback command

### DIFF
--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -518,6 +518,8 @@ en:
               buildSucceededAutomaticallyDeploying: "Build #{{ buildId }} succeeded. {{#bold}}Automatically deploying{{/bold}} to {{ accountIdentifier }}\n"
               readyToGoLive: "🚀 Ready to take your project live?"
               runCommand: "Run `{{ command }}`"
+              feedbackHeader: "We'd love to hear your feedback!"
+              feedbackMessage: "How are you liking the new projects and developer tools? \n > Run `{{#yellow}}hs feedback{{/yellow}}` to let us know what you think!\n"
             options:
               forceCreate:
                 describe: "Automatically create project if it does not exist"

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -592,6 +592,7 @@ en:
             success: "Successfully opened \"{{ projectName }}\""
           feedback:
             describe: "Leave your feedback on the CLI or file a bug report"
+            success: "We opened {{ url }} in your browser."
       remove:
         describe: "Delete a file or folder from HubSpot."
         deleted: "Deleted \"{{ path }}\" from account {{ accountId }}"

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -593,6 +593,12 @@ en:
           feedback:
             describe: "Leave feedback on HubSpot projects or file a bug report"
             success: "We opened {{ url }} in your browser."
+            options:
+              bug:
+                describe: "Open Github issues in your browser to report a bug."
+              general:
+                describe: "Open the projects feedback form in your browser."
+
       remove:
         describe: "Delete a file or folder from HubSpot."
         deleted: "Deleted \"{{ path }}\" from account {{ accountId }}"
@@ -932,8 +938,8 @@ en:
         feedbackPrompt:
           feedbackType:
             message: "What type of feedback would you like to leave?"
-            bug: "Report a bug"
-            general: "Tell us about your experience with projects"
+            bug: "[--bug] Report a bug"
+            general: "[--general] Tell us about your experience with projects"
           bugPrompt: "Create an issue on Github in your browser?"
           generalPrompt: "Open the projects feedback form in your browser?"
       process:

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -931,8 +931,8 @@ en:
             message: "What type of feedback would you like to leave?"
             bug: "Report a bug"
             general: "Tell us about your experience with projects"
-          bugPrompt: "Create an issue on Github in your browser? (Y/N)"
-          generalPrompt: "Open the projects feedback form in your browser? (Y/N)"
+          bugPrompt: "Create an issue on Github in your browser?"
+          generalPrompt: "Open the projects feedback form in your browser?"
       process:
         positionals:
           src:

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -591,7 +591,7 @@ en:
               default: "Opens the projects page for the specified account"
             success: "Successfully opened \"{{ projectName }}\""
           feedback:
-            describe: "Leave your feedback on the CLI or file a bug report"
+            describe: "Leave feedback on HubSpot projects or file a bug report"
             success: "We opened {{ url }} in your browser."
       remove:
         describe: "Delete a file or folder from HubSpot."

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -590,6 +590,8 @@ en:
             examples:
               default: "Opens the projects page for the specified account"
             success: "Successfully opened \"{{ projectName }}\""
+          feedback:
+            describe: "Leave your feedback on the CLI or file a bug report"
       remove:
         describe: "Delete a file or folder from HubSpot."
         deleted: "Deleted \"{{ path }}\" from account {{ accountId }}"
@@ -923,6 +925,13 @@ en:
           errors:
             invalidName: "You entered an invalid name. Please try again."
             projectDoesNotExist: "Project \"{{ projectName }}\" could not be found in \"{{ accountId }}\""
+        feedbackPrompt:
+          feedbackType:
+            message: "What type of feedback would you like to leave?"
+            bug: "Report a bug"
+            general: "Tell us about your experience with projects"
+          bugPrompt: "Create an issue on Github in your browser? (Y/N)"
+          generalPrompt: "Open the projects feedback form in your browser? (Y/N)"
       process:
         positionals:
           src:

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -797,6 +797,9 @@ en:
             createCommand:
               command: "hs create"
               message: "Add new components to your project with {{ command }}"
+            feedbackCommand:
+              command: "hs feedback"
+              message: "Run {{ command }} to report a bug or leave feedback"
             helpCommand:
               command: "hs help"
               message: "Run {{ command }} to see a list of available commands"

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -941,7 +941,7 @@ en:
           feedbackType:
             message: "What type of feedback would you like to leave?"
             bug: "[--bug] Report a bug"
-            general: "[--general] Tell us about your experience with projects"
+            general: "[--general] Tell us about your experience with HubSpot's developer tools"
           bugPrompt: "Create an issue on Github in your browser?"
           generalPrompt: "Open the projects feedback form in your browser?"
       process:

--- a/packages/cli-lib/lib/constants.js
+++ b/packages/cli-lib/lib/constants.js
@@ -209,6 +209,16 @@ const PROJECT_DEPLOY_TEXT = {
   SUBTASK_NAME_KEY: 'deployName',
 };
 
+const FEEDBACK_OPTIONS = {
+  BUG: 'bug',
+  GENERAL: 'general',
+};
+
+const FEEDBACK_URLS = {
+  BUG: 'https://github.com/HubSpot/hubspot-cli/issues/new',
+  GENERAL: 'https://hubspot.com',
+};
+
 module.exports = {
   ConfigFlags,
   Mode,
@@ -221,6 +231,8 @@ module.exports = {
   ENVIRONMENT_VARIABLES,
   ENVIRONMENTS,
   EMPTY_CONFIG_FILE_CONTENTS,
+  FEEDBACK_OPTIONS,
+  FEEDBACK_URLS,
   FOLDER_DOT_EXTENSIONS,
   FUNCTIONS_EXTENSION,
   GITHUB_RELEASE_TYPES,

--- a/packages/cli-lib/lib/constants.js
+++ b/packages/cli-lib/lib/constants.js
@@ -216,7 +216,8 @@ const FEEDBACK_OPTIONS = {
 
 const FEEDBACK_URLS = {
   BUG: 'https://github.com/HubSpot/hubspot-cli/issues/new',
-  GENERAL: 'https://hubspot.com',
+  GENERAL:
+    'https://docs.google.com/forms/d/e/1FAIpQLSejZZewYzuH3oKBU01tseX-cSWOUsTHLTr-YsiMGpzwcvgIMg/viewform?usp=sf_link',
 };
 
 module.exports = {

--- a/packages/cli-lib/lib/constants.js
+++ b/packages/cli-lib/lib/constants.js
@@ -220,6 +220,8 @@ const FEEDBACK_URLS = {
     'https://docs.google.com/forms/d/e/1FAIpQLSejZZewYzuH3oKBU01tseX-cSWOUsTHLTr-YsiMGpzwcvgIMg/viewform?usp=sf_link',
 };
 
+const FEEDBACK_INTERVAL = 10;
+
 module.exports = {
   ConfigFlags,
   Mode,
@@ -232,6 +234,7 @@ module.exports = {
   ENVIRONMENT_VARIABLES,
   ENVIRONMENTS,
   EMPTY_CONFIG_FILE_CONTENTS,
+  FEEDBACK_INTERVAL,
   FEEDBACK_OPTIONS,
   FEEDBACK_URLS,
   FOLDER_DOT_EXTENSIONS,

--- a/packages/cli/bin/cli.js
+++ b/packages/cli/bin/cli.js
@@ -40,6 +40,7 @@ const accountsCommand = require('../commands/accounts');
 const sandboxesCommand = require('../commands/sandbox');
 const processCommand = require('../commands/process');
 const cmsCommand = require('../commands/cms');
+const feedbackCommand = require('../commands/feedback');
 const { EXIT_CODES } = require('../lib/enums/exitCodes');
 
 const notifier = updateNotifier({ pkg: { ...pkg, name: '@hubspot/cli' } });
@@ -159,6 +160,7 @@ const argv = yargs
   .command(accountsCommand)
   .command(sandboxesCommand)
   .command(processCommand, false)
+  .command(feedbackCommand)
   .help()
   .recommendCommands()
   .demandCommand(1, '')

--- a/packages/cli/commands/feedback.js
+++ b/packages/cli/commands/feedback.js
@@ -9,8 +9,7 @@ const { logger } = require('@hubspot/cli-lib/logger');
 
 const {
   feedbackTypePrompt,
-  bugPrompt,
-  generalPrompt,
+  shouldOpenBrowserPrompt,
 } = require('../lib/prompts/feedbackPrompt');
 
 const i18nKey = 'cli.commands.project.subcommands.feedback';
@@ -20,12 +19,9 @@ exports.describe = i18n(`${i18nKey}.describe`);
 
 exports.handler = async () => {
   const { type } = await feedbackTypePrompt();
+  const { shouldOpen } = await shouldOpenBrowserPrompt(type);
 
-  const promptForType =
-    type === FEEDBACK_OPTIONS.BUG ? bugPrompt : generalPrompt;
-  const { shouldOpen } = await promptForType();
-
-  if (shouldOpen === 'Y') {
+  if (shouldOpen) {
     const url =
       type === FEEDBACK_OPTIONS.BUG ? FEEDBACK_URLS.BUG : FEEDBACK_URLS.GENERAL;
     open(url, { url: true });

--- a/packages/cli/commands/feedback.js
+++ b/packages/cli/commands/feedback.js
@@ -1,0 +1,32 @@
+const open = require('open');
+
+const { i18n } = require('@hubspot/cli-lib/lib/lang');
+const {
+  FEEDBACK_OPTIONS,
+  FEEDBACK_URLS,
+} = require('@hubspot/cli-lib/lib/constants');
+
+const {
+  feedbackTypePrompt,
+  bugPrompt,
+  generalPrompt,
+} = require('../lib/prompts/feedbackPrompt');
+
+const i18nKey = 'cli.commands.project.subcommands.feedback';
+
+exports.command = 'feedback';
+exports.describe = i18n(`${i18nKey}.describe`);
+
+exports.handler = async () => {
+  const { type } = await feedbackTypePrompt();
+
+  const promptForType =
+    type === FEEDBACK_OPTIONS.BUG ? bugPrompt : generalPrompt;
+  const { shouldOpen } = await promptForType();
+
+  if (shouldOpen === 'Y') {
+    const url =
+      type === FEEDBACK_OPTIONS.BUG ? FEEDBACK_URLS.BUG : FEEDBACK_URLS.GENERAL;
+    open(url, { url: true });
+  }
+};

--- a/packages/cli/commands/feedback.js
+++ b/packages/cli/commands/feedback.js
@@ -17,14 +17,32 @@ const i18nKey = 'cli.commands.project.subcommands.feedback';
 exports.command = 'feedback';
 exports.describe = i18n(`${i18nKey}.describe`);
 
-exports.handler = async () => {
-  const { type } = await feedbackTypePrompt();
-  const { shouldOpen } = await shouldOpenBrowserPrompt(type);
+exports.handler = async options => {
+  const { bug: bugFlag, general: generalFlag } = options;
+  const usedTypeFlag = bugFlag !== generalFlag;
 
-  if (shouldOpen) {
+  const { type } = await feedbackTypePrompt(usedTypeFlag);
+  const { shouldOpen } = await shouldOpenBrowserPrompt(type, usedTypeFlag);
+
+  if (shouldOpen || usedTypeFlag) {
     const url =
-      type === FEEDBACK_OPTIONS.BUG ? FEEDBACK_URLS.BUG : FEEDBACK_URLS.GENERAL;
+      type === FEEDBACK_OPTIONS.BUG || bugFlag
+        ? FEEDBACK_URLS.BUG
+        : FEEDBACK_URLS.GENERAL;
     open(url, { url: true });
     logger.success(i18n(`${i18nKey}.success`, { url }));
   }
+};
+
+exports.builder = yargs => {
+  yargs.options({
+    bug: {
+      describe: i18n(`${i18nKey}.options.bug.describe`),
+      type: 'boolean',
+    },
+    general: {
+      describe: i18n(`${i18nKey}.options.general.describe`),
+      type: 'boolean',
+    },
+  });
 };

--- a/packages/cli/commands/feedback.js
+++ b/packages/cli/commands/feedback.js
@@ -5,6 +5,7 @@ const {
   FEEDBACK_OPTIONS,
   FEEDBACK_URLS,
 } = require('@hubspot/cli-lib/lib/constants');
+const { logger } = require('@hubspot/cli-lib/logger');
 
 const {
   feedbackTypePrompt,
@@ -28,5 +29,6 @@ exports.handler = async () => {
     const url =
       type === FEEDBACK_OPTIONS.BUG ? FEEDBACK_URLS.BUG : FEEDBACK_URLS.GENERAL;
     open(url, { url: true });
+    logger.success(i18n(`${i18nKey}.success`, { url }));
   }
 };

--- a/packages/cli/commands/project/create.js
+++ b/packages/cli/commands/project/create.js
@@ -45,6 +45,7 @@ exports.handler = async options => {
     'projectUploadCommand',
     'projectDeployCommand',
     'projectHelpCommand',
+    'feedbackCommand',
   ]);
 };
 

--- a/packages/cli/commands/project/upload.js
+++ b/packages/cli/commands/project/upload.js
@@ -23,6 +23,8 @@ const { EXIT_CODES } = require('../../lib/enums/exitCodes');
 
 const i18nKey = 'cli.commands.project.subcommands.upload';
 
+const FEEDBACK_INTERVAL = 1;
+
 exports.command = 'upload [path]';
 exports.describe = i18n(`${i18nKey}.describe`);
 
@@ -99,6 +101,13 @@ exports.handler = async options => {
       );
     } catch (e) {
       logger.error(e);
+    }
+
+    if (buildId > 0 && buildId % FEEDBACK_INTERVAL === 0) {
+      uiLine();
+      logger.log(i18n(`${i18nKey}.logs.feedbackHeader`));
+      uiLine();
+      logger.log(i18n(`${i18nKey}.logs.feedbackMessage`));
     }
 
     process.exit(exitCode);

--- a/packages/cli/commands/project/upload.js
+++ b/packages/cli/commands/project/upload.js
@@ -13,6 +13,7 @@ const {
   ensureProjectExists,
   getProjectConfig,
   handleProjectUpload,
+  logFeedbackMessage,
   pollBuildStatus,
   pollDeployStatus,
   validateProjectConfig,
@@ -22,8 +23,6 @@ const { i18n } = require('@hubspot/cli-lib/lib/lang');
 const { EXIT_CODES } = require('../../lib/enums/exitCodes');
 
 const i18nKey = 'cli.commands.project.subcommands.upload';
-
-const FEEDBACK_INTERVAL = 1;
 
 exports.command = 'upload [path]';
 exports.describe = i18n(`${i18nKey}.describe`);
@@ -103,12 +102,7 @@ exports.handler = async options => {
       logger.error(e);
     }
 
-    if (buildId > 0 && buildId % FEEDBACK_INTERVAL === 0) {
-      uiLine();
-      logger.log(i18n(`${i18nKey}.logs.feedbackHeader`));
-      uiLine();
-      logger.log(i18n(`${i18nKey}.logs.feedbackMessage`));
-    }
+    logFeedbackMessage(buildId);
 
     process.exit(exitCode);
   };

--- a/packages/cli/commands/project/watch.js
+++ b/packages/cli/commands/project/watch.js
@@ -19,6 +19,7 @@ const {
   pollBuildStatus,
   pollDeployStatus,
   validateProjectConfig,
+  logFeedbackMessage,
 } = require('../../lib/projects');
 const {
   cancelStagedBuild,
@@ -47,6 +48,8 @@ const handleBuildStatus = async (accountId, projectName, buildId) => {
       buildId
     );
   }
+
+  logFeedbackMessage(buildId);
 };
 
 const handleUserInput = (accountId, projectName, currentBuildId) => {

--- a/packages/cli/lib/projects.js
+++ b/packages/cli/lib/projects.js
@@ -11,6 +11,7 @@ const { cloneGitHubRepo } = require('@hubspot/cli-lib/github');
 const { getHubSpotWebsiteOrigin } = require('@hubspot/cli-lib/lib/urls');
 const {
   ENVIRONMENTS,
+  FEEDBACK_INTERVAL,
   POLLING_DELAY,
   PROJECT_TEMPLATES,
   PROJECT_BUILD_TEXT,
@@ -517,6 +518,16 @@ const pollDeployStatus = makePollTaskStatusFunc({
   },
 });
 
+const logFeedbackMessage = buildId => {
+  const i18nKey = 'cli.commands.project.subcommands.upload';
+  if (buildId > 0 && buildId % FEEDBACK_INTERVAL === 0) {
+    uiLine();
+    logger.log(i18n(`${i18nKey}.logs.feedbackHeader`));
+    uiLine();
+    logger.log(i18n(`${i18nKey}.logs.feedbackMessage`));
+  }
+};
+
 module.exports = {
   writeProjectConfig,
   getProjectConfig,
@@ -529,4 +540,5 @@ module.exports = {
   pollBuildStatus,
   pollDeployStatus,
   ensureProjectExists,
+  logFeedbackMessage,
 };

--- a/packages/cli/lib/prompts/feedbackPrompt.js
+++ b/packages/cli/lib/prompts/feedbackPrompt.js
@@ -1,0 +1,43 @@
+const { promptUser } = require('./promptUtils');
+const { i18n } = require('@hubspot/cli-lib/lib/lang');
+const { FEEDBACK_OPTIONS } = require('@hubspot/cli-lib/lib/constants');
+
+const i18nKey = 'cli.lib.prompts.feedbackPrompt';
+
+const feedbackTypePrompt = () => {
+  return promptUser([
+    {
+      name: 'type',
+      message: i18n(`${i18nKey}.feedbackType.message`),
+      type: 'list',
+      choices: Object.values(FEEDBACK_OPTIONS).map(option => ({
+        name: i18n(`${i18nKey}.feedbackType.${option}`),
+        value: option,
+      })),
+    },
+  ]);
+};
+
+const bugPrompt = () => {
+  return promptUser([
+    {
+      name: 'shouldOpen',
+      message: i18n(`${i18nKey}.bugPrompt`),
+    },
+  ]);
+};
+
+const generalPrompt = () => {
+  return promptUser([
+    {
+      name: 'shouldOpen',
+      message: i18n(`${i18nKey}.generalPrompt`),
+    },
+  ]);
+};
+
+module.exports = {
+  feedbackTypePrompt,
+  bugPrompt,
+  generalPrompt,
+};

--- a/packages/cli/lib/prompts/feedbackPrompt.js
+++ b/packages/cli/lib/prompts/feedbackPrompt.js
@@ -4,12 +4,13 @@ const { FEEDBACK_OPTIONS } = require('@hubspot/cli-lib/lib/constants');
 
 const i18nKey = 'cli.lib.prompts.feedbackPrompt';
 
-const feedbackTypePrompt = () => {
+const feedbackTypePrompt = bypassPrompt => {
   return promptUser([
     {
       name: 'type',
       message: i18n(`${i18nKey}.feedbackType.message`),
       type: 'list',
+      when: !bypassPrompt,
       choices: Object.values(FEEDBACK_OPTIONS).map(option => ({
         name: i18n(`${i18nKey}.feedbackType.${option}`),
         value: option,
@@ -18,7 +19,7 @@ const feedbackTypePrompt = () => {
   ]);
 };
 
-const shouldOpenBrowserPrompt = type => {
+const shouldOpenBrowserPrompt = (type, bypassPrompt) => {
   return promptUser([
     {
       name: 'shouldOpen',
@@ -28,6 +29,7 @@ const shouldOpenBrowserPrompt = type => {
           : i18n(`${i18nKey}.generalPrompt`);
       },
       type: 'confirm',
+      when: !bypassPrompt,
     },
   ]);
 };

--- a/packages/cli/lib/prompts/feedbackPrompt.js
+++ b/packages/cli/lib/prompts/feedbackPrompt.js
@@ -18,26 +18,21 @@ const feedbackTypePrompt = () => {
   ]);
 };
 
-const bugPrompt = () => {
+const shouldOpenBrowserPrompt = type => {
   return promptUser([
     {
       name: 'shouldOpen',
-      message: i18n(`${i18nKey}.bugPrompt`),
-    },
-  ]);
-};
-
-const generalPrompt = () => {
-  return promptUser([
-    {
-      name: 'shouldOpen',
-      message: i18n(`${i18nKey}.generalPrompt`),
+      message: () => {
+        return type === FEEDBACK_OPTIONS.BUG
+          ? i18n(`${i18nKey}.bugPrompt`)
+          : i18n(`${i18nKey}.generalPrompt`);
+      },
+      type: 'confirm',
     },
   ]);
 };
 
 module.exports = {
   feedbackTypePrompt,
-  bugPrompt,
-  generalPrompt,
+  shouldOpenBrowserPrompt,
 };


### PR DESCRIPTION
This adds the feedback command + reminders for users to leave feedback.

<img width="569" alt="Screen Shot 2022-09-26 at 3 25 12 PM" src="https://user-images.githubusercontent.com/10413161/192364570-9313ea01-423d-400d-afc8-b97e911fe9e8.png">

<img width="547" alt="Screen Shot 2022-09-26 at 3 43 34 PM" src="https://user-images.githubusercontent.com/10413161/192365745-bc3877e4-4838-4d71-9f95-c3de1820869e.png">


### Feedback command
* `hs feedback`
* Asks user what type of feedback they want to leave, then prompts them to open the respective feedback page in the browser
* use `--general` or `--bug` to bypass prompts and open the browser directly

### Feedback reminders
* `hs project upload` - Displays every 5 builds. For this first pass, we're not tracking when users respond to the form, so we might want to make this less frequent
* `hs project create` - Added to the list of suggestions under "What's next?"