### PR TITLE
Add additional info to project locked error message

### DIFF
--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -518,7 +518,7 @@ en:
               buildSucceededAutomaticallyDeploying: "Build #{{ buildId }} succeeded. {{#bold}}Automatically deploying{{/bold}} to {{ accountIdentifier }}\n"
               readyToGoLive: "🚀 Ready to take your project live?"
               runCommand: "Run `{{ command }}`"
-              projectLockedError: "If this persists, your project may be locked by an active `{{#yellow}}hs project watch{{/yellow}}`. Try stopping the `{{#yellow}}watch{{/yellow}}` process before manually uploading. If this doesn't work, you may need to start and stop a new `{{#yellow}}watch{{/yellow}}` process to unlock the project."
+              projectLockedError: "\nYour project may be locked by an active `{{#yellow}}hs project watch{{/yellow}}`. Try stopping the `{{#yellow}}watch{{/yellow}}` process before uploading.\nIf that doesn't work, you may need to start and stop a new `{{#yellow}}watch{{/yellow}}` process to unlock the project."
             options:
               forceCreate:
                 describe: "Automatically create project if it does not exist"

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -518,6 +518,7 @@ en:
               buildSucceededAutomaticallyDeploying: "Build #{{ buildId }} succeeded. {{#bold}}Automatically deploying{{/bold}} to {{ accountIdentifier }}\n"
               readyToGoLive: "🚀 Ready to take your project live?"
               runCommand: "Run `{{ command }}`"
+              projectLockedError: "If this persists, your project may be locked by an active `{{#yellow}}hs project watch{{/yellow}}`. Try stopping the `{{#yellow}}watch{{/yellow}}` process before manually uploading. If this doesn't work, you may need to start and stop a new `{{#yellow}}watch{{/yellow}}` process to unlock the project."
             options:
               forceCreate:
                 describe: "Automatically create project if it does not exist"

--- a/packages/cli-lib/lib/constants.js
+++ b/packages/cli-lib/lib/constants.js
@@ -209,6 +209,10 @@ const PROJECT_DEPLOY_TEXT = {
   SUBTASK_NAME_KEY: 'deployName',
 };
 
+const ERROR_TYPES = {
+  PROJECT_LOCKED: 'BuildPipelineErrorType.PROJECT_LOCKED',
+};
+
 module.exports = {
   ConfigFlags,
   Mode,
@@ -221,6 +225,7 @@ module.exports = {
   ENVIRONMENT_VARIABLES,
   ENVIRONMENTS,
   EMPTY_CONFIG_FILE_CONTENTS,
+  ERROR_TYPES,
   FOLDER_DOT_EXTENSIONS,
   FUNCTIONS_EXTENSION,
   GITHUB_RELEASE_TYPES,

--- a/packages/cli-lib/projectsWatch.js
+++ b/packages/cli-lib/projectsWatch.js
@@ -14,6 +14,7 @@ const {
   deleteFileFromBuild,
   queueBuild,
 } = require('./api/dfs');
+const { ERROR_TYPES } = require('./lib/constants');
 
 const i18nKey = 'cli.commands.project.subcommands.watch';
 
@@ -121,7 +122,7 @@ const createNewBuild = async (accountId, projectName) => {
     return buildId;
   } catch (err) {
     logApiErrorInstance(err, new ApiErrorContext({ accountId, projectName }));
-    if (err.error.subCategory !== 'BuildPipelineErrorType.PROJECT_LOCKED') {
+    if (err.error.subCategory !== ERROR_TYPES.PROJECT_LOCKED) {
       await cancelStagedBuild(accountId, projectName);
       logger.log(i18n(`${i18nKey}.logs.previousStagingBuildCancelled`));
     }

--- a/packages/cli/lib/projects.js
+++ b/packages/cli/lib/projects.js
@@ -11,6 +11,7 @@ const { cloneGitHubRepo } = require('@hubspot/cli-lib/github');
 const { getHubSpotWebsiteOrigin } = require('@hubspot/cli-lib/lib/urls');
 const {
   ENVIRONMENTS,
+  ERROR_TYPES,
   POLLING_DELAY,
   PROJECT_TEMPLATES,
   PROJECT_BUILD_TEXT,
@@ -280,6 +281,9 @@ const uploadProjectFiles = async (accountId, projectName, filePath) => {
         projectName,
       })
     );
+    if (err.error.subCategory === ERROR_TYPES.PROJECT_LOCKED) {
+      logger.log(i18n(`${i18nKey}.logs.projectLockedError`));
+    }
     process.exit(EXIT_CODES.ERROR);
   }
 


### PR DESCRIPTION
This adds additional debugging info to the error that gets logged when you run upload while a watch is in progress.

![image](https://user-images.githubusercontent.com/10413161/193141977-513d8d7d-785e-4fe8-8a75-da9e9d0bced8.png)
