### PR TITLE
Reinstate sandboxes tracking events

### DIFF
--- a/packages/cli/commands/project/deploy.js
+++ b/packages/cli/commands/project/deploy.js
@@ -15,7 +15,7 @@ const { loadAndValidateOptions } = require('../../lib/validation');
 const { getProjectConfig, pollDeployStatus } = require('../../lib/projects');
 const { projectNamePrompt } = require('../../lib/prompts/projectNamePrompt');
 const { i18n } = require('@hubspot/cli-lib/lib/lang');
-// const { getAccountConfig } = require('@hubspot/cli-lib');
+const { getAccountConfig } = require('@hubspot/cli-lib');
 
 const i18nKey = 'cli.commands.project.subcommands.deploy';
 const { EXIT_CODES } = require('../../lib/enums/exitCodes');
@@ -27,11 +27,11 @@ exports.handler = async options => {
   await loadAndValidateOptions(options);
 
   const accountId = getAccountId(options);
-  // const accountConfig = getAccountConfig(accountId);
+  const accountConfig = getAccountConfig(accountId);
   const { project, buildId } = options;
-  // const sandboxType = accountConfig && accountConfig.sandboxAccountType;
+  const sandboxType = accountConfig && accountConfig.sandboxAccountType;
 
-  trackCommandUsage('project-deploy', null, accountId);
+  trackCommandUsage('project-deploy', { type: sandboxType }, accountId);
 
   const { projectConfig } = await getProjectConfig();
 

--- a/packages/cli/commands/project/upload.js
+++ b/packages/cli/commands/project/upload.js
@@ -19,7 +19,7 @@ const {
   validateProjectConfig,
 } = require('../../lib/projects');
 const { i18n } = require('@hubspot/cli-lib/lib/lang');
-// const { getAccountConfig } = require('@hubspot/cli-lib');
+const { getAccountConfig } = require('@hubspot/cli-lib');
 const { EXIT_CODES } = require('../../lib/enums/exitCodes');
 
 const i18nKey = 'cli.commands.project.subcommands.upload';
@@ -32,10 +32,10 @@ exports.handler = async options => {
 
   const { forceCreate, path: projectPath } = options;
   const accountId = getAccountId(options);
-  // const accountConfig = getAccountConfig(accountId);
-  // const sandboxType = accountConfig && accountConfig.sandboxAccountType;
+  const accountConfig = getAccountConfig(accountId);
+  const sandboxType = accountConfig && accountConfig.sandboxAccountType;
 
-  trackCommandUsage('project-upload', null, accountId);
+  trackCommandUsage('project-upload', { type: sandboxType }, accountId);
 
   const { projectConfig, projectDir } = await getProjectConfig(projectPath);
 

--- a/packages/cli/commands/sandbox/create.js
+++ b/packages/cli/commands/sandbox/create.js
@@ -151,6 +151,8 @@ exports.handler = async options => {
   } catch (err) {
     debugErrorAndContext(err);
 
+    trackCommandUsage('sandbox-create', { successful: false }, accountId);
+
     spinnies.fail('sandboxCreate', {
       text: i18n(`${i18nKey}.loading.fail`, {
         sandboxName,

--- a/packages/cli/commands/sandbox/delete.js
+++ b/packages/cli/commands/sandbox/delete.js
@@ -126,6 +126,8 @@ exports.handler = async options => {
   } catch (err) {
     debugErrorAndContext(err);
 
+    trackCommandUsage('sandbox-delete', { successful: false }, sandboxAccountId);
+
     if (
       err.error &&
       err.error.category === OBJECT_NOT_FOUND &&


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->

Brings back tracking events removed from https://github.com/HubSpot/hubspot-cli/pull/743 and adjusts prop names to use existing ones like `type` and `successful`. 

## Screenshots
<!-- Provide images of the before and after functionality -->

<img width="399" alt="Screen Shot 2022-10-05 at 17 20 38" src="https://user-images.githubusercontent.com/16788677/194155602-7fc44241-01a9-4ae5-8c37-2741130846c1.png">

<img width="1043" alt="Screen Shot 2022-10-05 at 17 22 30" src="https://user-images.githubusercontent.com/16788677/194155981-ef51461e-e600-41c8-ad53-4974b50463fd.png">


## TODO

<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->

@brandenrodgers @kemmerle 
