### PR TITLE
Sandboxes cli adjustments

### DIFF
--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -37,7 +37,6 @@ en:
               account:
                 describe: "Account name or id to use as the default"
             promptMessage: "Select an account to use as the default"
-            promptMessageReplaceDefault: "The default account was removed. Select a new account to use as the default"
             success:
               defaultAccountUpdated: "Default account updated to \"{{ accountName }}\""
           info:
@@ -645,8 +644,10 @@ en:
             examples:
               default: "Deletes the sandbox account named MySandboxAccount."
             confirm: "Delete sandbox {{#bold}}{{ account }}{{/bold}}? All data for this sandbox will be permanently deleted."
+            defaultAccountWarning: "The sandbox {{#bold}}{{ account }}{{/bold}} is currently set as the default account."
             success:
-              delete: "Sandbox \"{{ account }}\" with portalId \"{{ sandboxHubId }}\" deleted successfully."
+              delete: "Sandbox \"{{ account }}\" with portalId \"{{ sandboxHubId }}\" was deleted successfully."
+              deleteDefault: "Sandbox \"{{ account }}\" with portalId \"{{ sandboxHubId }}\" was deleted successfully and removed as the default account."
               configFileUpdated: "Removed account {{ account }} from {{ configFilename }}."
             objectNotFound: "Sandbox {{#bold}}{{ account }}{{/bold}} may have been be deleted through the UI. The account has been removed from the config."
             noParentPortalAvailable: "This sandbox can't be deleted from the CLI because you haven't given the CLI access to its parent account. To do this, run {{#bold}}{{ command }}{{/bold}}. You can also delete the sandbox from the HubSpot management tool: {{#bold}}{{ url }}{{/bold}}."

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -614,6 +614,7 @@ en:
         subcommands:
           create:
             describe: "Create a sandbox account"
+            sandboxLimitation: "The CLI only supports creation of development sandboxes at this time."
             examples:
               default: "Creates a sandbox account named MySandboxAccount."
             debug:
@@ -624,9 +625,9 @@ en:
               name:
                 describe: "Name to use for created sandbox"
             loading:
-              add: "Creating sandbox {{#bold}}{{ sandboxName }}{{/bold}}"
-              fail: "Failed to create sandbox {{#bold}}{{ sandboxName }}{{/bold}}."
-              succeed: "Successfully created sandbox {{#bold}}{{ name }}{{/bold}} with portalId {{#bold}}{{ sandboxHubId }}{{/bold}}."
+              add: "Creating development sandbox {{#bold}}{{ sandboxName }}{{/bold}}"
+              fail: "Failed to create a development sandbox {{#bold}}{{ sandboxName }}{{/bold}}."
+              succeed: "Successfully created a development sandbox {{#bold}}{{ name }}{{/bold}} with portalId {{#bold}}{{ sandboxHubId }}{{/bold}}."
             success:
               configFileUpdated: "{{ configFilename }} updated with {{ authMethod }} for account {{ account }}."
             failure:
@@ -920,7 +921,7 @@ en:
           errors:
             invalidValue: "You entered an invalid value. Please try again."
         sandboxesPrompt:
-          enterName: "Enter a name to use for the sandbox: "
+          enterName: "Enter a name to use for the development sandbox: "
           errors:
             invalidName: "You entered an invalid name. Please try again."
           selectAccountName: "Select the sandbox account you want to delete"

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -37,6 +37,7 @@ en:
               account:
                 describe: "Account name or id to use as the default"
             promptMessage: "Select an account to use as the default"
+            promptMessageReplaceDefault: "The default account was removed. Select a new account to use as the default"
             success:
               defaultAccountUpdated: "Default account updated to \"{{ accountName }}\""
           info:
@@ -647,7 +648,7 @@ en:
             success:
               delete: "Sandbox \"{{ account }}\" with portalId \"{{ sandboxHubId }}\" deleted successfully."
               configFileUpdated: "Removed account {{ account }} from {{ configFilename }}."
-            objectNotFound: "Sandbox {{#bold}}{{ account }}{{/bold}} not found, it may have already been deleted."
+            objectNotFound: "Sandbox {{#bold}}{{ account }}{{/bold}} may have been be deleted through the UI. The account has been removed from the config."
             noParentPortalAvailable: "This sandbox can't be deleted from the CLI because you haven't given the CLI access to its parent account. To do this, run {{#bold}}{{ command }}{{/bold}}. You can also delete the sandbox from the HubSpot management tool: {{#bold}}{{ url }}{{/bold}}."
             options:
               account:

--- a/packages/cli/commands/accounts/list.js
+++ b/packages/cli/commands/accounts/list.js
@@ -12,15 +12,13 @@ const {
 } = require('../../lib/commonOpts');
 const { trackCommandUsage } = require('../../lib/usageTracking');
 const { loadAndValidateOptions } = require('../../lib/validation');
+const { getSandboxType } = require('../../lib/prompts/sandboxesPrompt');
 const { i18n } = require('@hubspot/cli-lib/lib/lang');
 
 const i18nKey = 'cli.commands.accounts.subcommands.list';
 
 exports.command = 'list';
 exports.describe = i18n(`${i18nKey}.describe`);
-
-const getSandboxType = type =>
-  type === 'DEVELOPER' ? 'development' : 'standard';
 
 const sortAndMapPortals = portals => {
   const mappedPortalData = {};

--- a/packages/cli/commands/accounts/list.js
+++ b/packages/cli/commands/accounts/list.js
@@ -19,6 +19,9 @@ const i18nKey = 'cli.commands.accounts.subcommands.list';
 exports.command = 'list';
 exports.describe = i18n(`${i18nKey}.describe`);
 
+const getSandboxType = type =>
+  type === 'DEVELOPER' ? 'development' : 'standard';
+
 const sortAndMapPortals = portals => {
   const mappedPortalData = {};
   portals
@@ -57,7 +60,9 @@ const getPortalData = mappedPortalData => {
         portalData.push([portal.name, portal.portalId, portal.authType]);
       } else {
         portalData.push([
-          `↳ ${portal.name} [sandbox]`,
+          `↳ ${portal.name} [${getSandboxType(
+            portal.sandboxAccountType
+          )} sandbox]`,
           portal.portalId,
           portal.authType,
         ]);

--- a/packages/cli/commands/sandbox/create.js
+++ b/packages/cli/commands/sandbox/create.js
@@ -124,6 +124,9 @@ exports.handler = async options => {
 
   let namePrompt;
 
+  logger.log(i18n(`${i18nKey}.sandboxLimitation`));
+  logger.log('');
+
   if (!name) {
     namePrompt = await createSandboxPrompt();
   }

--- a/packages/cli/commands/sandbox/delete.js
+++ b/packages/cli/commands/sandbox/delete.js
@@ -49,6 +49,9 @@ exports.handler = async options => {
     account: account || accountPrompt.account,
   });
 
+  const isDefaultAccount =
+    sandboxAccountId === getAccountId(config.defaultPortal);
+
   trackCommandUsage('sandbox-delete', null, sandboxAccountId);
 
   let parentAccountId;
@@ -91,6 +94,14 @@ exports.handler = async options => {
     })
   );
 
+  if (isDefaultAccount) {
+    logger.log(
+      i18n(`${i18nKey}.defaultAccountWarning`, {
+        account: account || accountPrompt.account,
+      })
+    );
+  }
+
   try {
     const { confirmSandboxDeletePrompt: confirmed } = await promptUser([
       {
@@ -107,9 +118,12 @@ exports.handler = async options => {
 
     await deleteSandbox(parentAccountId, sandboxAccountId);
 
+    const deleteKey = isDefaultAccount
+      ? `${i18nKey}.success.deleteDefault`
+      : `${i18nKey}.success.delete`;
     logger.log('');
     logger.success(
-      i18n(`${i18nKey}.success.delete`, {
+      i18n(deleteKey, {
         account: account || accountPrompt.account,
         sandboxHubId: sandboxAccountId,
       })

--- a/packages/cli/commands/sandbox/delete.js
+++ b/packages/cli/commands/sandbox/delete.js
@@ -120,13 +120,17 @@ exports.handler = async options => {
       sandboxAccountId
     );
     if (promptDefaultAccount) {
-      await selectAndSetAsDefaultAccountPrompt(config);
+      await selectAndSetAsDefaultAccountPrompt(getConfig());
     }
     process.exit(EXIT_CODES.SUCCESS);
   } catch (err) {
     debugErrorAndContext(err);
 
-    trackCommandUsage('sandbox-delete', { successful: false }, sandboxAccountId);
+    trackCommandUsage(
+      'sandbox-delete',
+      { successful: false },
+      sandboxAccountId
+    );
 
     if (
       err.error &&
@@ -145,7 +149,7 @@ exports.handler = async options => {
         sandboxAccountId
       );
       if (promptDefaultAccount) {
-        await selectAndSetAsDefaultAccountPrompt(config);
+        await selectAndSetAsDefaultAccountPrompt(getConfig());
       }
       process.exit(EXIT_CODES.SUCCESS);
     } else {

--- a/packages/cli/lib/prompts/accountsPrompt.js
+++ b/packages/cli/lib/prompts/accountsPrompt.js
@@ -30,7 +30,7 @@ const selectAndSetAsDefaultAccountPrompt = async config => {
       look: false,
       name: 'default',
       pageSize: 20,
-      message: i18n(`${i18nKey}.promptMessage`),
+      message: i18n(`${i18nKey}.promptMessageReplaceDefault`),
       choices: config.portals.map(p => ({
         name: `${p.name} (${p.portalId})`,
         value: p.name || p.portalId,

--- a/packages/cli/lib/prompts/accountsPrompt.js
+++ b/packages/cli/lib/prompts/accountsPrompt.js
@@ -1,6 +1,7 @@
 const { updateDefaultAccount } = require('@hubspot/cli-lib/lib/config');
 const { promptUser } = require('./promptUtils');
 const { i18n } = require('@hubspot/cli-lib/lib/lang');
+const { mapAccountChoices } = require('./sandboxesPrompt');
 
 const i18nKey = 'cli.commands.accounts.subcommands.use';
 
@@ -12,10 +13,7 @@ const selectAccountFromConfig = async config => {
       name: 'default',
       pageSize: 20,
       message: i18n(`${i18nKey}.promptMessage`),
-      choices: config.portals.map(p => ({
-        name: `${p.name} (${p.portalId})`,
-        value: p.name || p.portalId,
-      })),
+      choices: mapAccountChoices(config.portals),
       default: config.defaultPortal,
     },
   ]);
@@ -30,11 +28,8 @@ const selectAndSetAsDefaultAccountPrompt = async config => {
       look: false,
       name: 'default',
       pageSize: 20,
-      message: i18n(`${i18nKey}.promptMessageReplaceDefault`),
-      choices: config.portals.map(p => ({
-        name: `${p.name} (${p.portalId})`,
-        value: p.name || p.portalId,
-      })),
+      message: i18n(`${i18nKey}.promptMessage`),
+      choices: mapAccountChoices(config.portals),
       default: config.defaultPortal,
     },
   ]);

--- a/packages/cli/lib/prompts/sandboxesPrompt.js
+++ b/packages/cli/lib/prompts/sandboxesPrompt.js
@@ -3,6 +3,19 @@ const { i18n } = require('@hubspot/cli-lib/lib/lang');
 
 const i18nKey = 'cli.lib.prompts.sandboxesPrompt';
 
+const getSandboxType = type =>
+  type === 'DEVELOPER' ? 'development' : 'standard';
+
+const mapAccountChoices = portals =>
+  portals.map(p => {
+    const isSandbox = p.sandboxAccountType !== null;
+    const sandboxName = `[${getSandboxType(p.sandboxAccountType)} sandbox] `;
+    return {
+      name: `${p.name} ${isSandbox ? sandboxName : ''}(${p.portalId})`,
+      value: p.name || p.portalId,
+    };
+  });
+
 const createSandboxPrompt = () => {
   return promptUser([
     {
@@ -31,7 +44,7 @@ const deleteSandboxPrompt = (config, promptParentAccount = false) => {
       type: 'list',
       look: false,
       pageSize: 20,
-      choices: config.portals.map(p => p.name || p.portalId),
+      choices: mapAccountChoices(config.portals),
       default: config.defaultPortal,
     },
   ]);
@@ -40,4 +53,6 @@ const deleteSandboxPrompt = (config, promptParentAccount = false) => {
 module.exports = {
   createSandboxPrompt,
   deleteSandboxPrompt,
+  getSandboxType,
+  mapAccountChoices,
 };


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->

Currently built off of #751 which will need to be merged first. This PR addresses some issues brought up by design and content:

- Update names to support development / standard sandboxes
  - In `hs accounts ls`
  - In `hs sandbox create` help text copy
- Fixes a bug where after deleting a sandbox, the default account prompt would include the recently deleted account
- Copy adjustments to reduce confusion on sandbox delete

## Screenshots
<!-- Provide images of the before and after functionality -->
<img width="539" alt="Screen Shot 2022-10-06 at 15 28 44" src="https://user-images.githubusercontent.com/16788677/194392260-2d0b2a95-785a-4c24-8a8e-52ddbadbdb00.png">
<img width="731" alt="Screen Shot 2022-10-06 at 13 58 52" src="https://user-images.githubusercontent.com/16788677/194392268-b821221f-a587-4423-9ea9-80e00a8baea5.png">
<img width="857" alt="Screen Shot 2022-10-06 at 15 38 52" src="https://user-images.githubusercontent.com/16788677/194392677-b53df302-eef3-4cea-bbd2-0e079e1fdcdc.png">
<img width="640" alt="Screen Shot 2022-10-06 at 13 43 40" src="https://user-images.githubusercontent.com/16788677/194392272-3925e05f-33bd-407b-8a22-91f7118aa33d.png">


## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->
n/a

## Who to Notify
<!-- /cc those you wish to know about the PR -->

@brandenrodgers @kemmerle 
