### PR TITLE
Add reupload reminder to hs secrets update command

### DIFF
--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -686,6 +686,7 @@ en:
                 describe: "Name of the secret to be updated"
             success:
               update: "The secret \"{{ secretName }}\" was updated in the HubSpot account: {{ accountId }}"
+              updateReupload: "Make sure to `{{#yellow}}upload{{/yellow}}` all components using this secret to access its new value."
       theme:
         describe: "Commands for working with themes, including marketplace validation with the marketplace-validate subcommand."
         subcommands:

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -662,7 +662,7 @@ en:
               name:
                 describe: "Name of the secret"
             success:
-              add: "The secret \"{{ secretName }}\" was added to the HubSpot account: {{ accountId }}"
+              add: "The secret \"{{ secretName }}\" was added to the HubSpot account: {{ accountIdentifier }}"
           delete:
             describe: "Delete a HubSpot secret"
             errors:
@@ -671,12 +671,12 @@ en:
               name:
                 describe: "Name of the secret"
             success:
-              delete: "The secret \"{{ secretName }}\" was deleted from the HubSpot account: {{ accountId }}"
+              delete: "The secret \"{{ secretName }}\" was deleted from the HubSpot account: {{ accountIdentifier }}"
           list:
             describe: "List all HubSpot secrets"
             errors:
               list: "The secrets could not be listed"
-            groupLabel: "Secrets for account {{ accountId }}:"
+            groupLabel: "Secrets for account {{ accountIdentifier }}:"
           update:
             describe: "Update an existing HubSpot secret"
             errors:
@@ -685,8 +685,8 @@ en:
               name:
                 describe: "Name of the secret to be updated"
             success:
-              update: "The secret \"{{ secretName }}\" was updated in the HubSpot account: {{ accountId }}"
-              updateReupload: "Make sure to `{{#yellow}}upload{{/yellow}}` all components using this secret to access its new value."
+              update: "The secret \"{{ secretName }}\" was updated in the HubSpot account: {{ accountIdentifier }}"
+              updateReupload: "Make sure to `{{#yellow}}upload{{/yellow}}` all serverless functions using this secret to access its new value."
       theme:
         describe: "Commands for working with themes, including marketplace validation with the marketplace-validate subcommand."
         subcommands:

--- a/packages/cli/commands/sandbox/delete.js
+++ b/packages/cli/commands/sandbox/delete.js
@@ -126,7 +126,11 @@ exports.handler = async options => {
   } catch (err) {
     debugErrorAndContext(err);
 
-    trackCommandUsage('sandbox-delete', { successful: false }, sandboxAccountId);
+    trackCommandUsage(
+      'sandbox-delete',
+      { successful: false },
+      sandboxAccountId
+    );
 
     if (
       err.error &&

--- a/packages/cli/commands/secrets/addSecret.js
+++ b/packages/cli/commands/secrets/addSecret.js
@@ -14,6 +14,7 @@ const {
   addUseEnvironmentOptions,
   getAccountId,
 } = require('../../lib/commonOpts');
+const { uiAccountDescription } = require('../../lib/ui');
 const { secretValuePrompt } = require('../../lib/prompts/secretPrompt');
 const { i18n } = require('@hubspot/cli-lib/lib/lang');
 
@@ -36,7 +37,7 @@ exports.handler = async options => {
     await addSecret(accountId, secretName, secretValue);
     logger.success(
       i18n(`${i18nKey}.success.add`, {
-        accountId,
+        accountIdentifier: uiAccountDescription(accountId),
         secretName,
       })
     );

--- a/packages/cli/commands/secrets/deleteSecret.js
+++ b/packages/cli/commands/secrets/deleteSecret.js
@@ -7,6 +7,7 @@ const { deleteSecret } = require('@hubspot/cli-lib/api/secrets');
 
 const { loadAndValidateOptions } = require('../../lib/validation');
 const { trackCommandUsage } = require('../../lib/usageTracking');
+const { uiAccountDescription } = require('../../lib/ui');
 
 const {
   addConfigOptions,
@@ -33,7 +34,7 @@ exports.handler = async options => {
     await deleteSecret(accountId, secretName);
     logger.success(
       i18n(`${i18nKey}.success.delete`, {
-        accountId,
+        accountIdentifier: uiAccountDescription(accountId),
         secretName,
       })
     );

--- a/packages/cli/commands/secrets/listSecrets.js
+++ b/packages/cli/commands/secrets/listSecrets.js
@@ -7,6 +7,7 @@ const { fetchSecrets } = require('@hubspot/cli-lib/api/secrets');
 
 const { loadAndValidateOptions } = require('../../lib/validation');
 const { trackCommandUsage } = require('../../lib/usageTracking');
+const { uiAccountDescription } = require('../../lib/ui');
 
 const {
   addConfigOptions,
@@ -30,7 +31,7 @@ exports.handler = async options => {
   try {
     const { results } = await fetchSecrets(accountId);
     const groupLabel = i18n(`${i18nKey}.groupLabel`, {
-      accountId,
+      accountIdentifier: uiAccountDescription(accountId),
     });
     logger.group(groupLabel);
     results.forEach(secret => logger.log(secret));

--- a/packages/cli/commands/secrets/updateSecret.js
+++ b/packages/cli/commands/secrets/updateSecret.js
@@ -7,6 +7,7 @@ const { updateSecret } = require('@hubspot/cli-lib/api/secrets');
 
 const { loadAndValidateOptions } = require('../../lib/validation');
 const { trackCommandUsage } = require('../../lib/usageTracking');
+const { uiAccountDescription } = require('../../lib/ui');
 
 const {
   addConfigOptions,
@@ -36,7 +37,7 @@ exports.handler = async options => {
     await updateSecret(accountId, secretName, secretValue);
     logger.success(
       i18n(`${i18nKey}.success.update`, {
-        accountId,
+        accountIdentifier: uiAccountDescription(accountId),
         secretName,
       })
     );

--- a/packages/cli/commands/secrets/updateSecret.js
+++ b/packages/cli/commands/secrets/updateSecret.js
@@ -40,6 +40,7 @@ exports.handler = async options => {
         secretName,
       })
     );
+    logger.log(i18n(`${i18nKey}.success.updateReupload`));
   } catch (e) {
     logger.error(
       i18n(`${i18nKey}.errors.update`, {


### PR DESCRIPTION
## Description and Context
When updating secrets via the CLI, it is not obvious that you have to rebuild and deploy your projects/themes etc to get them to use the secret's new value. This adds a reminder. Final copy will likely need some work - we need something that applies to both projects and the CMS side of things

## Screenshots
<img width="629" alt="Screen Shot 2022-10-13 at 2 17 21 PM" src="https://user-images.githubusercontent.com/10413161/195675592-db01d7eb-72a9-4953-8cc6-b6004034ca59.png">



## TODO
Finalize copy

## Who to Notify
@brandenrodgers @kemmerle 
