### PR TITLE
Fixing null value TypeError when uploading a non-project directory

### DIFF
--- a/packages/cli/commands/sandbox/delete.js
+++ b/packages/cli/commands/sandbox/delete.js
@@ -126,7 +126,11 @@ exports.handler = async options => {
   } catch (err) {
     debugErrorAndContext(err);
 
-    trackCommandUsage('sandbox-delete', { successful: false }, sandboxAccountId);
+    trackCommandUsage(
+      'sandbox-delete',
+      { successful: false },
+      sandboxAccountId
+    );
 
     if (
       err.error &&

--- a/packages/cli/commands/upload.js
+++ b/packages/cli/commands/upload.js
@@ -78,7 +78,7 @@ exports.handler = async options => {
     logger.error(i18n(`${i18nKey}.errors.destinationRequired`));
     return;
   }
-  // The theme.json file must always be at the root of the project - so we look for that and determine the root path based on it.
+  // Check for theme.json file and determine the root path for the project based on it if it exists
   const themeJsonPath = getThemeJSONPath(absoluteSrcPath);
   const projectRoot = themeJsonPath && path.dirname(themeJsonPath);
   const processFieldsJs =

--- a/packages/cli/commands/upload.js
+++ b/packages/cli/commands/upload.js
@@ -79,12 +79,15 @@ exports.handler = async options => {
     return;
   }
   // The theme.json file must always be at the root of the project - so we look for that and determine the root path based on it.
-  const projectRoot = path.dirname(getThemeJSONPath(absoluteSrcPath));
-  const processFieldsJs = isProcessableFieldsJs(
-    projectRoot,
-    absoluteSrcPath,
-    options.processFieldsJs
-  );
+  const themeJsonPath = getThemeJSONPath(absoluteSrcPath);
+  const projectRoot = themeJsonPath && path.dirname(themeJsonPath);
+  const processFieldsJs =
+    projectRoot &&
+    isProcessableFieldsJs(
+      projectRoot,
+      absoluteSrcPath,
+      options.processFieldsJs
+    );
   let fieldsJs;
   if (processFieldsJs) {
     fieldsJs = await new FieldsJs(


### PR DESCRIPTION
## Description and Context
When uploading a non-project directory, I encounter the error `The "path" argument must be of type string. Received null`. The `null` creates a type error because the theme.json path does not exist because we are not uploading a theme/project. The code assumes that all uploads will have a theme.json path (which is not correct). This PR adds a check for a `themeJsonPath` and only checks the `projectRoot` if it exists. It also prevents `isProcessableFieldsJs` from running unless a `projectRoot` is found.

```
[DEBUG] Error: TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received null
    at new NodeError (node:internal/errors:393:5)
    at validateString (node:internal/validators:161:11)
    at Object.dirname (node:path:1276:5)
    at exports.handler (/Users/mtalley/.config/yarn/global/node_modules/@hubspot/cli/commands/upload.js:82:28)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5) {
  [stack]: 'TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received null\n' +
    '    at new NodeError (node:internal/errors:393:5)\n' +
    '    at validateString (node:internal/validators:161:11)\n' +
    '    at Object.dirname (node:path:1276:5)\n' +
    '    at exports.handler (/Users/mtalley/.config/yarn/global/node_modules/@hubspot/cli/commands/upload.js:82:28)\n' +
    '    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)',
  [message]: 'The "path" argument must be of type string. Received null',
```

## Who to Notify
@j-malt @brandenrodgers @TanyaScales 
