### PR TITLE
Fix bug with subdeploy statuses 

### DIFF
--- a/packages/cli-lib/lib/constants.js
+++ b/packages/cli-lib/lib/constants.js
@@ -203,6 +203,7 @@ const PROJECT_DEPLOY_TEXT = {
     [PROJECT_DEPLOY_STATES.BUILDING]: 'is deploying',
     [PROJECT_DEPLOY_STATES.FAILURE]: 'failed to deploy',
     [PROJECT_DEPLOY_STATES.PENDING]: 'is pending',
+    [PROJECT_DEPLOY_STATES.DEPLOYING]: 'is deploying',
     [PROJECT_DEPLOY_STATES.SUCCESS]: 'deployed successfully',
   },
   SUBTASK_KEY: 'subdeployStatuses',

--- a/packages/cli/commands/sandbox/delete.js
+++ b/packages/cli/commands/sandbox/delete.js
@@ -126,7 +126,11 @@ exports.handler = async options => {
   } catch (err) {
     debugErrorAndContext(err);
 
-    trackCommandUsage('sandbox-delete', { successful: false }, sandboxAccountId);
+    trackCommandUsage(
+      'sandbox-delete',
+      { successful: false },
+      sandboxAccountId
+    );
 
     if (
       err.error &&


### PR DESCRIPTION
## Description and Context

@m-roll discovered a bug when attempting to deploy with the new subdeploys: a status was returning as "undefined" during the deploy. We discussed this via Slack. I did some digging and discovered that we were missing a constant in `PROJECT_DEPLOY_TEXT`.  

To test out this change, you'll need to ungate your portal to `Developers:DependentComponents`. 

## Screenshots

Before the change (with bug):

<img width="503" alt="Screen Shot 2022-10-12 at 12 44 17 PM" src="https://user-images.githubusercontent.com/25392256/195902262-c8c50b5b-e44d-43b7-8bea-6c0f92bc828b.png">

After change:

<img width="754" alt="Screen Shot 2022-10-14 at 1 02 37 PM" src="https://user-images.githubusercontent.com/25392256/195902301-1d535fe8-8eb8-4dd5-9cfc-834974f1364c.png">

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@brandenrodgers @m-roll 