### PR TITLE
Remove build numbers from components

### DIFF
--- a/packages/cli/commands/sandbox/delete.js
+++ b/packages/cli/commands/sandbox/delete.js
@@ -126,7 +126,11 @@ exports.handler = async options => {
   } catch (err) {
     debugErrorAndContext(err);
 
-    trackCommandUsage('sandbox-delete', { successful: false }, sandboxAccountId);
+    trackCommandUsage(
+      'sandbox-delete',
+      { successful: false },
+      sandboxAccountId
+    );
 
     if (
       err.error &&

--- a/packages/cli/lib/projects.js
+++ b/packages/cli/lib/projects.js
@@ -387,7 +387,7 @@ const makePollTaskStatusFunc = ({
       const subTaskName = subTask[statusText.SUBTASK_NAME_KEY];
 
       spinnies.add(subTaskName, {
-        text: `${chalk.bold(subTaskName)} #${displayId} ${
+        text: `${chalk.bold(subTaskName)} ${
           statusText.STATUS_TEXT[statusText.STATES.ENQUEUED]
         }\n`,
         indent: 2,
@@ -410,7 +410,7 @@ const makePollTaskStatusFunc = ({
               return;
             }
 
-            const updatedText = `${chalk.bold(subTaskName)} #${displayId} ${
+            const updatedText = `${chalk.bold(subTaskName)} ${
               statusText.STATUS_TEXT[subTask.status]
             }\n`;
 


### PR DESCRIPTION
## Description and Context
@markhazlewood pointed out the following:

> In the CLI build + deploy status, each component seems to be showing its own build number. This is redundant but also inaccurate and potentially confusing. 

I've removed build numbers from components in this PR. 

<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->

## Screenshots
<!-- Provide images of the before and after functionality -->

Before (with build numbers):

<img width="345" alt="cli-screenshot" src="https://user-images.githubusercontent.com/25392256/195909901-9ea5ddc7-ec2f-4b84-a967-b40b9309bcea.png">

After (without build numbers):

<img width="865" alt="Screen Shot 2022-10-14 at 1 51 41 PM" src="https://user-images.githubusercontent.com/25392256/195910062-915fc2b5-b886-4002-b7f3-421fadbd364c.png">


## Who to Notify
<!-- /cc those you wish to know about the PR -->
@brandenrodgers @camden11 @markhazlewood 
