### PR TITLE
Handle errors from disconnecting CLI from UI

### DIFF
--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -548,6 +548,7 @@ en:
               deleteFolderSucceeded: "Deleted folder \"{{ remotePath }}\""
               previousStagingBuildCancelled: "Killed the previous watch process. Please try running `hs project watch` again"
               processExited: "Stopping watcher..."
+              watchCancelledFromUi: "The watch process has been cancelled from the UI. Any changes made since cancelling have not been uploaded. To resume watching, rerun {{#yellow}}`hs project watch`{{/yellow}}."
             debug:
               attemptNewBuild: "Attempting to create a new build"
               uploading: "Attempting to upload file \"{{ filePath }}\" to \"{{ remotePath }}\""

--- a/packages/cli-lib/lib/constants.js
+++ b/packages/cli-lib/lib/constants.js
@@ -225,6 +225,8 @@ const FEEDBACK_INTERVAL = 10;
 
 const ERROR_TYPES = {
   PROJECT_LOCKED: 'BuildPipelineErrorType.PROJECT_LOCKED',
+  MISSING_PROJECT_PROVISION: 'BuildPipelineErrorType.MISSING_PROJECT_PROVISION',
+  BUILD_NOT_IN_PROGRESS: 'BuildPipelineErrorType.BUILD_NOT_IN_PROGRESS',
 };
 
 module.exports = {

--- a/packages/cli-lib/projectsWatch.js
+++ b/packages/cli-lib/projectsWatch.js
@@ -15,6 +15,7 @@ const {
   queueBuild,
 } = require('./api/dfs');
 const { ERROR_TYPES } = require('./lib/constants');
+const { EXIT_CODES } = require('../cli/lib/enums/exitCodes');
 
 const i18nKey = 'cli.commands.project.subcommands.watch';
 
@@ -58,7 +59,19 @@ const debounceQueueBuild = (accountId, projectName) => {
       await queueBuild(accountId, projectName);
       logger.debug(i18n(`${i18nKey}.debug.buildStarted`, { projectName }));
     } catch (err) {
-      logApiErrorInstance(err, new ApiErrorContext({ accountId, projectName }));
+      if (
+        err.error &&
+        err.error.subCategory === ERROR_TYPES.MISSING_PROJECT_PROVISION
+      ) {
+        logger.log(i18n(`${i18nKey}.logs.watchCancelledFromUi`));
+        process.exit(EXIT_CODES.SUCCESS);
+      } else {
+        logApiErrorInstance(
+          err,
+          new ApiErrorContext({ accountId, projectName })
+        );
+      }
+
       return;
     }
 

--- a/packages/cli/commands/project/watch.js
+++ b/packages/cli/commands/project/watch.js
@@ -5,6 +5,7 @@ const {
   ApiErrorContext,
 } = require('@hubspot/cli-lib/errorHandlers');
 const { logger } = require('@hubspot/cli-lib/logger');
+const { ERROR_TYPES } = require('@hubspot/cli-lib/lib/constants');
 const {
   addAccountOptions,
   addConfigOptions,
@@ -61,11 +62,15 @@ const handleUserInput = (accountId, projectName, currentBuildId) => {
         await cancelStagedBuild(accountId, projectName);
         process.exit(EXIT_CODES.SUCCESS);
       } catch (err) {
-        logApiErrorInstance(
-          err,
-          new ApiErrorContext({ accountId, projectName: projectName })
-        );
-        process.exit(EXIT_CODES.ERROR);
+        if (err.error.subCategory === ERROR_TYPES.BUILD_NOT_IN_PROGRESS) {
+          process.exit(EXIT_CODES.SUCCESS);
+        } else {
+          logApiErrorInstance(
+            err,
+            new ApiErrorContext({ accountId, projectName: projectName })
+          );
+          process.exit(EXIT_CODES.ERROR);
+        }
       }
     } else {
       process.exit(EXIT_CODES.SUCCESS);


### PR DESCRIPTION
## Description and Context
This is the CLI side of this PR https://git.hubteam.com/HubSpot/developer-projects-ui/pull/341
Modifies watch command error handling so CLI processes cancelled via the UI don't give users error messages, since its behavior we support.

This occurs when
* User exits watch from the UI, then modifies a file
* User exits watch from the UI, then kills CLI

## Screenshots
Modifying a file - Before (doesn't exit)
<img width="562" alt="Screen Shot 2022-10-25 at 12 10 51 PM" src="https://user-images.githubusercontent.com/10413161/197826417-77793627-ce6f-42b9-9da4-4a85e97b8c21.png">

Modifying a file - After (exits)
<img width="566" alt="Screen Shot 2022-10-25 at 12 10 11 PM" src="https://user-images.githubusercontent.com/10413161/197826485-e83bf2dd-be1b-4793-b091-767fdbb78e9c.png">



