### PR TITLE
Prevent TypeError when running hs watch

### DIFF
--- a/packages/cli-lib/lib/uploadFolder.js
+++ b/packages/cli-lib/lib/uploadFolder.js
@@ -119,8 +119,8 @@ async function uploadFolder(
   src,
   dest,
   fileMapperOptions,
-  commandOptions,
-  filePaths
+  commandOptions = {},
+  filePaths = []
 ) {
   const { saveOutput, processFieldsJs } = commandOptions;
   const tmpDir = processFieldsJs


### PR DESCRIPTION
## Description and Context
When running `hs watch`, for example `hs watch --initial-upload --account=qa src/static/@hubspot/quote_company local-commerce-default-modules`, there are a couple of TypeErrors.

```
[ERROR] A TypeError has occurred. Cannot destructure property 'saveOutput' of 'commandOptions' as it is undefined.
Watcher is ready and watching /Users/mtalley/HubSpot/prod/hubspot-cli/temp/cms. Any changes detected will be automatically uploaded and overwrite the current version in the developer file system.
```

```
[ERROR] A TypeError has occurred. filePaths is not iterable
```

## Who to Notify
@brandenrodgers @TanyaScales
