### PR TITLE
Add warnings to theme validation

### DIFF
--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -703,6 +703,9 @@ en:
             results:
               required: "Required validation results:"
               recommended: "Recommended validation results:"
+              warnings:
+                file: "File: {{ file }}"
+                lineNumber: "Line number: {{ line }}"
               noErrors: "No errors"
             positionals:
               src:

--- a/packages/cli/commands/theme/marketplace-validate.js
+++ b/packages/cli/commands/theme/marketplace-validate.js
@@ -100,6 +100,21 @@ exports.handler = async options => {
   }
 
   const displayResults = checks => {
+    const displayFileInfo = (file, line) => {
+      file &&
+        logger.log(
+          i18n(`${i18nKey}.results.warnings.file`, {
+            file,
+          })
+        );
+      line &&
+        logger.log(
+          i18n(`${i18nKey}.results.warnings.lineNumber`, {
+            line,
+          })
+        );
+    };
+
     if (checks) {
       const { status, results } = checks;
 
@@ -107,13 +122,32 @@ exports.handler = async options => {
         const failedValidations = results.filter(
           test => test.status === 'FAIL'
         );
+        const warningValidations = results.filter(
+          test => test.status === 'WARN'
+        );
+
         failedValidations.forEach(val => {
           logger.error(`${val.message}`);
+          displayFileInfo(val.file, val.line);
+        });
+
+        warningValidations.forEach(val => {
+          logger.warn(`${val.message}`);
+          displayFileInfo(val.file, val.line);
         });
       }
 
       if (status === 'PASS') {
         logger.success(i18n(`${i18nKey}.results.noErrors`));
+
+        const warningValidations = results.filter(
+          test => test.status === 'WARN'
+        );
+
+        warningValidations.forEach(val => {
+          logger.warn(`${val.message}`);
+          displayFileInfo(val.file, val.line);
+        });
       }
     }
     return null;


### PR DESCRIPTION
## Description and Context
@ssethia2 discovered this morning that we weren't displaying warnings during theme validation or file names/line numbers. This PR adds both. 

## Screenshots

Current validation results:

<img width="938" alt="Screen Shot 2022-11-01 at 12 57 34 PM" src="https://user-images.githubusercontent.com/25392256/199291795-4c8cec55-93f9-4e11-8e67-198776e5ca24.png">

Validation results with changes: 

<img width="1916" alt="Screen Shot 2022-11-01 at 12 52 52 PM" src="https://user-images.githubusercontent.com/25392256/199291876-98dba587-a88b-4531-a9c1-6339fae263a1.png">

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@ssethia2 @brandenrodgers @camden11 
