### PR TITLE
Adding deleteAccount, deleteConfigFile and returning config from methods (VSCode Extension Updates)

### DIFF
--- a/packages/cli-lib/lib/config.js
+++ b/packages/cli-lib/lib/config.js
@@ -581,6 +581,11 @@ const deleteAccount = async accountName => {
 
   setConfig({
     ...config,
+    defaultPortal:
+      config.defaultPortal === accountName ||
+      config.defaultPortal === accountIdToDelete
+        ? null
+        : config.defaultPortal,
     portals: accounts.filter(account => account.portalId !== accountIdToDelete),
   });
 

--- a/packages/cli-lib/lib/config.js
+++ b/packages/cli-lib/lib/config.js
@@ -630,6 +630,10 @@ const deleteEmptyConfigFile = () => {
   );
 };
 
+const deleteConfigFile = () => {
+  return configFileExists() && fs.unlinkSync(_configPath);
+};
+
 const getConfigVariablesFromEnv = () => {
   const env = process.env;
 
@@ -787,6 +791,7 @@ module.exports = {
   deleteAccount,
   createEmptyConfigFile,
   deleteEmptyConfigFile,
+  deleteConfigFile,
   isTrackingAllowed,
   validateConfig,
   writeConfig,

--- a/packages/cli-lib/lib/config.js
+++ b/packages/cli-lib/lib/config.js
@@ -567,6 +567,26 @@ const renameAccount = async (currentName, newName) => {
   return writeConfig();
 };
 
+/**
+ * @throws {Error}
+ */
+const deleteAccount = async accountName => {
+  const config = getAndLoadConfigIfNeeded();
+  let accounts = getConfigAccounts(config);
+  const accountIdToDelete = getAccountId(accountName);
+
+  if (!accountIdToDelete) {
+    throw new Error(`Cannot find account with identifier ${accountName}`);
+  }
+
+  setConfig({
+    ...config,
+    portals: accounts.filter(account => account.portalId !== accountIdToDelete),
+  });
+
+  return writeConfig();
+};
+
 const setDefaultConfigPathIfUnset = () => {
   if (!_configPath) {
     setDefaultConfigPath();
@@ -759,6 +779,7 @@ module.exports = {
   updateHttpTimeout,
   updateAllowUsageTracking,
   renameAccount,
+  deleteAccount,
   createEmptyConfigFile,
   deleteEmptyConfigFile,
   isTrackingAllowed,

--- a/packages/cli-lib/lib/config.js
+++ b/packages/cli-lib/lib/config.js
@@ -249,6 +249,8 @@ const loadConfigFromFile = (path, options = {}) => {
     logger.debug('Initializing an empty config');
     setConfig({ portals: [] });
   }
+
+  return getConfig();
 };
 
 const loadConfig = (
@@ -260,12 +262,13 @@ const loadConfig = (
   if (options.useEnv && loadEnvironmentVariableConfig()) {
     logger.debug('Loaded environment variable config');
     environmentVariableConfigLoaded = true;
-    return;
   } else {
     logger.debug(`Loading config from ${path}`);
     loadConfigFromFile(path, options);
     environmentVariableConfigLoaded = false;
   }
+
+  return getConfig();
 };
 
 const isTrackingAllowed = () => {


### PR DESCRIPTION
## Description and Context
To coordinate with https://github.com/HubSpot/hubspot-cms-vscode/pull/134, there were some changes made to the config section to allow functionality there.
- Added `deleteAccount` method - deletes a single specified account from the `hubspot.config.yml` file
- Added `deleteConfigFile` method - deletes the `hubspot.config.yml` file
- Return `getConfig` from `loadConfig` and `loadConfigFromFile` methods instead of `undefined`.

## Who to Notify
@anthmatic @TanyaScales @jsines @brandenrodgers @kemmerle 
