### PR TITLE
JS Fields Updates

### DIFF
--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -786,6 +786,7 @@ en:
           initialUpload: "To upload the directory run \"hs upload\" beforehand or add the \"--initial-upload\" option when running \"hs watch\"."
           notUploaded: "The \"hs watch\" command no longer uploads the watched directory when started. The directory \"{{ path }}\" was not uploaded."
       process:
+        describe: "Processes a specific javascript fields file"
         positionals:
           src:
             describe: Path to JS Fields file or directory containing javascript fields files.

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -90,6 +90,7 @@ en:
                 promptMessage: "Enter http timeout duration"
                 success: "The http timeout has been set to: {{ timeout }}"
       cms:
+        describe: "Commands for working with the CMS."
         subcommands:
           lighthouseScore:
             describe: "Score a theme using Google lighthouse."
@@ -733,7 +734,7 @@ en:
           invalidPath: "The path \"{{ path }}\" is not a path to a file or folder"
           uploadFailed: "Uploading file \"{{ src }}\" to \"{{ dest }}\" failed"
           someFilesFailed: "One or more files failed to upload to \"{{ dest }}\" in the Design Manager"
-          fieldsJsSyntaxError: "There was an error processing JS file \"{{ path }}\""
+          fieldsJsSyntaxError: "There was an error converting JS file \"{{ path }}\""
           fieldsJsNotReturnArray: "There was an error loading JS file \"{{ path }}\". Expected type \"Array\" but received type \"{{ returned }}\" . Make sure that your function returns an array"
           fieldsJsNotFunction:  "There was an error loading JS file \"{{ path }}\". Expected type \"Function\" but received type \"{{ returned }}\". Make sure that your default export is a function."
         options:
@@ -741,8 +742,8 @@ en:
             describe: "Options to pass to javascript fields files"
           saveOutput:
             describe: "If true, saves all output from javascript fields files as 'fields.output.json'."
-          processFields:
-            describe: "If true, processes any javascript fields files contained in module folder or project root."
+          convertFields:
+            describe: "If true, converts any javascript fields files contained in module folder or project root."
         previewUrl: "To preview this theme, visit: {{ previewUrl }}"
         positionals:
           src:
@@ -770,8 +771,8 @@ en:
             describe: "Log to specified file when a watch task is triggered and after workers have gone idle. Ex. --notify path/to/file"
           remove:
             describe: "Will cause watch to delete files in your HubSpot account that are not found locally."
-          processFields:
-            describe: "If true, processes any javascript fields files contained in module folder or project root."
+          convertFields:
+            describe: "If true, converts any javascript fields files contained in module folder or project root."
           saveOutput:
             describe: "If true, saves all output from javascript fields files as 'fields.output.json'."
           options:
@@ -785,7 +786,7 @@ en:
           disableInitial: "Passing the \"--disable-initial\" option is no longer necessary. Running \"hs watch\" no longer uploads the watched directory by default."
           initialUpload: "To upload the directory run \"hs upload\" beforehand or add the \"--initial-upload\" option when running \"hs watch\"."
           notUploaded: "The \"hs watch\" command no longer uploads the watched directory when started. The directory \"{{ path }}\" was not uploaded."
-      process:
+      convertFields:
         describe: "Converts a specific JavaScript fields file of a module or theme to JSON"
         positionals:
           src:
@@ -956,7 +957,7 @@ en:
             general: "[--general] Tell us about your experience with HubSpot's developer tools"
           bugPrompt: "Create an issue on Github in your browser?"
           generalPrompt: "Open the projects feedback form in your browser?"
-      process:
+      convertFields:
         positionals:
           src:
             describe: Path to JS Fields file or directory containing javascript fields files.

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -786,7 +786,7 @@ en:
           initialUpload: "To upload the directory run \"hs upload\" beforehand or add the \"--initial-upload\" option when running \"hs watch\"."
           notUploaded: "The \"hs watch\" command no longer uploads the watched directory when started. The directory \"{{ path }}\" was not uploaded."
       process:
-        describe: "Processes a specific javascript fields file"
+        describe: "Converts a specific JavaScript fields file of a module or theme to JSON"
         positionals:
           src:
             describe: Path to JS Fields file or directory containing javascript fields files.

--- a/packages/cli/bin/cli.js
+++ b/packages/cli/bin/cli.js
@@ -38,7 +38,6 @@ const moduleCommand = require('../commands/module');
 const configCommand = require('../commands/config');
 const accountsCommand = require('../commands/accounts');
 const sandboxesCommand = require('../commands/sandbox');
-const processCommand = require('../commands/process');
 const cmsCommand = require('../commands/cms');
 const feedbackCommand = require('../commands/feedback');
 const { EXIT_CODES } = require('../lib/enums/exitCodes');
@@ -159,7 +158,6 @@ const argv = yargs
   .command(configCommand)
   .command(accountsCommand)
   .command(sandboxesCommand)
-  .command(processCommand, false)
   .command(feedbackCommand)
   .help()
   .recommendCommands()

--- a/packages/cli/commands/cms.js
+++ b/packages/cli/commands/cms.js
@@ -1,16 +1,21 @@
+const { i18n } = require('@hubspot/cli-lib/lib/lang');
 const { addConfigOptions, addAccountOptions } = require('../lib/commonOpts');
 const lighthouseScore = require('./cms/lighthouseScore');
+const convertFields = require('./cms/convertFields');
 
-// const i18nKey = 'cli.commands.cms';
+const i18nKey = 'cli.commands.cms';
 
 exports.command = 'cms';
-exports.describe = false; // i18n(`${i18nKey}.describe`);
+exports.describe = i18n(`${i18nKey}.describe`);
 
 exports.builder = yargs => {
   addConfigOptions(yargs, true);
   addAccountOptions(yargs, true);
 
-  yargs.command(lighthouseScore).demandCommand(1, '');
+  yargs
+    .command(lighthouseScore)
+    .command(convertFields)
+    .demandCommand(1, '');
 
   return yargs;
 };

--- a/packages/cli/commands/cms/convertFields.js
+++ b/packages/cli/commands/cms/convertFields.js
@@ -11,10 +11,10 @@ const {
   isProcessableFieldsJs,
 } = require('@hubspot/cli-lib/lib/handleFieldsJs');
 
-const { trackProcessFieldsUsage } = require('../lib/usageTracking');
-const i18nKey = 'cli.commands.process';
+const { trackProcessFieldsUsage } = require('../../lib/usageTracking');
+const i18nKey = 'cli.commands.convertFields';
 
-exports.command = 'process';
+exports.command = 'convert-fields';
 exports.describe = i18n(`${i18nKey}.describe`);
 
 const invalidPath = src => {

--- a/packages/cli/commands/cms/lighthouseScore.js
+++ b/packages/cli/commands/cms/lighthouseScore.js
@@ -38,7 +38,7 @@ const DEFAULT_TABLE_HEADER = [
 ];
 
 exports.command = 'lighthouse-score [--theme]';
-exports.describe = i18n(`${i18nKey}.describe`);
+exports.describe = false; // i18n(`${i18nKey}.describe`);
 
 const selectTheme = async accountId => {
   const { theme: selectedTheme } = await promptUser([

--- a/packages/cli/commands/process.js
+++ b/packages/cli/commands/process.js
@@ -15,7 +15,7 @@ const { trackProcessFieldsUsage } = require('../lib/usageTracking');
 const i18nKey = 'cli.commands.process';
 
 exports.command = 'process';
-exports.describe = false;
+exports.describe = i18n(`${i18nKey}.describe`);
 
 const invalidPath = src => {
   logger.error(

--- a/packages/cli/commands/upload.js
+++ b/packages/cli/commands/upload.js
@@ -315,9 +315,8 @@ exports.builder = yargs => {
     type: 'boolean',
     default: false,
   });
-  yargs.option('processFieldsJs', {
-    describe: i18n(`${i18nKey}.options.processFields.describe`),
-    alias: ['processFields'],
+  yargs.option('convertFields', {
+    describe: i18n(`${i18nKey}.options.convertFields.describe`),
     type: 'boolean',
     default: false,
   });

--- a/packages/cli/commands/upload.js
+++ b/packages/cli/commands/upload.js
@@ -314,14 +314,12 @@ exports.builder = yargs => {
     describe: i18n(`${i18nKey}.options.saveOutput.describe`),
     type: 'boolean',
     default: false,
-    hidden: true,
   });
   yargs.option('processFieldsJs', {
     describe: i18n(`${i18nKey}.options.processFields.describe`),
     alias: ['processFields'],
     type: 'boolean',
     default: false,
-    hidden: true,
   });
   return yargs;
 };

--- a/packages/cli/commands/watch.js
+++ b/packages/cli/commands/watch.js
@@ -128,9 +128,8 @@ exports.builder = yargs => {
     type: 'string',
     requiresArg: true,
   });
-  yargs.option('processFieldsJs', {
-    describe: i18n(`${i18nKey}.options.processFields.describe`),
-    alias: ['processFields'],
+  yargs.option('convertFields', {
+    describe: i18n(`${i18nKey}.options.convertFields.describe`),
     type: 'boolean',
     default: false,
   });

--- a/packages/cli/commands/watch.js
+++ b/packages/cli/commands/watch.js
@@ -133,13 +133,11 @@ exports.builder = yargs => {
     alias: ['processFields'],
     type: 'boolean',
     default: false,
-    hidden: true,
   });
   yargs.option('saveOutput', {
     describe: i18n(`${i18nKey}.options.saveOutput.describe`),
     type: 'boolean',
     default: false,
-    hidden: true,
   });
   return yargs;
 };


### PR DESCRIPTION
## Description and Context
Documents field js commands

`hs process` is now `hs cms convert-fields`

and the supported flags for `hs watch` and `hs upload` have changed from `--processFieldsJs` to `--convertFields`

## Screenshots
`hs cms convert-fields`
![image](https://user-images.githubusercontent.com/9009552/202240944-615bf001-0892-42cb-a1d9-1f9184e82f4f.png)

`hs watch/upload --convertFields`
![image](https://user-images.githubusercontent.com/9009552/202241086-00448c3b-e6e0-45e0-ad4b-95f2f5dbc76c.png)


## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
