### PR TITLE
Fix module path regex bug

### DIFF
--- a/packages/cli-lib/modules.js
+++ b/packages/cli-lib/modules.js
@@ -5,9 +5,11 @@ const { walk } = require('./lib/walk');
 const { MODULE_EXTENSION } = require('./lib/constants');
 
 // Matches files named module.html
-const MODULE_HTML_EXTENSION_REGEX = new RegExp(/\.module\/module\.html$/);
+const MODULE_HTML_EXTENSION_REGEX = new RegExp(
+  /\.module(?:\/|\\)module\.html$/
+);
 // Matches files named module.css
-const MODULE_CSS_EXTENSION_REGEX = new RegExp(/\.module\/module\.css$/);
+const MODULE_CSS_EXTENSION_REGEX = new RegExp(/\.module(?:\/|\\)module\.css$/);
 
 const isBool = x => !!x === x;
 


### PR DESCRIPTION
## Description and Context
The VS Code extension  uses these RegEx patterns to detect if a file is in a module but the patterns did not account for Windows based file paths. 

Related issue for VS Code bug: https://github.com/HubSpot/hubspot-cms-vscode/issues/116

## Screenshots
<!-- Provide images of the before and after functionality -->

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
