### PR TITLE
Handle subcomponents in hs project upload

### DIFF
--- a/packages/cli-lib/api/dfs.js
+++ b/packages/cli-lib/api/dfs.js
@@ -133,6 +133,23 @@ async function getBuildStatus(accountId, projectName, buildId) {
 }
 
 /**
+ * Get project build component structure
+ *
+ * @async
+ * @param {number} accountId
+ * @param {string} projectName
+ * @param {number} buildId
+ * @returns {Promise}
+ */
+async function getBuildStructure(accountId, projectName, buildId) {
+  return http.get(accountId, {
+    uri: `dfs/v1/builds/by-project-name/${encodeURIComponent(
+      projectName
+    )}/builds/${buildId}/structure`,
+  });
+}
+
+/**
  * Deploy project
  *
  * @async
@@ -165,6 +182,23 @@ async function getDeployStatus(accountId, projectName, deployId) {
     uri: `${PROJECTS_DEPLOY_API_PATH}/deploy-status/projects/${encodeURIComponent(
       projectName
     )}/deploys/${deployId}`,
+  });
+}
+
+/**
+ * Get project build component structure
+ *
+ * @async
+ * @param {number} accountId
+ * @param {string} projectName
+ * @param {number} buildId
+ * @returns {Promise}
+ */
+async function getDeployStructure(accountId, projectName, deployId) {
+  return http.get(accountId, {
+    uri: `${PROJECTS_DEPLOY_API_PATH}/deploys/by-project-name/${encodeURIComponent(
+      projectName
+    )}/deploys/${deployId}/structure`,
   });
 }
 
@@ -296,7 +330,9 @@ module.exports = {
   fetchProjectSettings,
   fetchDeployComponentsMetadata,
   getBuildStatus,
+  getBuildStructure,
   getDeployStatus,
+  getDeployStructure,
   provisionBuild,
   queueBuild,
   uploadFileToBuild,

--- a/packages/cli-lib/api/dfs.js
+++ b/packages/cli-lib/api/dfs.js
@@ -186,7 +186,7 @@ async function getDeployStatus(accountId, projectName, deployId) {
 }
 
 /**
- * Get project build component structure
+ * Get project deploy component structure
  *
  * @async
  * @param {number} accountId

--- a/packages/cli/lib/projects.js
+++ b/packages/cli/lib/projects.js
@@ -22,7 +22,9 @@ const {
 const {
   createProject,
   getBuildStatus,
+  getBuildStructure,
   getDeployStatus,
+  getDeployStructure,
   fetchProject,
   uploadProject,
 } = require('@hubspot/cli-lib/api/dfs');
@@ -340,6 +342,7 @@ const handleProjectUpload = async (
 
 const makePollTaskStatusFunc = ({
   statusFn,
+  structureFn,
   statusText,
   statusStrings,
   linkToHubSpot,
@@ -372,9 +375,19 @@ const makePollTaskStatusFunc = ({
 
     spinnies.add('overallTaskStatus', { text: 'Beginning' });
 
-    const initialTaskStatus = await statusFn(accountId, taskName, taskId);
+    const [
+      initialTaskStatus,
+      { topLevelComponentsWithChildren: taskStructure },
+    ] = await Promise.all([
+      statusFn(accountId, taskName, taskId),
+      structureFn(accountId, taskName, taskId),
+    ]);
 
-    const numOfComponents = initialTaskStatus[statusText.SUBTASK_KEY].length;
+    const topLevelSubtasks = initialTaskStatus[statusText.SUBTASK_KEY].filter(
+      ({ id }) => !!taskStructure[id]
+    );
+
+    const numOfComponents = topLevelSubtasks.length;
     const componentCountText = `\nFound ${numOfComponents} component${
       numOfComponents !== 1 ? 's' : ''
     } in this project ...\n`;
@@ -383,7 +396,7 @@ const makePollTaskStatusFunc = ({
       text: `${statusStrings.INITIALIZE(taskName)}${componentCountText}`,
     });
 
-    for (let subTask of initialTaskStatus[statusText.SUBTASK_KEY]) {
+    for (let subTask of topLevelSubtasks) {
       const subTaskName = subTask[statusText.SUBTASK_NAME_KEY];
 
       spinnies.add(subTaskName, {
@@ -491,6 +504,7 @@ const pollBuildStatus = makePollTaskStatusFunc({
       getProjectBuildDetailUrl(taskName, taskId, accountId)
     ),
   statusFn: getBuildStatus,
+  structureFn: getBuildStructure,
   statusText: PROJECT_BUILD_TEXT,
   statusStrings: {
     INITIALIZE: name => `Building ${chalk.bold(name)}`,
@@ -510,6 +524,7 @@ const pollDeployStatus = makePollTaskStatusFunc({
       getProjectDeployDetailUrl(taskName, taskId, accountId)
     ),
   statusFn: getDeployStatus,
+  structureFn: getDeployStructure,
   statusText: PROJECT_DEPLOY_TEXT,
   statusStrings: {
     INITIALIZE: name => `Deploying ${chalk.bold(name)}`,


### PR DESCRIPTION
## Description and Context
This updates the `hs project upload` command  to work with the new subcomponent setup. It now uses the `/structure` endpoints to determine which components are top level, and shows only those when building and deploying.
https://git.hubteam.com/HubSpot/hubspot-cli-issues/issues/360

## Screenshots
Before (
<img width="483" alt="Screen Shot 2022-11-17 at 4 51 25 PM" src="https://user-images.githubusercontent.com/10413161/202570874-34d54197-6a03-4f92-98ec-10df4a3eef85.png">
ungated)


After (ungated + matches gated)
<img width="501" alt="Screen Shot 2022-11-17 at 4 58 28 PM" src="https://user-images.githubusercontent.com/10413161/202570895-d2eb81a7-92eb-45f6-89fe-7a2381f77868.png">


## TODO
There are a few minor issues here but they should theoretically be resolved on the backend.

## Who to Notify
@brandenrodgers @kemmerle 
