### PR TITLE
Support annotation lookup by source

### DIFF
--- a/packages/cli-lib/templates.js
+++ b/packages/cli-lib/templates.js
@@ -32,6 +32,10 @@ const buildAnnotationValueGetter = file => {
     logger.error(`Error reading file annotations ${file}`);
     return;
   }
+  return getAnnotationsFromSource(source);
+};
+
+const getAnnotationsFromSource = source => {
   const match = source.match(ANNOTATIONS_REGEX);
   const annotation = match && match[1] ? match[1] : '';
   return annotationKey => getAnnotationValue(annotation, annotationKey);
@@ -46,6 +50,7 @@ const isCodedFile = filePath => TEMPLATE_EXTENSION_REGEX.test(filePath);
 module.exports = {
   ANNOTATION_KEYS,
   getAnnotationValue,
+  getAnnotationsFromSource,
   buildAnnotationValueGetter,
   isCodedFile,
 };


### PR DESCRIPTION
## Description and Context
I didn't notice it before but the ability to get annotations straight from the source was removed in #556 which removes functionality that the VS Code extension relies on.
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->

## Screenshots
<!-- Provide images of the before and after functionality -->

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
