### PR TITLE
Add message to project upload command

### DIFF
--- a/packages/cli-lib/api/dfs.js
+++ b/packages/cli-lib/api/dfs.js
@@ -43,12 +43,18 @@ async function createProject(accountId, name) {
  * @param {string} projectFile
  * @returns {Promise}
  */
-async function uploadProject(accountId, projectName, projectFile) {
+async function uploadProject(
+  accountId,
+  projectName,
+  projectFile,
+  uploadMessage
+) {
   return http.post(accountId, {
     uri: `${PROJECTS_API_PATH}/upload/${encodeURIComponent(projectName)}`,
     timeout: 60000,
     formData: {
       file: fs.createReadStream(projectFile),
+      uploadMessage,
     },
   });
 }

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -524,6 +524,8 @@ en:
             options:
               forceCreate:
                 describe: "Automatically create project if it does not exist"
+              message:
+                describe: "Add a message when you upload your project and create a build"
             positionals:
               path:
                 describe: "Path to a project folder"

--- a/packages/cli/commands/project/upload.js
+++ b/packages/cli/commands/project/upload.js
@@ -30,7 +30,7 @@ exports.describe = i18n(`${i18nKey}.describe`);
 exports.handler = async options => {
   await loadAndValidateOptions(options);
 
-  const { forceCreate, path: projectPath } = options;
+  const { forceCreate, path: projectPath, message } = options;
   const accountId = getAccountId(options);
   const accountConfig = getAccountConfig(accountId);
   const sandboxType = accountConfig && accountConfig.sandboxAccountType;
@@ -111,7 +111,13 @@ exports.handler = async options => {
     process.exit(exitCode);
   };
 
-  await handleProjectUpload(accountId, projectConfig, projectDir, startPolling);
+  await handleProjectUpload(
+    accountId,
+    projectConfig,
+    projectDir,
+    startPolling,
+    message
+  );
 };
 
 exports.builder = yargs => {
@@ -124,6 +130,13 @@ exports.builder = yargs => {
     describe: i18n(`${i18nKey}.options.forceCreate.describe`),
     type: 'boolean',
     default: false,
+  });
+
+  yargs.option('message', {
+    alias: 'm',
+    describe: i18n(`${i18nKey}.options.message.describe`),
+    type: 'string',
+    default: '',
   });
 
   yargs.example([

--- a/packages/cli/lib/projects.js
+++ b/packages/cli/lib/projects.js
@@ -233,7 +233,12 @@ const getProjectDeployDetailUrl = (projectName, deployId, accountId) => {
     accountId
   )}/activity/deploy/${deployId}`;
 };
-const uploadProjectFiles = async (accountId, projectName, filePath) => {
+const uploadProjectFiles = async (
+  accountId,
+  projectName,
+  filePath,
+  uploadMessage
+) => {
   const i18nKey = 'cli.commands.project.subcommands.upload';
   const spinnies = new Spinnies({
     succeedColor: 'white',
@@ -250,7 +255,12 @@ const uploadProjectFiles = async (accountId, projectName, filePath) => {
   let buildId;
 
   try {
-    const upload = await uploadProject(accountId, projectName, filePath);
+    const upload = await uploadProject(
+      accountId,
+      projectName,
+      filePath,
+      uploadMessage
+    );
 
     buildId = upload.buildId;
 
@@ -295,7 +305,8 @@ const handleProjectUpload = async (
   accountId,
   projectConfig,
   projectDir,
-  callbackFunc
+  callbackFunc,
+  uploadMessage
 ) => {
   const i18nKey = 'cli.commands.project.subcommands.upload';
   const tempFile = tmp.fileSync({ postfix: '.zip' });
@@ -319,7 +330,8 @@ const handleProjectUpload = async (
     const { buildId } = await uploadProjectFiles(
       accountId,
       projectConfig.name,
-      tempFile.name
+      tempFile.name,
+      uploadMessage
     );
 
     if (callbackFunc) {


### PR DESCRIPTION
## Description and Context
We are adding a new optional message flag to the `hs project upload` command, so that developers can add a message to each project build. 

## Screenshots
<!-- Provide images of the before and after functionality -->

The new command in action (You can also use the alias `m`): 

<img width="1432" alt="Screen Shot 2022-11-18 at 4 08 46 PM" src="https://user-images.githubusercontent.com/25392256/202802792-3b829c53-94c5-4e71-8429-206fd9bd203a.png">

Help menu:

<img width="1639" alt="Screen Shot 2022-11-18 at 4 10 19 PM" src="https://user-images.githubusercontent.com/25392256/202803036-cbefb496-4c76-4eb1-99a6-d7f01addde5a.png">

## Test

Pull down this branch to test locally. Run `yarn hs project upload <path-to-project> --message=<uploadMessage>`.

We haven't implemented support in the projects ui frontend yet, but you can test it out by navigating to the project activity table and opening the network tab to inspect the return for the `/activity` endpoint. Examine the build number associated with your upload message, and you should see an upload message attached to it. 

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@brandenrodgers @camden11 
