### PR TITLE
Update empty upload messaging

### DIFF
--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -521,6 +521,8 @@ en:
               feedbackHeader: "We'd love to hear your feedback!"
               feedbackMessage: "How are you liking the new projects and developer tools? \n > Run `{{#yellow}}hs feedback{{/yellow}}` to let us know what you think!\n"
               projectLockedError: "\nYour project may be locked by an active `{{#yellow}}hs project watch{{/yellow}}`. Try stopping the `{{#yellow}}watch{{/yellow}}` process before uploading.\nIf that doesn't work, you may need to start and stop a new `{{#yellow}}watch{{/yellow}}` process to unlock the project."
+              emptySource: "Source directory \"{{ srcDir }}\" is empty. Add files to your project and rerun `{{#yellow}}hs project upload{{/yellow}}` to upload them to HubSpot."
+
             options:
               forceCreate:
                 describe: "Automatically create project if it does not exist"
@@ -601,6 +603,11 @@ en:
                 describe: "Open Github issues in your browser to report a bug."
               general:
                 describe: "Open the projects feedback form in your browser."
+        lib:
+          ensureProjectExists:
+            createPrompt: "The project {{ projectName }} does not exist in {{ accountIdentifier }}. Would you like to create it?"
+            createSuccess: "New project {{#bold}}{{ projectName }}{{/bold}} successfully created in {{#bold}}{{ accountIdentifier }}{{/bold}}."
+            notFound: "Your project {{#bold}}{{ projectName }}{{/bold}} could not be found in {{#bold}}{{ accountIdentifier }}{{/bold}}."
 
       remove:
         describe: "Delete a file or folder from HubSpot."


### PR DESCRIPTION
## Description and Context
See https://git.hubteam.com/HubSpot/hubspot-cli-issues/issues/324
This improves messaging when users attempt to upload an empty project.

## Screenshots
Before
<img width="870" alt="Screen Shot 2022-11-29 at 3 29 54 PM" src="https://user-images.githubusercontent.com/10413161/204641188-55f07dee-1133-454a-8b0d-1e274a2fd715.png">

After
<img width="599" alt="Screen Shot 2022-11-28 at 4 06 40 PM" src="https://user-images.githubusercontent.com/10413161/204641205-2254fa7e-e90f-4a83-a45c-1b5314d08b4d.png">


## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
