### PR TITLE
Remove copy from project create command

### DIFF
--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -819,9 +819,6 @@ en:
             authCommand:
               command: "hs auth"
               message: "Run {{ command }} to connect the CLI to additional HubSpot accounts"
-            createCommand:
-              command: "hs create"
-              message: "Add new components to your project with {{ command }}"
             feedbackCommand:
               command: "hs feedback"
               message: "Run {{ command }} to report a bug or leave feedback"

--- a/packages/cli/commands/project/create.js
+++ b/packages/cli/commands/project/create.js
@@ -41,7 +41,6 @@ exports.handler = async options => {
   logger.log('');
   logger.log(chalk.bold(i18n(`${i18nKey}.logs.welcomeMessage`)));
   uiFeatureHighlight([
-    'createCommand',
     'projectUploadCommand',
     'projectDeployCommand',
     'projectHelpCommand',


### PR DESCRIPTION
## Description and Context
Based on @markhazlewood's suggestion, we're going to remove the first line of copy (`Add new components to your project with hs create`) in the text that appears after the customer runs the `hs project create` command. 

## Screenshots
<!-- Provide images of the before and after functionality -->

The new feature highlights after the `hs project create` command:

<img width="1303" alt="Screen Shot 2022-12-08 at 11 12 55 AM" src="https://user-images.githubusercontent.com/25392256/206500634-db0529e6-1ef9-456a-8593-4ef42ed689dc.png">

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@brandenrodgers @camden11 @markhazlewood 
