### PR TITLE
Fix issue with convertFields on Win machines with multiple hard drives

### DIFF
--- a/packages/cli-lib/lib/watch.js
+++ b/packages/cli-lib/lib/watch.js
@@ -16,7 +16,11 @@ const { shouldIgnoreFile, ignoreFile } = require('../ignoreRules');
 const { getFileMapperQueryValues } = require('../fileMapper');
 const { upload, deleteFile } = require('../api/fileMapper');
 const escapeRegExp = require('./escapeRegExp');
-const { convertToUnixPath, isAllowedExtension } = require('../path');
+const {
+  convertToUnixPath,
+  convertToImportPath,
+  isAllowedExtension,
+} = require('../path');
 const { triggerNotify } = require('./notify');
 const { getThemePreviewUrl } = require('./files');
 const spawn = require('./spawnFunction');
@@ -66,7 +70,7 @@ async function uploadFile(accountId, file, dest, options) {
     // So this spawns a new node process that calls `hs upload` with the same options as watch was called with.
     // More context: https://github.com/HubSpot/hubspot-cli/pull/712#discussion_r945056954
     const uploadCommandPath = require.resolve('@hubspot/cli/commands/upload');
-    const fieldsJsProcessCode = `require('${convertToUnixPath(
+    const fieldsJsProcessCode = `require('${convertToImportPath(
       uploadCommandPath
     )}').handler(${parsedOptions})`;
     spawn(fieldsJsProcessCode);

--- a/packages/cli-lib/path.js
+++ b/packages/cli-lib/path.js
@@ -11,6 +11,18 @@ const convertToWindowsPath = _path => {
   return path.normalize(_path).replace(rgx, path.win32.sep);
 };
 
+/**
+ * Converts a Win32 path to Posix, retaining the drive letter (ex. 'c:')
+ *
+ * @param {string} _path
+ */
+const convertToImportPath = _path => {
+  if (path.sep === path.win32.sep) {
+    return _path.split(path.win32.sep).join(path.posix.sep);
+  }
+  return _path;
+};
+
 const convertToLocalFileSystemPath = _path => {
   switch (path.sep) {
     case path.posix.sep:
@@ -101,6 +113,7 @@ const isRelativePath = _path => !path.isAbsolute(_path);
 module.exports = {
   convertToUnixPath,
   convertToWindowsPath,
+  convertToImportPath,
   convertToLocalFileSystemPath,
   getAllowedExtensions,
   getAbsoluteFilePath,


### PR DESCRIPTION
## Description and Context
Moves to manually convert Win > Unix paths because `unixify` always drops the drive letter and we need it in order to resolve modules correctly, specifically on Windows computers with multiple HDDs.
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->

## Screenshots
<!-- Provide images of the before and after functionality -->

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
