### PR TITLE
Update polling timeout to 2.5s

### DIFF
--- a/packages/cli-lib/lib/constants.js
+++ b/packages/cli-lib/lib/constants.js
@@ -99,7 +99,7 @@ const MARKETPLACE_FOLDER = '@marketplace';
 
 const FOLDER_DOT_EXTENSIONS = ['functions', 'module'];
 
-const POLLING_DELAY = 5000;
+const POLLING_DELAY = 2500;
 
 const GITHUB_RELEASE_TYPES = {
   RELEASE: 'release',


### PR DESCRIPTION
## Description and Context
We get some performance gains, at least from the user's perspective, by reducing this polling amount. I still think we should consider opening up some websockets on the backend so we can give live status updates. 

I chose 2.5 since its just half of what existed.

## Screenshots
<!-- Provide images of the before and after functionality -->

## TODO
- [ ] Should this constant be configurable by the config yml or environment variables, instead of hard-coded?

## Who to Notify
cc @brandenrodgers @kemmerle @camden11 
