### PR TITLE
Add timeout to sandbox create

### DIFF
--- a/packages/cli-lib/api/sandbox-hubs.js
+++ b/packages/cli-lib/api/sandbox-hubs.js
@@ -4,6 +4,7 @@ const SANDBOX_API_PATH = 'sandbox-hubs/v1';
 async function createSandbox(accountId, name) {
   return http.post(accountId, {
     body: { name },
+    timeout: 60000,
     uri: SANDBOX_API_PATH,
   });
 }


### PR DESCRIPTION
## Description and Context

Sandboxes has done some digging and we think adding a longer timeout may address an intermittent issue we've been having with ESOCKETTIMEOUT errors when creating a sandbox through the CLI. 

More information can be found here: https://git.hubteam.com/HubSpot/sandboxes-ui/issues/1573#issuecomment-3460607

## TODO
n/a

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@brandenrodgers @kemmerle 
