### PR TITLE
Sandboxes create - error message update

### DIFF
--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -636,6 +636,7 @@ en:
             success:
               configFileUpdated: "{{ configFilename }} updated with {{ authMethod }} for account {{ account }}."
             failure:
+              creatingWithinSandbox: "Development sandboxes must be created from a production account. You’re using a {{ sandboxType }} sandbox right now. Run `hs auth` to connect a production account or `hs accounts use` to switch to your production account, then try again."
               scopes:
                 message: "The personal access key you provided doesn't include sandbox permissions."
                 instructions: "To update CLI permissions for \"{{ accountName }}\":

--- a/packages/cli/commands/sandbox/create.js
+++ b/packages/cli/commands/sandbox/create.js
@@ -10,7 +10,10 @@ const { logger } = require('@hubspot/cli-lib/logger');
 const Spinnies = require('spinnies');
 const { createSandbox } = require('@hubspot/cli-lib/sandboxes');
 const { loadAndValidateOptions } = require('../../lib/validation');
-const { createSandboxPrompt } = require('../../lib/prompts/sandboxesPrompt');
+const {
+  createSandboxPrompt,
+  getSandboxType,
+} = require('../../lib/prompts/sandboxesPrompt');
 const { i18n } = require('@hubspot/cli-lib/lib/lang');
 const { logErrorInstance } = require('@hubspot/cli-lib/errorHandlers');
 const {
@@ -121,6 +124,18 @@ exports.handler = async options => {
   });
 
   trackCommandUsage('sandbox-create', null, accountId);
+
+  if (accountConfig.sandboxAccountType !== null) {
+    trackCommandUsage('sandbox-create', { successful: false }, accountId);
+
+    logger.error(
+      i18n(`${i18nKey}.failure.creatingWithinSandbox`, {
+        sandboxType: getSandboxType(accountConfig.sandboxAccountType),
+      })
+    );
+
+    process.exit(EXIT_CODES.ERROR);
+  }
 
   let namePrompt;
 

--- a/packages/cli/commands/sandbox/create.js
+++ b/packages/cli/commands/sandbox/create.js
@@ -125,7 +125,10 @@ exports.handler = async options => {
 
   trackCommandUsage('sandbox-create', null, accountId);
 
-  if (accountConfig.sandboxAccountType !== null) {
+  if (
+    accountConfig.sandboxAccountType &&
+    accountConfig.sandboxAccountType !== null
+  ) {
     trackCommandUsage('sandbox-create', { successful: false }, accountId);
 
     logger.error(


### PR DESCRIPTION
## Description and Context

Sandboxes identified an inconsistent error message when attempting to create a sandbox when the default account was set to a sandbox. This PR addresses that and adds a new check to make sure a user can't attempt a create in that scenario. 

## Screenshots
<!-- Provide images of the before and after functionality -->

Before:
<img width="629" alt="Screen Shot 2023-01-11 at 13 31 49" src="https://user-images.githubusercontent.com/16788677/211905329-9172be6d-8e6b-421e-9857-a022c7ecb78f.png">

After:
<img width="632" alt="Screen Shot 2023-01-11 at 13 31 17" src="https://user-images.githubusercontent.com/16788677/211905430-d640578f-ec1e-4cea-b773-895bed066d83.png">


## TODO
n/a

## Who to Notify

@kemmerle @brandenrodgers 
