### PR TITLE
Sandbox delete - portal list updates

### DIFF
--- a/packages/cli/lib/prompts/accountsPrompt.js
+++ b/packages/cli/lib/prompts/accountsPrompt.js
@@ -1,7 +1,19 @@
 const { updateDefaultAccount } = require('@hubspot/cli-lib/lib/config');
 const { promptUser } = require('./promptUtils');
 const { i18n } = require('@hubspot/cli-lib/lib/lang');
-const { mapAccountChoices } = require('./sandboxesPrompt');
+
+const getSandboxType = type =>
+  type === 'DEVELOPER' ? 'development' : 'standard';
+
+const mapAccountChoices = portals =>
+  portals.map(p => {
+    const isSandbox = p.sandboxAccountType !== null;
+    const sandboxName = `[${getSandboxType(p.sandboxAccountType)} sandbox] `;
+    return {
+      name: `${p.name} ${isSandbox ? sandboxName : ''}(${p.portalId})`,
+      value: p.name || p.portalId,
+    };
+  });
 
 const i18nKey = 'cli.commands.accounts.subcommands.use';
 

--- a/packages/cli/lib/prompts/accountsPrompt.js
+++ b/packages/cli/lib/prompts/accountsPrompt.js
@@ -7,7 +7,7 @@ const getSandboxType = type =>
 
 const mapAccountChoices = portals =>
   portals.map(p => {
-    const isSandbox = p.sandboxAccountType !== null;
+    const isSandbox = p.sandboxAccountType && p.sandboxAccountType !== null;
     const sandboxName = `[${getSandboxType(p.sandboxAccountType)} sandbox] `;
     return {
       name: `${p.name} ${isSandbox ? sandboxName : ''}(${p.portalId})`,

--- a/packages/cli/lib/prompts/sandboxesPrompt.js
+++ b/packages/cli/lib/prompts/sandboxesPrompt.js
@@ -6,15 +6,17 @@ const i18nKey = 'cli.lib.prompts.sandboxesPrompt';
 const getSandboxType = type =>
   type === 'DEVELOPER' ? 'development' : 'standard';
 
-const mapAccountChoices = portals =>
-  portals.map(p => {
-    const isSandbox = p.sandboxAccountType !== null;
-    const sandboxName = `[${getSandboxType(p.sandboxAccountType)} sandbox] `;
-    return {
-      name: `${p.name} ${isSandbox ? sandboxName : ''}(${p.portalId})`,
-      value: p.name || p.portalId,
-    };
-  });
+const mapSandboxAccountChoices = portals =>
+  portals
+    .filter(p => p.sandboxAccountType !== null)
+    .map(p => {
+      const isSandbox = p.sandboxAccountType !== null;
+      const sandboxName = `[${getSandboxType(p.sandboxAccountType)} sandbox] `;
+      return {
+        name: `${p.name} ${isSandbox ? sandboxName : ''}(${p.portalId})`,
+        value: p.name || p.portalId,
+      };
+    });
 
 const createSandboxPrompt = () => {
   return promptUser([
@@ -44,7 +46,7 @@ const deleteSandboxPrompt = (config, promptParentAccount = false) => {
       type: 'list',
       look: false,
       pageSize: 20,
-      choices: mapAccountChoices(config.portals),
+      choices: mapSandboxAccountChoices(config.portals),
       default: config.defaultPortal,
     },
   ]);
@@ -54,5 +56,4 @@ module.exports = {
   createSandboxPrompt,
   deleteSandboxPrompt,
   getSandboxType,
-  mapAccountChoices,
 };

--- a/packages/cli/lib/prompts/sandboxesPrompt.js
+++ b/packages/cli/lib/prompts/sandboxesPrompt.js
@@ -8,12 +8,11 @@ const getSandboxType = type =>
 
 const mapSandboxAccountChoices = portals =>
   portals
-    .filter(p => p.sandboxAccountType !== null)
+    .filter(p => p.sandboxAccountType && p.sandboxAccountType !== null)
     .map(p => {
-      const isSandbox = p.sandboxAccountType !== null;
       const sandboxName = `[${getSandboxType(p.sandboxAccountType)} sandbox] `;
       return {
-        name: `${p.name} ${isSandbox ? sandboxName : ''}(${p.portalId})`,
+        name: `${p.name} ${sandboxName}(${p.portalId})`,
         value: p.name || p.portalId,
       };
     });


### PR DESCRIPTION
## Description and Context

When listing portals for the `hs sandbox delete` command, users were getting confused when presented options that were not sandbox portals. While the API would not allow any other portal type to be deleted (like prod for instance), the messaging was not clear and made it seem like customer portals could be deleted. 

The list of portals shown in the picker is now limited to sandboxes only. The default account picker remains the same. 

## Screenshots
<!-- Provide images of the before and after functionality -->

Before:
<img width="630" alt="Screen Shot 2023-01-11 at 16 21 16" src="https://user-images.githubusercontent.com/16788677/211920258-4db1711c-ba09-4851-88e5-c261f96c6cb6.png">


After:
<img width="628" alt="Screen Shot 2023-01-11 at 16 10 37" src="https://user-images.githubusercontent.com/16788677/211920181-394d5240-9bdb-4c16-92cf-0bfb8a15e50a.png">


## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@kemmerle @brandenrodgers 
