### PR TITLE
Fix issue where files do not upload running `hs watch --initial-upload`

### DIFF
--- a/packages/cli-lib/lib/watch.js
+++ b/packages/cli-lib/lib/watch.js
@@ -150,7 +150,7 @@ function watch(
 
   if (!disableInitial) {
     // Use uploadFolder so that failures of initial upload are retried
-    uploadFolder(accountId, src, dest, { mode }, {}, filePaths)
+    uploadFolder(accountId, src, dest, { mode }, commandOptions, filePaths)
       .then(() => {
         logger.success(
           `Completed uploading files in ${src} to ${dest} in ${accountId}`

--- a/packages/cli-lib/lib/watch.js
+++ b/packages/cli-lib/lib/watch.js
@@ -131,7 +131,7 @@ function watch(
   accountId,
   src,
   dest,
-  { mode, remove, disableInitial, notify, commandOptions }
+  { mode, remove, disableInitial, notify, commandOptions, filePaths }
 ) {
   const regex = new RegExp(`^${escapeRegExp(src)}`);
   if (notify) {
@@ -150,7 +150,7 @@ function watch(
 
   if (!disableInitial) {
     // Use uploadFolder so that failures of initial upload are retried
-    uploadFolder(accountId, src, dest, { mode })
+    uploadFolder(accountId, src, dest, { mode }, {}, filePaths)
       .then(() => {
         logger.success(
           `Completed uploading files in ${src} to ${dest} in ${accountId}`

--- a/packages/cli/commands/upload.js
+++ b/packages/cli/commands/upload.js
@@ -1,7 +1,5 @@
 const fs = require('fs');
 const path = require('path');
-const { walk } = require('@hubspot/cli-lib/lib/walk');
-const { createIgnoreFilter } = require('@hubspot/cli-lib/ignoreRules');
 const { uploadFolder, hasUploadErrors } = require('@hubspot/cli-lib');
 const { getFileMapperQueryValues } = require('@hubspot/cli-lib/fileMapper');
 const { upload } = require('@hubspot/cli-lib/api/fileMapper');
@@ -28,9 +26,9 @@ const {
   getMode,
 } = require('../lib/commonOpts');
 const { uploadPrompt } = require('../lib/prompts/uploadPrompt');
-const { fieldsJsPrompt } = require('../lib/prompts/cmsFieldPrompt');
 const { validateMode, loadAndValidateOptions } = require('../lib/validation');
 const { trackCommandUsage } = require('../lib/usageTracking');
+const { getUploadableFileList } = require('../lib/upload');
 const {
   getThemePreviewUrl,
   getThemeJSONPath,
@@ -246,46 +244,6 @@ exports.handler = async options => {
         process.exit(EXIT_CODES.WARNING);
       });
   }
-};
-
-/*
- * Walks the src folder for files, filters them based on ignore filter.
- * If convertFields is true then will check for any JS fields conflicts (i.e., JS fields file and fields.json file) and prompt to resolve
- */
-const getUploadableFileList = async (src, convertFields) => {
-  const filePaths = await walk(src);
-  const allowedFiles = filePaths
-    .filter(file => {
-      if (!isAllowedExtension(file)) {
-        return false;
-      }
-      return true;
-    })
-    .filter(createIgnoreFilter());
-  if (!convertFields) {
-    return allowedFiles;
-  }
-
-  let uploadableFiles = [];
-  let skipFiles = [];
-  for (const filePath of allowedFiles) {
-    const fileName = path.basename(filePath);
-    if (skipFiles.includes(filePath)) continue;
-    const isConvertable = isConvertableFieldJs(src, filePath, convertFields);
-    if (isConvertable || fileName == 'fields.json') {
-      // This prompt checks if there are multiple field files in the folder and gets user to choose.
-      const [choice, updatedSkipFiles] = await fieldsJsPrompt(
-        filePath,
-        src,
-        skipFiles
-      );
-      skipFiles = updatedSkipFiles;
-      // If they chose something other than the current file, move on.
-      if (choice !== filePath) continue;
-    }
-    uploadableFiles.push(filePath);
-  }
-  return uploadableFiles;
 };
 
 exports.builder = yargs => {

--- a/packages/cli/commands/watch.js
+++ b/packages/cli/commands/watch.js
@@ -71,16 +71,19 @@ exports.handler = async options => {
 
   if (disableInitial) {
     logger.info(i18n(`${i18nKey}.warnings.disableInitial`));
-    filesToUpload = await getUploadableFileList(
-      absoluteSrcPath,
-      options.convertFields
-    );
   } else {
     logger.info(i18n(`${i18nKey}.warnings.notUploaded`, { path: src }));
 
     if (!initialUpload) {
       logger.info(i18n(`${i18nKey}.warnings.initialUpload`));
     }
+  }
+
+  if (initialUpload) {
+    filesToUpload = await getUploadableFileList(
+      absoluteSrcPath,
+      options.convertFields
+    );
   }
 
   trackCommandUsage('watch', { mode }, accountId);
@@ -125,7 +128,6 @@ exports.builder = yargs => {
     type: 'boolean',
   });
   yargs.option('disable-initial', {
-    alias: 'd',
     describe: i18n(`${i18nKey}.options.disableInitial.describe`),
     type: 'boolean',
     hidden: true,

--- a/packages/cli/commands/watch.js
+++ b/packages/cli/commands/watch.js
@@ -17,6 +17,7 @@ const { uploadPrompt } = require('../lib/prompts/uploadPrompt');
 const { validateMode, loadAndValidateOptions } = require('../lib/validation');
 const { trackCommandUsage } = require('../lib/usageTracking');
 const { i18n } = require('@hubspot/cli-lib/lib/lang');
+const { getUploadableFileList } = require('../lib/upload');
 
 const i18nKey = 'cli.commands.watch';
 const { EXIT_CODES } = require('../lib/enums/exitCodes');
@@ -66,8 +67,14 @@ exports.handler = async options => {
     return;
   }
 
+  let filesToUpload = [];
+
   if (disableInitial) {
     logger.info(i18n(`${i18nKey}.warnings.disableInitial`));
+    filesToUpload = await getUploadableFileList(
+      absoluteSrcPath,
+      options.convertFields
+    );
   } else {
     logger.info(i18n(`${i18nKey}.warnings.notUploaded`, { path: src }));
 
@@ -83,6 +90,7 @@ exports.handler = async options => {
     disableInitial: initialUpload ? false : true,
     notify,
     commandOptions: options,
+    filePaths: filesToUpload,
   });
 };
 

--- a/packages/cli/lib/upload.js
+++ b/packages/cli/lib/upload.js
@@ -1,0 +1,50 @@
+const path = require('path');
+const { walk } = require('@hubspot/cli-lib/lib/walk');
+const { createIgnoreFilter } = require('@hubspot/cli-lib/ignoreRules');
+const { fieldsJsPrompt } = require('../lib/prompts/cmsFieldPrompt');
+const { isAllowedExtension } = require('@hubspot/cli-lib/path');
+const { isConvertableFieldJs } = require('@hubspot/cli-lib/lib/handleFieldsJs');
+
+/*
+ * Walks the src folder for files, filters them based on ignore filter.
+ * If convertFields is true then will check for any JS fields conflicts (i.e., JS fields file and fields.json file) and prompt to resolve
+ */
+const getUploadableFileList = async (src, convertFields) => {
+  const filePaths = await walk(src);
+  const allowedFiles = filePaths
+    .filter(file => {
+      if (!isAllowedExtension(file)) {
+        return false;
+      }
+      return true;
+    })
+    .filter(createIgnoreFilter());
+  if (!convertFields) {
+    return allowedFiles;
+  }
+
+  let uploadableFiles = [];
+  let skipFiles = [];
+  for (const filePath of allowedFiles) {
+    const fileName = path.basename(filePath);
+    if (skipFiles.includes(filePath)) continue;
+    const isConvertable = isConvertableFieldJs(src, filePath, convertFields);
+    if (isConvertable || fileName == 'fields.json') {
+      // This prompt checks if there are multiple field files in the folder and gets user to choose.
+      const [choice, updatedSkipFiles] = await fieldsJsPrompt(
+        filePath,
+        src,
+        skipFiles
+      );
+      skipFiles = updatedSkipFiles;
+      // If they chose something other than the current file, move on.
+      if (choice !== filePath) continue;
+    }
+    uploadableFiles.push(filePath);
+  }
+  return uploadableFiles;
+};
+
+module.exports = {
+  getUploadableFileList,
+};


### PR DESCRIPTION
## Description and Context
Since 4.1.0, passing the `--initial-upload` flag to the `hs watch` command does not actually upload any files because there was a step added to `uploadFolder` that was not accounted for in the watch command.

It also looks like the logging for `disable-initial` has been broken possibly since we moved from commander > yargs due to a collision where `debug` and `disable-initial` both share the same flag alias, `d`.



## Screenshots
![image](https://user-images.githubusercontent.com/9009552/212133060-47f1af6b-b9ad-4afb-8f86-342261addaf5.png)
<!-- Provide images of the before and after functionality -->

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
