### PR TITLE
Error saying that environment variable config could not be loaded only shows when `useEnv` is specified

### DIFF
--- a/packages/cli-lib/lib/config.js
+++ b/packages/cli-lib/lib/config.js
@@ -711,11 +711,8 @@ const loadConfigFromEnvironment = () => {
     refreshToken,
     env,
   } = getConfigVariablesFromEnv();
-  const unableToLoadEnvConfigError =
-    'Unable to load config from environment variables.';
 
   if (!portalId) {
-    logger.error(unableToLoadEnvConfigError);
     return;
   }
 
@@ -733,7 +730,6 @@ const loadConfigFromEnvironment = () => {
   } else if (apiKey) {
     return generateApiKeyConfig(portalId, apiKey, env);
   } else {
-    logger.error(unableToLoadEnvConfigError);
     return;
   }
 };


### PR DESCRIPTION
## Description and Context
When running commands in the CLI and specifying an account using `--account=<accountName>`, the config validation code path checks for an environment variable based config in addition to specifying the account, which would be invalid. This check always displays an error stating `Unable to load config from environment variables.`. This message can be confusing because it seems like the command did not work, even though it did.

This PR fixes the error from showing up when this validation check is made by passing in options when calling `loadConfigFromEnvironment` and checking for `useEnv` to be `true` in order to show the error message.

## Screenshots
Before: When running `hs upload ./tmp/MyFunctions.functions MyFunctions.functions --account=<accountName>`
<img width="1272" alt="image" src="https://user-images.githubusercontent.com/6472448/215566452-b9bddffe-1c6f-4968-961d-621c0786cc95.png">

After: When running `hs upload ./tmp/MyFunctions.functions MyFunctions.functions --account=<accountName>`
<img width="1281" alt="image" src="https://user-images.githubusercontent.com/6472448/215566546-5c02d917-ffef-4532-85c9-c9382f66a692.png">
