### PR TITLE
Error saying that environment variable config could not be loaded only shows when useEnv is specified

### DIFF
--- a/packages/cli-lib/lib/config.js
+++ b/packages/cli-lib/lib/config.js
@@ -259,7 +259,7 @@ const loadConfig = (
     useEnv: false,
   }
 ) => {
-  if (options.useEnv && loadEnvironmentVariableConfig()) {
+  if (options.useEnv && loadEnvironmentVariableConfig(options)) {
     logger.debug('Loaded environment variable config');
     environmentVariableConfigLoaded = true;
   } else {
@@ -701,7 +701,7 @@ const generateApiKeyConfig = (portalId, apiKey, env) => {
   };
 };
 
-const loadConfigFromEnvironment = () => {
+const loadConfigFromEnvironment = ({ useEnv = false } = {}) => {
   const {
     apiKey,
     clientId,
@@ -715,7 +715,7 @@ const loadConfigFromEnvironment = () => {
     'Unable to load config from environment variables.';
 
   if (!portalId) {
-    logger.error(unableToLoadEnvConfigError);
+    useEnv && logger.error(unableToLoadEnvConfigError);
     return;
   }
 
@@ -733,13 +733,13 @@ const loadConfigFromEnvironment = () => {
   } else if (apiKey) {
     return generateApiKeyConfig(portalId, apiKey, env);
   } else {
-    logger.error(unableToLoadEnvConfigError);
+    useEnv && logger.error(unableToLoadEnvConfigError);
     return;
   }
 };
 
-const loadEnvironmentVariableConfig = () => {
-  const envConfig = loadConfigFromEnvironment();
+const loadEnvironmentVariableConfig = options => {
+  const envConfig = loadConfigFromEnvironment(options);
 
   if (!envConfig) {
     return;

--- a/packages/cli/lib/validation.js
+++ b/packages/cli/lib/validation.js
@@ -78,7 +78,7 @@ async function validateAccount(options) {
     return false;
   }
 
-  if (accountOption && loadConfigFromEnvironment()) {
+  if (accountOption && loadConfigFromEnvironment({ silent: true })) {
     throw new Error(
       'Cannot specify an account when environment variables are supplied. Please unset the environment variables or do not use the "--account" flag.'
     );

--- a/packages/cli/lib/validation.js
+++ b/packages/cli/lib/validation.js
@@ -78,7 +78,7 @@ async function validateAccount(options) {
     return false;
   }
 
-  if (accountOption && loadConfigFromEnvironment({ silent: true })) {
+  if (accountOption && loadConfigFromEnvironment()) {
     throw new Error(
       'Cannot specify an account when environment variables are supplied. Please unset the environment variables or do not use the "--account" flag.'
     );


### PR DESCRIPTION
## Description and Context
When running commands in the CLI and specifying an account using `--account=<accountName>`, the config validation code path checks for an environment variable based config in addition to specifying the account, which would be invalid. This check always displays an error stating `Unable to load config from environment variables.`. This message can be confusing because it seems like the command did not work, even though it did.

This PR fixes the error from showing up when this validation check is made by passing in options when calling `loadConfigFromEnvironment` and checking for `useEnv` to be `true` in order to show the error message.

## Screenshots
Before: When running `hs upload ./tmp/MyFunctions.functions MyFunctions.functions --account=<accountName>`
<img width="1272" alt="image" src="https://user-images.githubusercontent.com/6472448/215566452-b9bddffe-1c6f-4968-961d-621c0786cc95.png">

After: When running `hs upload ./tmp/MyFunctions.functions MyFunctions.functions --account=<accountName>`
<img width="1281" alt="image" src="https://user-images.githubusercontent.com/6472448/215566546-5c02d917-ffef-4532-85c9-c9382f66a692.png">
