### PR TITLE
Update ignoreRules.js

### DIFF
--- a/packages/cli-lib/ignoreRules.js
+++ b/packages/cli-lib/ignoreRules.js
@@ -12,7 +12,6 @@ const ignoreList = [
   '*.log', // Error log for npm
   '*.swp', // Swap file for vim state
   '.env', // Dotenv file
-  'package-lock.json', // Temporary solution to improve serverless beta: https://git.hubteam.com/HubSpot/cms-devex-super-repo/issues/2
 
   // # macOS
   'Icon\\r', // Custom Finder icon: http://superuser.com/questions/298785/icon-file-on-os-x-desktop


### PR DESCRIPTION
## Description and Context
With some of the experimental features to the back-end, I'd like to open the possibility of reading `package-lock.json` from customer uploads. I can provide more context in our backroom channel, but I think the reason this was previously included in the ignore list is now moot since we moved over to our sub-component based build strategy for private Apps.

Previous PR that introduced the ignore: https://github.com/HubSpot/hubspot-cli/pull/477

## Screenshots
<!-- Provide images of the before and after functionality -->

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
