### PR TITLE
Allow package-lock.json to be uploaded in developer projects

### DIFF
--- a/packages/cli-lib/ignoreRules.js
+++ b/packages/cli-lib/ignoreRules.js
@@ -12,8 +12,6 @@ const ignoreList = [
   '*.log', // Error log for npm
   '*.swp', // Swap file for vim state
   '.env', // Dotenv file
-  'package-lock.json', // Temporary solution to improve serverless beta: https://git.hubteam.com/HubSpot/cms-devex-super-repo/issues/2
-
   // # macOS
   'Icon\\r', // Custom Finder icon: http://superuser.com/questions/298785/icon-file-on-os-x-desktop
   '__MACOSX', // Resource fork
@@ -35,10 +33,17 @@ const ignoreRules = ignore().add(ignoreList);
 
 let searchDomain = null;
 let loaded = false;
-function loadIgnoreConfig() {
+function loadIgnoreConfig(isInProject = false) {
   if (loaded) {
     return;
   }
+
+  // Temporary solution to improve serverless beta: https://git.hubteam.com/HubSpot/cms-devex-super-repo/issues/2
+  // Do not do this when in a developer project b/c we want the package-lock.json file uploaded.
+  if (!isInProject) {
+    ignoreRules.add('package-lock.json');
+  }
+
   const file = findup('.hsignore');
   if (file) {
     if (fs.existsSync(file)) {
@@ -49,16 +54,16 @@ function loadIgnoreConfig() {
   loaded = true;
 }
 
-function shouldIgnoreFile(file) {
-  loadIgnoreConfig();
+function shouldIgnoreFile(file, isInProject) {
+  loadIgnoreConfig(isInProject);
   const relativeTo = searchDomain || '/';
   const relativePath = path.relative(relativeTo, file);
 
   return !!relativePath && ignoreRules.ignores(relativePath);
 }
 
-function createIgnoreFilter() {
-  loadIgnoreConfig();
+function createIgnoreFilter(isInProject) {
+  loadIgnoreConfig(isInProject);
   return file => !shouldIgnoreFile(file);
 }
 

--- a/packages/cli-lib/projectsWatch.js
+++ b/packages/cli-lib/projectsWatch.js
@@ -99,7 +99,7 @@ const queueFileOrFolder = async (
     logger.debug(i18n(`${i18nKey}.debug.extensionNotAllowed`, { filePath }));
     return;
   }
-  if (shouldIgnoreFile(filePath)) {
+  if (shouldIgnoreFile(filePath, true)) {
     logger.debug(i18n(`${i18nKey}.debug.ignored`, { filePath }));
     return;
   }

--- a/packages/cli/lib/projects.js
+++ b/packages/cli/lib/projects.js
@@ -363,7 +363,7 @@ const handleProjectUpload = async (
   archive.pipe(output);
 
   archive.directory(srcDir, false, file =>
-    shouldIgnoreFile(file.name) ? false : file
+    shouldIgnoreFile(file.name, true) ? false : file
   );
 
   archive.finalize();


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
Moving towards allowing package-lock.json files to be uploaded in developer projects to mitigate unexpected dep updates on deploy. I'm keeping the ignore rule present for any non-project upload because it looks like it's still being used.

## Screenshots
<!-- Provide images of the before and after functionality -->

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
cc/ @m-roll 