### PR TITLE
Standard sandbox sync support

### DIFF
--- a/packages/cli-lib/api/sandboxes-sync.js
+++ b/packages/cli-lib/api/sandboxes-sync.js
@@ -22,9 +22,9 @@ async function fetchTaskStatus(accountId, taskId) {
   });
 }
 
-async function fetchTypes(toHubId) {
-  return http.get(toHubId, {
-    uri: `${SANDBOXES_SYNC_API_PATH}/types/${
+async function fetchTypes(accountId, toHubId) {
+  return http.get(accountId, {
+    uri: `${SANDBOXES_SYNC_API_PATH}/types${
       toHubId ? `?toHubId=${toHubId}` : ''
     }`,
   });

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -698,6 +698,29 @@ en:
               missingParentPortal: "The production account associated to {{#bold}}{{ sandboxName }}{{/bold}} is not connected to your HubSpot CLI.
                 \n- Run `{{#bold}}hs auth{{/bold}}` to connect that account to your terminal, then try again.
                 \n- Run `{{#bold}}hs accounts use{{/bold}}` to change your default account, if you want to sync to a different sandbox. Then try again.\n"
+            types:
+              parcels:
+                label: "Account tools and features"
+              super-admins:
+                label: "Super Admins"
+              object-schemas:
+                label: "Object definitions"
+              object-records:
+                label: "Contacts and associated records"
+              cms-developer-assets:
+                label: "Themes, templates, and modules"
+              object-pipelines:
+                label: "Pipelines"
+              object-lists:
+                label: "Lists"
+              workflows:
+                label: "Workflows"
+              forms:
+                label: "Forms"
+              lead-flows:
+                label: "Lead Flows"
+              marketing-email:
+                label: "Marketing emails"
       secrets:
         describe: "Manage HubSpot secrets."
         subcommands:

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -698,6 +698,8 @@ en:
               missingParentPortal: "The production account associated to {{#bold}}{{ sandboxName }}{{/bold}} is not connected to your HubSpot CLI.
                 \n- Run `{{#bold}}hs auth{{/bold}}` to connect that account to your terminal, then try again.
                 \n- Run `{{#bold}}hs accounts use{{/bold}}` to change your default account, if you want to sync to a different sandbox. Then try again.\n"
+              missingScopes: "Couldn’t run the sync because there are scopes missing. To update scopes, deactivate your current personal access key, and generate a new one. Then run `hs auth` to update the CLI with the new key."
+              syncInProgress: "Couldn’t run the sync because there’s another sync in progress. Wait for the current sync to finish and then try again. To check the status of your sync, visit your sync activity log: {{ url }}."
             types:
               parcels:
                 label: "Account tools and features"

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -674,6 +674,7 @@ en:
               default: "Initiates a sync to a sandbox account."
             info:
               developmentSandbox: "This will sync CRM object definitions."
+              standardSandbox: "This will sync all supported assets. To sync only specific assets, follow this link: {{#bold}}{{ url }}{{/bold}}"
               sync: "\nSync direction:
                 \n- Target sandbox: {{#bold}}{{ sandboxName }}{{/bold}}
                 \n- Source account: {{#bold}}{{ parentAccountName }}{{/bold}}
@@ -682,6 +683,7 @@ en:
             warning: "All object definitions in that sandbox will be overwritten except for the ones that were originally created in your sandbox and not synced from production."
             confirm:
               developmentSandbox: "Sync CRM object definitions to {{#bold}}{{ sandboxName }}{{/bold}} from {{#bold}}{{ parentAccountName }}{{/bold}}?"
+              standardSandbox: "Sync all supported assets to {{#bold}}{{ sandboxName }}{{/bold}} from {{#bold}}{{ parentAccountName }}{{/bold}}?"
               backgroundSync: "Syncing may take some time. Hit enter to exit and continue the sync in the background."
             loading:
               startSync: "Initiating sync..."

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -692,10 +692,10 @@ en:
               fail: "Failed to fetch sync updates. View the sync status at: {{ url }}"
               succeed: "Sandbox sync complete."
             failure:
-              notSandbox: "Sync must be run in a sandbox account. Your default account is a production account. Run `hs auth` to connect your sandbox account to the CLI or `hs accounts use` to change your default account, then try again."
+              notSandbox: "Sync must be run in a sandbox account. Your default account is a production account. Run `{{#bold}}hs auth{{/bold}}` to connect your sandbox account to the CLI or `{{#bold}}hs accounts use{{/bold}}` to change your default account, then try again."
               missingParentPortal: "The production account associated to {{#bold}}{{ sandboxName }}{{/bold}} is not connected to your HubSpot CLI.
-                \n- Run `hs auth` to connect that account to your terminal, then try again.
-                \n- Run `hs accounts use` to change your default account, if you want to sync to a different sandbox. Then try again.\n"
+                \n- Run `{{#bold}}hs auth{{/bold}}` to connect that account to your terminal, then try again.
+                \n- Run `{{#bold}}hs accounts use{{/bold}}` to change your default account, if you want to sync to a different sandbox. Then try again.\n"
       secrets:
         describe: "Manage HubSpot secrets."
         subcommands:

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -699,8 +699,7 @@ en:
                 \n- Run `{{#bold}}hs auth{{/bold}}` to connect that account to your terminal, then try again.
                 \n- Run `{{#bold}}hs accounts use{{/bold}}` to change your default account, if you want to sync to a different sandbox. Then try again.\n"
               missingScopes: "Couldn’t run the sync because there are scopes missing in your production account. To update scopes, deactivate your current personal access key for {{#bold}}{{ accountName }}{{/bold}}, and generate a new one. Then run `hs auth` to update the CLI with the new key."
-              syncInProgress: "Couldn’t run the sync because there’s another sync in progress. Wait for the current sync to finish and then try again.
-                \nTo check the sync status, visit the sync activity log: {{ url }}."
+              syncInProgress: "Couldn’t run the sync because there’s another sync in progress. Wait for the current sync to finish and then try again. To check the sync status, visit the sync activity log: {{ url }}."
             types:
               parcels:
                 label: "Account tools and features"

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -698,8 +698,9 @@ en:
               missingParentPortal: "The production account associated to {{#bold}}{{ sandboxName }}{{/bold}} is not connected to your HubSpot CLI.
                 \n- Run `{{#bold}}hs auth{{/bold}}` to connect that account to your terminal, then try again.
                 \n- Run `{{#bold}}hs accounts use{{/bold}}` to change your default account, if you want to sync to a different sandbox. Then try again.\n"
-              missingScopes: "Couldn’t run the sync because there are scopes missing. To update scopes, deactivate your current personal access key, and generate a new one. Then run `hs auth` to update the CLI with the new key."
-              syncInProgress: "Couldn’t run the sync because there’s another sync in progress. Wait for the current sync to finish and then try again. To check the status of your sync, visit your sync activity log: {{ url }}."
+              missingScopes: "Couldn’t run the sync because there are scopes missing in your production account. To update scopes, deactivate your current personal access key for {{#bold}}{{ accountName }}{{/bold}}, and generate a new one. Then run `hs auth` to update the CLI with the new key."
+              syncInProgress: "Couldn’t run the sync because there’s another sync in progress. Wait for the current sync to finish and then try again.
+                \nTo check the sync status, visit the sync activity log: {{ url }}."
             types:
               parcels:
                 label: "Account tools and features"

--- a/packages/cli-lib/sandboxes.js
+++ b/packages/cli-lib/sandboxes.js
@@ -75,7 +75,7 @@ async function initiateSync(fromHubId, toHubId, tasks, sandboxHubId) {
  * Fetches a task.
  * @param {String} accountId - Parent account ID.
  * @param {String} taskId - Sync task ID.
- * @returns {200}
+ * @returns {Object} a sync task instance.
  */
 async function fetchTaskStatus(accountId, taskId) {
   let resp;
@@ -92,18 +92,18 @@ async function fetchTaskStatus(accountId, taskId) {
 /**
  * Fetches available sync types for a specified portal.
  * @param {Number} toHubId - Portal ID to fetch available types.
- * @returns {200}
+ * @returns {Object} a list of available sync types
  */
-async function fetchTypes(toHubId) {
+async function fetchTypes(accountId, toHubId) {
   let resp;
 
   try {
-    resp = await _fetchTypes(toHubId);
+    resp = await _fetchTypes(accountId, toHubId);
   } catch (err) {
     throw err;
   }
 
-  return resp;
+  return resp.results;
 }
 
 module.exports = {

--- a/packages/cli/commands/sandbox/delete.js
+++ b/packages/cli/commands/sandbox/delete.js
@@ -11,7 +11,7 @@ const { loadAndValidateOptions } = require('../../lib/validation');
 const {
   debugErrorAndContext,
 } = require('@hubspot/cli-lib/errorHandlers/standardErrors');
-
+const { logErrorInstance } = require('@hubspot/cli-lib/errorHandlers');
 const { deleteSandbox } = require('@hubspot/cli-lib/sandboxes');
 const { i18n } = require('@hubspot/cli-lib/lib/lang');
 const { getConfig, getEnv } = require('@hubspot/cli-lib');
@@ -167,11 +167,7 @@ exports.handler = async options => {
       }
       process.exit(EXIT_CODES.SUCCESS);
     } else {
-      if (err.message) {
-        logger.error(err.message);
-      } else {
-        logger.error(err.error && err.error.message);
-      }
+      logErrorInstance(err);
     }
     process.exit(EXIT_CODES.ERROR);
   }

--- a/packages/cli/commands/sandbox/sync.js
+++ b/packages/cli/commands/sandbox/sync.js
@@ -174,7 +174,7 @@ exports.handler = async options => {
     uiLine();
 
     logger.log('');
-    spinnies.update('sandboxSync', {
+    spinnies.succeed('sandboxSync', {
       text: i18n(`${i18nKey}.loading.succeed`),
     });
   } catch (err) {
@@ -190,21 +190,25 @@ exports.handler = async options => {
   }
 
   try {
-    spinnies.update('sandboxSync', {
-      text: i18n(`${i18nKey}.polling.syncing`),
-    });
-
+    logger.log('');
+    logger.log('Sync progress:');
     await pollSyncStatus(parentAccountId, initiateSyncResponse.id);
 
-    spinnies.succeed('sandboxSync', {
+    logger.log('');
+    spinnies.add('syncComplete', {
+      text: i18n(`${i18nKey}.polling.syncing`),
+    });
+    spinnies.succeed('syncComplete', {
       text: i18n(`${i18nKey}.polling.succeed`),
     });
   } catch (err) {
     logErrorInstance(err);
 
     // If polling fails at this point, we do not track a failed sync since it is running in the background.
-
-    spinnies.fail('sandboxSync', {
+    spinnies.add('syncComplete', {
+      text: i18n(`${i18nKey}.polling.syncing`),
+    });
+    spinnies.fail('syncComplete', {
       text: i18n(`${i18nKey}.polling.fail`, {
         url: `${baseUrl}/sandboxes-developer/${parentAccountId}/development`,
       }),

--- a/packages/cli/lib/sandboxes.js
+++ b/packages/cli/lib/sandboxes.js
@@ -21,7 +21,7 @@ const {
   setAsDefaultAccountPrompt,
 } = require('./prompts/setAsDefaultAccountPrompt');
 const { uiFeatureHighlight } = require('./ui');
-const { fetchTaskStatus } = require('@hubspot/cli-lib/sandboxes');
+const { fetchTaskStatus, fetchTypes } = require('@hubspot/cli-lib/sandboxes');
 
 const getSandboxType = type =>
   type === 'DEVELOPER' ? 'development' : 'standard';
@@ -33,11 +33,16 @@ function getAccountName(config) {
   return `${config.name} ${isSandbox ? sandboxName : ''}(${config.portalId})`;
 }
 
-function getSyncTasks(config) {
+async function getSyncTypes(parentAccountConfig, config) {
   if (config.sandboxAccountType === 'DEVELOPER') {
     return [{ type: 'object-schemas' }];
   }
-  // TODO: fetch types for standard sandbox sync
+  if (config.sandboxAccountType === 'STANDARD') {
+    const parentPortalId = parentAccountConfig.portalId;
+    const portalId = config.portalId;
+    const syncTypes = await fetchTypes(parentPortalId, portalId);
+    return syncTypes.map(t => ({ type: t.name }));
+  }
   return null;
 }
 
@@ -123,7 +128,7 @@ function pollSyncStatus(accountId, taskId) {
 module.exports = {
   getSandboxType,
   getAccountName,
-  getSyncTasks,
+  getSyncTypes,
   sandboxCreatePersonalAccessKeyFlow,
   pollSyncStatus,
 };

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -12,6 +12,7 @@
     "@hubspot/serverless-dev-runtime": "4.1.6",
     "archiver": "^5.3.0",
     "chalk": "^4.1.2",
+    "cli-progress": "^3.11.2",
     "express": "^4.17.1",
     "findup-sync": "^4.0.0",
     "fs-extra": "^8.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2151,6 +2151,13 @@ cli-cursor@^3.0.0, cli-cursor@^3.1.0:
   dependencies:
     restore-cursor "^3.1.0"
 
+cli-progress@^3.11.2:
+  version "3.11.2"
+  resolved "https://registry.yarnpkg.com/cli-progress/-/cli-progress-3.11.2.tgz#f8c89bd157e74f3f2c43bcfb3505670b4d48fc77"
+  integrity sha512-lCPoS6ncgX4+rJu5bS3F/iCz17kZ9MPZ6dpuTtI0KXKABkhyXIdYB3Inby1OpaGti3YlI3EeEkM9AuWpelJrVA==
+  dependencies:
+    string-width "^4.2.3"
+
 cli-spinners@^2.2.0, cli-spinners@^2.5.0:
   version "2.6.0"
   resolved "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.6.0.tgz"


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->

PR 2 of 2 for updates to `hs sandbox sync` command. This PR adds the ability to sync standard sandboxes with the appropriate sync types and error handling. 

The sync flow is as follows: 
- Fetch sandbox sync types
- Initiate a sync and receive a response with a task ID
- Start polling for task updates which powers the progress bars
  - The polling logic combines lead-flows and forms into one single bar. This is the same logic as the UI. 

## Screenshots
<!-- Provide images of the before and after functionality -->

Syncing all types with progress bar:
<img width="1259" alt="Screenshot 2023-02-21 at 14 17 09" src="https://user-images.githubusercontent.com/16788677/221239100-4e78f014-42a8-4cda-88ed-acc81bf119a0.png">

Error for parallel syncs:
<img width="1244" alt="Screenshot 2023-02-24 at 12 41 48" src="https://user-images.githubusercontent.com/16788677/221239140-88715348-2b0c-4640-be01-5761feedf186.png">

Missing scopes error:
<img width="1261" alt="Screenshot 2023-02-24 at 11 47 46" src="https://user-images.githubusercontent.com/16788677/221239327-73667675-931c-4fd3-9f7a-1d2a36618ea7.png">


## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
