### PR TITLE
Add scripting options for hs sandbox delete

### DIFF
--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -660,8 +660,11 @@ en:
               delete: "Sandbox \"{{ account }}\" with portalId \"{{ sandboxHubId }}\" was deleted successfully."
               deleteDefault: "Sandbox \"{{ account }}\" with portalId \"{{ sandboxHubId }}\" was deleted successfully and removed as the default account."
               configFileUpdated: "Removed account {{ account }} from {{ configFilename }}."
-            objectNotFound: "Sandbox {{#bold}}{{ account }}{{/bold}} may have been be deleted through the UI. The account has been removed from the config."
-            noParentPortalAvailable: "This sandbox can't be deleted from the CLI because you haven't given the CLI access to its parent account. To do this, run {{#bold}}{{ command }}{{/bold}}. You can also delete the sandbox from the HubSpot management tool: {{#bold}}{{ url }}{{/bold}}."
+            failure:
+              noAccount: "No account specified. Specify an account by using the --account flag."
+              noParentAccount: "This sandbox can't be deleted from the CLI because you haven't given the CLI access to its parent account. To do this, run {{#bold}}hs auth{{/bold}} and add the parent account."
+              objectNotFound: "Sandbox {{#bold}}{{ account }}{{/bold}} may have been be deleted through the UI. The account has been removed from the config."
+              noParentPortalAvailable: "This sandbox can't be deleted from the CLI because you haven't given the CLI access to its parent account. To do this, run {{#bold}}{{ command }}{{/bold}}. You can also delete the sandbox from the HubSpot management tool: {{#bold}}{{ url }}{{/bold}}."
             options:
               account:
                 describe: "Account name or id to delete"

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -663,7 +663,7 @@ en:
               configFileUpdated: "Removed account {{ account }} from {{ configFilename }}."
             failure:
               noAccount: "No account specified. Specify an account by using the --account flag."
-              noSandboxAccounts: "No sandbox accounts available."
+              noSandboxAccounts: "No sandbox accounts to delete."
               noParentAccount: "This sandbox can't be deleted from the CLI because you haven't given the CLI access to its parent account. To do this, run {{#bold}}hs auth{{/bold}} and add the parent account."
               objectNotFound: "Sandbox {{#bold}}{{ account }}{{/bold}} may have been be deleted through the UI. The account has been removed from the config."
               noParentPortalAvailable: "This sandbox can't be deleted from the CLI because you haven't given the CLI access to its parent account. To do this, run {{#bold}}{{ command }}{{/bold}}. You can also delete the sandbox from the HubSpot management tool: {{#bold}}{{ url }}{{/bold}}."

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -663,7 +663,7 @@ en:
               configFileUpdated: "Removed account {{ account }} from {{ configFilename }}."
             failure:
               noAccount: "No account specified. Specify an account by using the --account flag."
-              noSandboxAccounts: "No sandbox accounts to delete."
+              noSandboxAccounts: "There are no sandboxes connected to the CLI. To add a sandbox, run {{#bold}}hs auth{{/bold}}."
               noParentAccount: "This sandbox can't be deleted from the CLI because you haven't given the CLI access to its parent account. To do this, run {{#bold}}hs auth{{/bold}} and add the parent account."
               objectNotFound: "Sandbox {{#bold}}{{ account }}{{/bold}} may have been be deleted through the UI. The account has been removed from the config."
               noParentPortalAvailable: "This sandbox can't be deleted from the CLI because you haven't given the CLI access to its parent account. To do this, run {{#bold}}{{ command }}{{/bold}}. You can also delete the sandbox from the HubSpot management tool: {{#bold}}{{ url }}{{/bold}}."

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -654,6 +654,7 @@ en:
               error: "Error deleting sandbox account:"
             examples:
               default: "Deletes the sandbox account named MySandboxAccount."
+              force: "Skips all confirmation prompts when deleting a sandbox account."
             confirm: "Delete sandbox {{#bold}}{{ account }}{{/bold}}? All data for this sandbox will be permanently deleted."
             defaultAccountWarning: "The sandbox {{#bold}}{{ account }}{{/bold}} is currently set as the default account."
             success:

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -663,6 +663,7 @@ en:
               configFileUpdated: "Removed account {{ account }} from {{ configFilename }}."
             failure:
               noAccount: "No account specified. Specify an account by using the --account flag."
+              noSandboxAccounts: "No sandbox accounts available."
               noParentAccount: "This sandbox can't be deleted from the CLI because you haven't given the CLI access to its parent account. To do this, run {{#bold}}hs auth{{/bold}} and add the parent account."
               objectNotFound: "Sandbox {{#bold}}{{ account }}{{/bold}} may have been be deleted through the UI. The account has been removed from the config."
               noParentPortalAvailable: "This sandbox can't be deleted from the CLI because you haven't given the CLI access to its parent account. To do this, run {{#bold}}{{ command }}{{/bold}}. You can also delete the sandbox from the HubSpot management tool: {{#bold}}{{ url }}{{/bold}}."

--- a/packages/cli/commands/sandbox/delete.js
+++ b/packages/cli/commands/sandbox/delete.js
@@ -48,10 +48,17 @@ exports.handler = async options => {
       accountPrompt = await deleteSandboxPrompt(config);
     } else {
       // Account is required, throw error if force flag is present and no account is specified
+      logger.log('');
       logger.error(i18n(`${i18nKey}.failure.noAccount`));
       process.exit(EXIT_CODES.ERROR);
     }
+    if (!accountPrompt) {
+      logger.log('');
+      logger.error(i18n(`${i18nKey}.failure.noSandboxAccounts`));
+      process.exit(EXIT_CODES.ERROR);
+    }
   }
+
   const sandboxAccountId = getAccountId({
     account: account || accountPrompt.account,
   });

--- a/packages/cli/commands/sandbox/delete.js
+++ b/packages/cli/commands/sandbox/delete.js
@@ -198,8 +198,10 @@ exports.builder = yargs => {
     describe: i18n(`${i18nKey}.options.account.describe`),
     type: 'string',
   });
-  yargs.option('force', {
+  yargs.option('f', {
     type: 'boolean',
+    alias: 'force',
+    describe: i18n(`${i18nKey}.examples.force`),
   });
 
   yargs.example([

--- a/packages/cli/lib/prompts/accountsPrompt.js
+++ b/packages/cli/lib/prompts/accountsPrompt.js
@@ -51,4 +51,5 @@ const selectAndSetAsDefaultAccountPrompt = async config => {
 module.exports = {
   selectAndSetAsDefaultAccountPrompt,
   selectAccountFromConfig,
+  mapAccountChoices,
 };

--- a/packages/cli/lib/prompts/sandboxesPrompt.js
+++ b/packages/cli/lib/prompts/sandboxesPrompt.js
@@ -1,6 +1,5 @@
 const { promptUser } = require('./promptUtils');
 const { i18n } = require('@hubspot/cli-lib/lib/lang');
-const { mapAccountChoices } = require('./accountsPrompt');
 
 const i18nKey = 'cli.lib.prompts.sandboxesPrompt';
 
@@ -14,6 +13,18 @@ const mapSandboxAccountChoices = portals =>
       const sandboxName = `[${getSandboxType(p.sandboxAccountType)} sandbox] `;
       return {
         name: `${p.name} ${sandboxName}(${p.portalId})`,
+        value: p.name || p.portalId,
+      };
+    });
+
+const mapNonSandboxAccountChoices = portals =>
+  portals
+    .filter(
+      p => p.sandboxAccountType === null || p.sandboxAccountType === undefined
+    )
+    .map(p => {
+      return {
+        name: `${p.name} (${p.portalId})`,
         value: p.name || p.portalId,
       };
     });
@@ -47,7 +58,7 @@ const deleteSandboxPrompt = (config, promptParentAccount = false) => {
       look: false,
       pageSize: 20,
       choices: promptParentAccount
-        ? mapAccountChoices(config.portals)
+        ? mapNonSandboxAccountChoices(config.portals)
         : mapSandboxAccountChoices(config.portals),
       default: config.defaultPortal,
     },

--- a/packages/cli/lib/prompts/sandboxesPrompt.js
+++ b/packages/cli/lib/prompts/sandboxesPrompt.js
@@ -17,6 +17,18 @@ const mapSandboxAccountChoices = portals =>
       };
     });
 
+const mapNonSandboxAccountChoices = portals =>
+  portals
+    .filter(
+      p => p.sandboxAccountType === null || p.sandboxAccountType === undefined
+    )
+    .map(p => {
+      return {
+        name: `${p.name} (${p.portalId})`,
+        value: p.name || p.portalId,
+      };
+    });
+
 const createSandboxPrompt = () => {
   return promptUser([
     {
@@ -45,7 +57,9 @@ const deleteSandboxPrompt = (config, promptParentAccount = false) => {
       type: 'list',
       look: false,
       pageSize: 20,
-      choices: mapSandboxAccountChoices(config.portals),
+      choices: promptParentAccount
+        ? mapNonSandboxAccountChoices(config.portals)
+        : mapSandboxAccountChoices(config.portals),
       default: config.defaultPortal,
     },
   ]);

--- a/packages/cli/lib/prompts/sandboxesPrompt.js
+++ b/packages/cli/lib/prompts/sandboxesPrompt.js
@@ -1,5 +1,6 @@
 const { promptUser } = require('./promptUtils');
 const { i18n } = require('@hubspot/cli-lib/lib/lang');
+const { mapAccountChoices } = require('./accountsPrompt');
 
 const i18nKey = 'cli.lib.prompts.sandboxesPrompt';
 
@@ -13,18 +14,6 @@ const mapSandboxAccountChoices = portals =>
       const sandboxName = `[${getSandboxType(p.sandboxAccountType)} sandbox] `;
       return {
         name: `${p.name} ${sandboxName}(${p.portalId})`,
-        value: p.name || p.portalId,
-      };
-    });
-
-const mapNonSandboxAccountChoices = portals =>
-  portals
-    .filter(
-      p => p.sandboxAccountType === null || p.sandboxAccountType === undefined
-    )
-    .map(p => {
-      return {
-        name: `${p.name} (${p.portalId})`,
         value: p.name || p.portalId,
       };
     });
@@ -58,7 +47,7 @@ const deleteSandboxPrompt = (config, promptParentAccount = false) => {
       look: false,
       pageSize: 20,
       choices: promptParentAccount
-        ? mapNonSandboxAccountChoices(config.portals)
+        ? mapAccountChoices(config.portals)
         : mapSandboxAccountChoices(config.portals),
       default: config.defaultPortal,
     },

--- a/packages/cli/lib/prompts/sandboxesPrompt.js
+++ b/packages/cli/lib/prompts/sandboxesPrompt.js
@@ -44,6 +44,12 @@ const createSandboxPrompt = () => {
 };
 
 const deleteSandboxPrompt = (config, promptParentAccount = false) => {
+  const choices = promptParentAccount
+    ? mapNonSandboxAccountChoices(config.portals)
+    : mapSandboxAccountChoices(config.portals);
+  if (!choices.length) {
+    return undefined;
+  }
   return promptUser([
     {
       name: 'account',
@@ -55,9 +61,7 @@ const deleteSandboxPrompt = (config, promptParentAccount = false) => {
       type: 'list',
       look: false,
       pageSize: 20,
-      choices: promptParentAccount
-        ? mapNonSandboxAccountChoices(config.portals)
-        : mapSandboxAccountChoices(config.portals),
+      choices,
       default: config.defaultPortal,
     },
   ]);


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->

Support scripting by adding a --force flag to skip all confirmations. Added additional error logging to handle missing data/flags when skipping confirmations. 

## Screenshots
<!-- Provide images of the before and after functionality -->
Error when the account config does not have `parentAccountId` set:
<img width="1186" alt="Screenshot 2023-03-03 at 17 03 24" src="https://user-images.githubusercontent.com/16788677/222815727-6449d91c-288b-4e32-b50e-272500e9a7bd.png">
Error when no account is specified:
<img width="641" alt="Screenshot 2023-03-03 at 17 02 51" src="https://user-images.githubusercontent.com/16788677/222815732-4c912184-f4f4-4e11-8aa5-82fa9c2e2ede.png">

Success:
<img width="840" alt="Screenshot 2023-03-03 at 17 20 02" src="https://user-images.githubusercontent.com/16788677/222820953-b3b0bdcb-30bb-4690-b363-17fcada17a98.png">

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->
I'll do a separate PR for sandbox create

## Who to Notify
<!-- /cc those you wish to know about the PR -->

