### PR TITLE
Fix package versions

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -5,5 +5,5 @@
     "packages/*",
     "acceptance-tests"
   ],
-  "version": "4.1.7-beta.1"
+  "version": "4.1.7-beta.2"
 }

--- a/packages/cli-lib/package.json
+++ b/packages/cli-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hubspot/cli-lib",
-  "version": "4.1.7-beta.1",
+  "version": "4.1.7-beta.2",
   "description": "Library for creating scripts for working with HubSpot",
   "license": "Apache-2.0",
   "main": "index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hubspot/cli",
-  "version": "4.1.7-beta.1",
+  "version": "4.1.7-beta.2",
   "description": "CLI for working with HubSpot",
   "license": "Apache-2.0",
   "repository": {
@@ -8,8 +8,8 @@
     "url": "https://github.com/HubSpot/hubspot-cms-tools"
   },
   "dependencies": {
-    "@hubspot/cli-lib": "4.1.7-beta.1",
-    "@hubspot/serverless-dev-runtime": "4.1.7-beta.1",
+    "@hubspot/cli-lib": "4.1.7-beta.2",
+    "@hubspot/serverless-dev-runtime": "4.1.7-beta.2",
     "archiver": "^5.3.0",
     "chalk": "^4.1.2",
     "cli-progress": "^3.11.2",

--- a/packages/serverless-dev-runtime/package.json
+++ b/packages/serverless-dev-runtime/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@hubspot/serverless-dev-runtime",
-  "version": "4.1.7-beta.1",
+  "version": "4.1.7-beta.2",
   "description": "A tool for testing HubSpot CMS serverless functions locally",
   "main": "index.js",
   "repository": "https://github.com/HubSpot/hubspot-cli",
   "license": "Apache-2.0",
   "dependencies": {
-    "@hubspot/cli-lib": "4.1.7-beta.1",
+    "@hubspot/cli-lib": "4.1.7-beta.2",
     "body-parser": "^1.19.0",
     "chalk": "^4.1.0",
     "chokidar": "^3.4.3",

--- a/packages/webpack-cms-plugins/package.json
+++ b/packages/webpack-cms-plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hubspot/webpack-cms-plugins",
-  "version": "4.1.7-beta.1",
+  "version": "4.1.7-beta.2",
   "description": "Webpack plugins for using with the HubSpot CMS",
   "license": "Apache-2.0",
   "repository": {
@@ -17,7 +17,7 @@
     "test": "echo \"Error: run tests from root\" && exit 1"
   },
   "dependencies": {
-    "@hubspot/cli-lib": "4.1.7-beta.1"
+    "@hubspot/cli-lib": "4.1.7-beta.2"
   },
   "gitHead": "0659fd19cabc3645af431b177c11d0c1b089e0f8"
 }


### PR DESCRIPTION
Made a goof when running prerelease and accidentally ran the command on a feature branch, this should correct the version numbers to the current published version