### PR TITLE
Deliver modules separately

### DIFF
--- a/packages/cli/commands/upload.js
+++ b/packages/cli/commands/upload.js
@@ -62,11 +62,10 @@ exports.handler = async options => {
     accountId,
     absoluteSrcPath,
     dest,
-    {
-      mode,
-    },
+    { mode },
     options,
-    filePaths) {
+    filePaths
+  ) {
     return uploadFolder(
       accountId,
       absoluteSrcPath,


### PR DESCRIPTION
## Description and Context
We have made some changes internally that require us to upload modules after all other assets have been uploaded.
This is done by delivering all other assets synchronously, before queueing up module uploads. 

## Who to Notify
cc @mattcoley @jmagnarelli-hs @jsines 
