### PR TITLE
Adjust sandbox error messaging

### DIFF
--- a/packages/cli-lib/api/hubs.js
+++ b/packages/cli-lib/api/hubs.js
@@ -1,13 +1,37 @@
 const request = require('request-promise-native');
 const { getRequestOptions } = require('../http/requestOptions');
 const { ENVIRONMENTS } = require('../lib/constants');
-const HUBS_API_PATH = 'sandbox-hubs/v1/self';
+const HUBS2_API_PATH = 'hubs2/v1/info/hub';
+const SANDBOX_HUBS_API_PATH = 'sandbox-hubs/v1/self';
+
+async function fetchSandboxHubData(
+  accessToken,
+  portalId,
+  env = ENVIRONMENTS.PROD
+) {
+  const requestOptions = getRequestOptions(
+    { env },
+    {
+      uri: `${SANDBOX_HUBS_API_PATH}`,
+      qs: { portalId },
+    }
+  );
+  const reqWithToken = {
+    ...requestOptions,
+    headers: {
+      ...requestOptions.headers,
+      Authorization: `Bearer ${accessToken}`,
+    },
+  };
+
+  return request.get(reqWithToken);
+}
 
 async function fetchHubData(accessToken, portalId, env = ENVIRONMENTS.PROD) {
   const requestOptions = getRequestOptions(
     { env },
     {
-      uri: `${HUBS_API_PATH}`,
+      uri: `${HUBS2_API_PATH}/${portalId}`,
       qs: { portalId },
     }
   );
@@ -23,5 +47,6 @@ async function fetchHubData(accessToken, portalId, env = ENVIRONMENTS.PROD) {
 }
 
 module.exports = {
+  fetchSandboxHubData,
   fetchHubData,
 };

--- a/packages/cli-lib/api/hubs.js
+++ b/packages/cli-lib/api/hubs.js
@@ -1,7 +1,6 @@
 const request = require('request-promise-native');
 const { getRequestOptions } = require('../http/requestOptions');
 const { ENVIRONMENTS } = require('../lib/constants');
-const HUBS2_API_PATH = 'hubs2/v1/info/hub';
 const SANDBOX_HUBS_API_PATH = 'sandbox-hubs/v1/self';
 
 async function fetchSandboxHubData(
@@ -27,26 +26,6 @@ async function fetchSandboxHubData(
   return request.get(reqWithToken);
 }
 
-async function fetchHubData(accessToken, portalId, env = ENVIRONMENTS.PROD) {
-  const requestOptions = getRequestOptions(
-    { env },
-    {
-      uri: `${HUBS2_API_PATH}/${portalId}`,
-      qs: { portalId },
-    }
-  );
-  const reqWithToken = {
-    ...requestOptions,
-    headers: {
-      ...requestOptions.headers,
-      Authorization: `Bearer ${accessToken}`,
-    },
-  };
-
-  return request.get(reqWithToken);
-}
-
 module.exports = {
   fetchSandboxHubData,
-  fetchHubData,
 };

--- a/packages/cli-lib/errorHandlers/apiErrors.js
+++ b/packages/cli-lib/errorHandlers/apiErrors.js
@@ -26,6 +26,7 @@ const isApiUploadValidationError = err =>
 const isMissingScopeError = err =>
   err.name === 'StatusCodeError' &&
   err.statusCode === 403 &&
+  err.error &&
   err.error.category === 'MISSING_SCOPES';
 
 const isSpecifiedError = (
@@ -35,8 +36,9 @@ const isSpecifiedError = (
   subCategory = undefined
 ) => {
   const statusCodeErr = statusCode && err.statusCode === statusCode;
-  const categoryErr = category && err.error.category === category;
-  const subCategoryErr = subCategory && err.error.subCategory === subCategory;
+  const categoryErr = category && err.error && err.error.category === category;
+  const subCategoryErr =
+    subCategory && err.error && err.error.subCategory === subCategory;
   return (
     err.name === 'StatusCodeError' &&
     statusCodeErr &&

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -643,10 +643,10 @@ en:
             failure:
               creatingWithinSandbox: "Development sandboxes must be created from a production account. You’re using a {{ sandboxType }} sandbox right now. Run {{#bold}}hs auth{{/bold}} to connect a production account or {{#bold}}hs accounts use{{/bold}} to switch to your production account, then try again."
               limit:
-                one: "{{#bold}}{{ accountName }}{{/bold}} reached the limit of one development sandbox per account. View sandbox details at {{ devSandboxesLink }}. To connect a sandbox to your HubSpot CLI, run {{#bold}}hs auth{{/bold}} and follow the prompts."
+                one: "{{#bold}}{{ accountName }}{{/bold}} reached the limit of {{ limit }} development sandbox per account. View sandbox details at {{ devSandboxesLink }}. To connect a sandbox to your HubSpot CLI, run {{#bold}}hs auth{{/bold}} and follow the prompts."
                 other: "{{#bold}}{{ accountName }}{{/bold}} reached the limit of {{ limit }} development sandboxes per account. View sandbox details at {{ devSandboxesLink }}. To connect a sandbox to your HubSpot CLI, run {{#bold}}hs auth{{/bold}} and follow the prompts."
               alreadyInConfig:
-                one: "{{#bold}}{{ accountName }}{{/bold}} reached the limit of one development sandbox per account.
+                one: "{{#bold}}{{ accountName }}{{/bold}} reached the limit of {{ limit }} development sandbox per account.
                 \n- To use an existing development sandbox, run {{#bold}}hs accounts use{{/bold}}.
                 \n- To delete an existing sandbox, run {{#bold}}hs sandbox delete{{/bold}}."
                 other: "{{#bold}}{{ accountName }}{{/bold}} reached the limit of {{ limit }} development sandboxes per account.

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -671,6 +671,7 @@ en:
               noParentAccount: "This sandbox can't be deleted from the CLI because you haven't given the CLI access to its parent account. To do this, run {{#bold}}hs auth{{/bold}} and add the parent account."
               objectNotFound: "Sandbox {{#bold}}{{ account }}{{/bold}} may have been be deleted through the UI. The account has been removed from the config."
               noParentPortalAvailable: "This sandbox can't be deleted from the CLI because you haven't given the CLI access to its parent account. To do this, run {{#bold}}{{ command }}{{/bold}}. You can also delete the sandbox from the HubSpot management tool: {{#bold}}{{ url }}{{/bold}}."
+              invalidKey: "Your personal access key for account {{#bold}}{{ account }}{{/bold}} is inactive. To re-authenticate, please run {{#bold}}hs auth personalaccesskey{{/bold}}."
             options:
               account:
                 describe: "Account name or id to delete"

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -642,8 +642,14 @@ en:
               configFileUpdated: "{{ configFilename }} updated with {{ authMethod }} for account {{ account }}."
             failure:
               creatingWithinSandbox: "Development sandboxes must be created from a production account. You’re using a {{ sandboxType }} sandbox right now. Run {{#bold}}hs auth{{/bold}} to connect a production account or {{#bold}}hs accounts use{{/bold}} to switch to your production account, then try again."
-              limit: "{{#bold}}{{ accountName }}{{/bold}} reached the limit of {{ limit }} development sandbox(s) per account. View sandbox details at {{ devSandboxesLink }}. To connect a sandbox to your HubSpot CLI, run {{#bold}}hs auth{{/bold}} and follow the prompts."
-              alreadyInConfig: "{{#bold}}{{ accountName }}{{/bold}} reached the limit of {{ limit }} development sandbox(s) per account.
+              limit:
+                one: "{{#bold}}{{ accountName }}{{/bold}} reached the limit of one development sandbox per account. View sandbox details at {{ devSandboxesLink }}. To connect a sandbox to your HubSpot CLI, run {{#bold}}hs auth{{/bold}} and follow the prompts."
+                other: "{{#bold}}{{ accountName }}{{/bold}} reached the limit of {{ limit }} development sandboxes per account. View sandbox details at {{ devSandboxesLink }}. To connect a sandbox to your HubSpot CLI, run {{#bold}}hs auth{{/bold}} and follow the prompts."
+              alreadyInConfig:
+                one: "{{#bold}}{{ accountName }}{{/bold}} reached the limit of one development sandbox per account.
+                \n- To use an existing development sandbox, run {{#bold}}hs accounts use{{/bold}}.
+                \n- To delete an existing sandbox, run {{#bold}}hs sandbox delete{{/bold}}."
+                other: "{{#bold}}{{ accountName }}{{/bold}} reached the limit of {{ limit }} development sandboxes per account.
                 \n- To use an existing development sandbox, run {{#bold}}hs accounts use{{/bold}}.
                 \n- To delete an existing sandbox, run {{#bold}}hs sandbox delete{{/bold}}."
               scopes:

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -641,12 +641,16 @@ en:
             success:
               configFileUpdated: "{{ configFilename }} updated with {{ authMethod }} for account {{ account }}."
             failure:
-              creatingWithinSandbox: "Development sandboxes must be created from a production account. You’re using a {{ sandboxType }} sandbox right now. Run `hs auth` to connect a production account or `hs accounts use` to switch to your production account, then try again."
+              creatingWithinSandbox: "Development sandboxes must be created from a production account. You’re using a {{ sandboxType }} sandbox right now. Run {{#bold}}hs auth{{/bold}} to connect a production account or {{#bold}}hs accounts use{{/bold}} to switch to your production account, then try again."
+              limit: "{{#bold}}{{ accountName }}{{/bold}} reached the limit of {{ limit }} development sandbox(s) per account. View sandbox details at {{ devSandboxesLink }}. To connect a sandbox to your HubSpot CLI, run {{#bold}}hs auth{{/bold}} and follow the prompts."
+              alreadyInConfig: "{{#bold}}{{ accountName }}{{/bold}} reached the limit of {{ limit }} development sandbox(s) per account.
+                \n- To use an existing development sandbox, run {{#bold}}hs accounts use{{/bold}}.
+                \n- To delete an existing sandbox, run {{#bold}}hs sandbox delete{{/bold}}."
               scopes:
                 message: "The personal access key you provided doesn't include sandbox permissions."
                 instructions: "To update CLI permissions for \"{{ accountName }}\":
                   \n- Go to {{ url }}, deactivate the existing personal access key, and create a new one that includes Sandboxes permissions.
-                  \n- Update the CLI config for this account by running `hs auth` and entering the new key.\n"
+                  \n- Update the CLI config for this account by running {{#bold}}hs auth{{/bold}} and entering the new key.\n"
           delete:
             describe: "Delete a sandbox account"
             debug:
@@ -684,7 +688,7 @@ en:
               sync: "\nSync direction:
                 \n- Target sandbox: {{#cyan}}{{#bold}}{{ sandboxName }}{{/bold}}{{/cyan}}
                 \n- Source account: {{#bold}}{{ parentAccountName }}{{/bold}}
-                \n\nRun `{{#bold}}hs accounts use{{/bold}}` to change your default account and sync to a different target sandbox."
+                \n\nRun {{#bold}}hs accounts use{{/bold}} to change your default account and sync to a different target sandbox."
               syncStatus: "View the sync status details at: {{#bold}}{{ url }}{{/bold}}"
               earlyExit: "Syncing may take some time. Hit {{#bold}}Enter{{/bold}} or {{#bold}}Ctrl+C{{/bold}} to exit and continue the sync in the background."
             warning:
@@ -702,10 +706,10 @@ en:
               fail: "Failed to fetch sync updates. View the sync status at: {{ url }}"
               succeed: "Sandbox sync complete."
             failure:
-              notSandbox: "Sync must be run in a sandbox account. Your default account is a production account. Run `{{#bold}}hs auth{{/bold}}` to connect your sandbox account to the CLI or `{{#bold}}hs accounts use{{/bold}}` to change your default account, then try again."
+              notSandbox: "Sync must be run in a sandbox account. Your default account is a production account. Run {{#bold}}hs auth{{/bold}} to connect your sandbox account to the CLI or {{#bold}}hs accounts use{{/bold}} to change your default account, then try again."
               missingParentPortal: "The production account associated to {{#bold}}{{ sandboxName }}{{/bold}} is not connected to your HubSpot CLI.
-                \n- Run `{{#bold}}hs auth{{/bold}}` to connect that account to your terminal, then try again.
-                \n- Run `{{#bold}}hs accounts use{{/bold}}` to change your default account, if you want to sync to a different sandbox. Then try again.\n"
+                \n- Run {{#bold}}hs auth{{/bold}} to connect that account to your terminal, then try again.
+                \n- Run {{#bold}}hs accounts use{{/bold}} to change your default account, if you want to sync to a different sandbox. Then try again.\n"
               missingScopes: "Couldn’t run the sync because there are scopes missing in your production account. To update scopes, deactivate your current personal access key for {{#bold}}{{ accountName }}{{/bold}}, and generate a new one. Then run `hs auth` to update the CLI with the new key."
               syncInProgress: "Couldn’t run the sync because there’s another sync in progress. Wait for the current sync to finish and then try again. To check the sync status, visit the sync activity log: {{ url }}."
               notSuperAdmin: "Couldn't run the sync because you are not a super admin in {{ account }}. Ask the account owner for super admin access to the sandbox."
@@ -802,7 +806,7 @@ en:
                 describe: "Output raw json data"
             results:
               required: "Required validation results:"
-              recommended: "Recommended validation results:"  
+              recommended: "Recommended validation results:"
               warnings:
                 file: "File: {{ file }}"
                 lineNumber: "Line number: {{ line }}"

--- a/packages/cli-lib/personalAccessKey.js
+++ b/packages/cli-lib/personalAccessKey.js
@@ -34,6 +34,8 @@ async function getAccessToken(
     if (e.response) {
       const errorOutput = `Error while retrieving new access token: ${e.response.body.message}.`;
       if (e.response.statusCode === 401) {
+        // Before adjusting the error message below, please verify that changes do not break regex match in cli/commands/sandbox/delete.js
+        // For future changes: if response.statusCode is passed into the new error below, sandboxes can skip the regex check and pull the statusCode instead
         throw new HubSpotAuthError(
           `${errorOutput} \nYour personal access key is invalid. Please run "hs auth personalaccesskey" to reauthenticate. See https://designers.hubspot.com/docs/personal-access-keys for more information.`
         );

--- a/packages/cli-lib/personalAccessKey.js
+++ b/packages/cli-lib/personalAccessKey.js
@@ -14,7 +14,7 @@ const {
 } = require('./lib/constants');
 const { logErrorInstance } = require('./errorHandlers/standardErrors');
 const { fetchAccessToken } = require('./api/localDevAuth/unauthenticated');
-const { fetchHubData } = require('./api/hubs');
+const { fetchSandboxHubData } = require('./api/hubs');
 
 const refreshRequests = new Map();
 
@@ -148,7 +148,7 @@ const updateConfigWithPersonalAccessKey = async (configData, makeDefault) => {
 
   let hubInfo;
   try {
-    hubInfo = await fetchHubData(accessToken, portalId, accountEnv);
+    hubInfo = await fetchSandboxHubData(accessToken, portalId, accountEnv);
   } catch (err) {
     // Ignore error, returns 404 if account is not a sandbox
   }

--- a/packages/cli/commands/sandbox/create.js
+++ b/packages/cli/commands/sandbox/create.js
@@ -130,20 +130,24 @@ exports.handler = async options => {
     ) {
       logger.log('');
       const devSandboxLimitString = getDevSandboxLimit(err.error.message);
+      const plural = devSandboxLimitString !== 'one';
       const hasDevelopmentSandboxes = getHasDevelopmentSandboxes(accountConfig);
       if (hasDevelopmentSandboxes) {
         logger.error(
-          i18n(`${i18nKey}.failure.alreadyInConfig`, {
-            accountName: accountConfig.name || accountId,
-            limit: devSandboxLimitString,
-          })
+          i18n(
+            `${i18nKey}.failure.alreadyInConfig.${plural ? 'other' : 'one'}`,
+            {
+              accountName: accountConfig.name || accountId,
+              limit: devSandboxLimitString,
+            }
+          )
         );
       } else {
         const baseUrl = getHubSpotWebsiteOrigin(
           getEnv(accountId) === 'qa' ? ENVIRONMENTS.QA : ENVIRONMENTS.PROD
         );
         logger.error(
-          i18n(`${i18nKey}.failure.limit`, {
+          i18n(`${i18nKey}.failure.limit.${plural ? 'other' : 'one'}`, {
             accountName: accountConfig.name || accountId,
             limit: devSandboxLimitString,
             devSandboxesLink: `${baseUrl}/sandboxes-developer/${accountId}/development`,

--- a/packages/cli/commands/sandbox/create.js
+++ b/packages/cli/commands/sandbox/create.js
@@ -129,7 +129,6 @@ exports.handler = async options => {
       err.error.message
     ) {
       logger.log('');
-      // logger.error(err.error.message);
       const devSandboxLimitString = getDevSandboxLimit(err.error.message);
       const hasDevelopmentSandboxes = getHasDevelopmentSandboxes(accountConfig);
       if (hasDevelopmentSandboxes) {

--- a/packages/cli/commands/sandbox/create.js
+++ b/packages/cli/commands/sandbox/create.js
@@ -129,7 +129,7 @@ exports.handler = async options => {
       err.error.message
     ) {
       logger.log('');
-      const devSandboxLimit = getDevSandboxLimit(err.error.message);
+      const devSandboxLimit = getDevSandboxLimit(err.error);
       const plural = devSandboxLimit !== 1;
       const hasDevelopmentSandboxes = getHasDevelopmentSandboxes(accountConfig);
       if (hasDevelopmentSandboxes) {

--- a/packages/cli/commands/sandbox/create.js
+++ b/packages/cli/commands/sandbox/create.js
@@ -129,8 +129,8 @@ exports.handler = async options => {
       err.error.message
     ) {
       logger.log('');
-      const devSandboxLimitString = getDevSandboxLimit(err.error.message);
-      const plural = devSandboxLimitString !== 'one';
+      const devSandboxLimit = getDevSandboxLimit(err.error.message);
+      const plural = devSandboxLimit !== 1;
       const hasDevelopmentSandboxes = getHasDevelopmentSandboxes(accountConfig);
       if (hasDevelopmentSandboxes) {
         logger.error(
@@ -138,7 +138,7 @@ exports.handler = async options => {
             `${i18nKey}.failure.alreadyInConfig.${plural ? 'other' : 'one'}`,
             {
               accountName: accountConfig.name || accountId,
-              limit: devSandboxLimitString,
+              limit: devSandboxLimit,
             }
           )
         );
@@ -149,7 +149,7 @@ exports.handler = async options => {
         logger.error(
           i18n(`${i18nKey}.failure.limit.${plural ? 'other' : 'one'}`, {
             accountName: accountConfig.name || accountId,
-            limit: devSandboxLimitString,
+            limit: devSandboxLimit,
             devSandboxesLink: `${baseUrl}/sandboxes-developer/${accountId}/development`,
           })
         );

--- a/packages/cli/commands/sandbox/delete.js
+++ b/packages/cli/commands/sandbox/delete.js
@@ -148,7 +148,7 @@ exports.handler = async options => {
     logger.log('');
     logger.success(
       i18n(deleteKey, {
-        account: getAccountConfig(accountConfig),
+        account: account || accountPrompt.account,
         sandboxHubId: sandboxAccountId,
       })
     );

--- a/packages/cli/lib/sandboxes.js
+++ b/packages/cli/lib/sandboxes.js
@@ -52,11 +52,10 @@ function getHasDevelopmentSandboxes(parentAccountConfig) {
   return false;
 }
 
-function getDevSandboxLimit(message) {
-  // Return the first grouping of digits, in this case the count from the string
-  const regex = /\d+/;
-  const match = message.match(regex);
-  return match && parseInt(match[0], 10);
+function getDevSandboxLimit(error) {
+  // Error context should contain a limit property with a list of one number. That number is the current limit
+  const limit = error.context && error.context.limit && error.context.limit[0];
+  return limit ? parseInt(limit, 10) : 1; // Default to 1
 }
 
 // Fetches available sync types for a given sandbox portal

--- a/packages/cli/lib/sandboxes.js
+++ b/packages/cli/lib/sandboxes.js
@@ -53,8 +53,8 @@ function getHasDevelopmentSandboxes(parentAccountConfig) {
 }
 
 function getDevSandboxLimit(message) {
-  // Return the word after the matched sentence, in this case the number
-  const regex = /(?<=\breached your limit of\s)(\w+)/;
+  // Return the first grouping of digits, in this case the count from the string
+  const regex = /\d+/;
   const match = message.match(regex);
   return match && match[0];
 }

--- a/packages/cli/lib/sandboxes.js
+++ b/packages/cli/lib/sandboxes.js
@@ -35,6 +35,30 @@ function getAccountName(config) {
   return `${config.name} ${isSandbox ? sandboxName : ''}(${config.portalId})`;
 }
 
+function getHasDevelopmentSandboxes(parentAccountConfig) {
+  const config = getConfig();
+  const parentPortalId = parentAccountConfig.portalId;
+  for (const portal of config.portals) {
+    if (
+      (portal.parentAccountId !== null ||
+        portal.parentAccountId !== undefined) &&
+      portal.parentAccountId === parentPortalId &&
+      portal.sandboxAccountType &&
+      portal.sandboxAccountType === 'DEVELOPER'
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function getDevSandboxLimit(message) {
+  // Return the word after the matched sentence, in this case the number
+  const regex = /(?<=\breached your limit of\s)(\w+)/;
+  const match = message.match(regex);
+  return match[0];
+}
+
 // Fetches available sync types for a given sandbox portal
 async function getAvailableSyncTypes(parentAccountConfig, config) {
   const parentPortalId = parentAccountConfig.portalId;
@@ -211,6 +235,8 @@ function pollSyncTaskStatus(accountId, taskId, syncStatusUrl) {
 module.exports = {
   getSandboxType,
   getAccountName,
+  getHasDevelopmentSandboxes,
+  getDevSandboxLimit,
   getAvailableSyncTypes,
   sandboxCreatePersonalAccessKeyFlow,
   pollSyncTaskStatus,

--- a/packages/cli/lib/sandboxes.js
+++ b/packages/cli/lib/sandboxes.js
@@ -56,7 +56,7 @@ function getDevSandboxLimit(message) {
   // Return the first grouping of digits, in this case the count from the string
   const regex = /\d+/;
   const match = message.match(regex);
-  return match && match[0];
+  return match && parseInt(match[0], 10);
 }
 
 // Fetches available sync types for a given sandbox portal

--- a/packages/cli/lib/sandboxes.js
+++ b/packages/cli/lib/sandboxes.js
@@ -56,7 +56,7 @@ function getDevSandboxLimit(message) {
   // Return the word after the matched sentence, in this case the number
   const regex = /(?<=\breached your limit of\s)(\w+)/;
   const match = message.match(regex);
-  return match[0];
+  return match && match[0];
 }
 
 // Fetches available sync types for a given sandbox portal


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->

Sandboxes identified a few areas where error messaging could improve. 

- When a user hits their development sandbox limit (currently 1), we show an error based on whether or not they already have a development sandbox tied to the parent portal in the config. 
- If a user tries to interact with sandboxes and the parent portal PAK is invalid, a very generic message was thrown. Since the underlying logic of sandboxes is to use the parent portal PAK and not the sandbox PAK to interact with sandboxes, users may try to fix the sandbox PAK incorrectly. We intercept this message and display a more detailed version containing the portal that needs to be fixed. 

## Screenshots
<!-- Provide images of the before and after functionality -->
Sandbox limit when dev sandbox is NOT in config:
<img width="1401" alt="Screenshot 2023-03-30 at 11 53 36" src="https://user-images.githubusercontent.com/16788677/229153705-224a68f0-94b5-4021-bea4-e6117f1dbf8e.png">

Sandbox limit when dev sandbox IS in the config (gives option to switch accounts with hs use):
<img width="731" alt="Screenshot 2023-03-30 at 11 54 44" src="https://user-images.githubusercontent.com/16788677/229154254-9c849f9c-3813-42ab-b9e6-1b5233a017af.png">

If the parent portal PAK is invalid, we intercept the error and show one specifically showing the portal that the PAK needs to be updated for:
<img width="988" alt="Screenshot 2023-03-30 at 14 37 34" src="https://user-images.githubusercontent.com/16788677/229154584-6f1f8c5c-d8de-4f29-ad79-622faa4b9505.png">

Note for this last one - the `HubSpotAuthError` class is set with a link that points to [designers.hubspot.com](https://github.com/HubSpot/hubspot-cli/blob/b441e5eb014e27633c811a54cc7f3bdcea87b6a5/packages/cli-lib/personalAccessKey.js#L38). Is this something that is still valid? 

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->
n/a

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@brandenrodgers @kemmerle 
