### PR TITLE
Add hook for callback after initial upload in watch

### DIFF
--- a/packages/cli-lib/lib/watch.js
+++ b/packages/cli-lib/lib/watch.js
@@ -131,7 +131,8 @@ function watch(
   accountId,
   src,
   dest,
-  { mode, remove, disableInitial, notify, commandOptions, filePaths }
+  { mode, remove, disableInitial, notify, commandOptions, filePaths },
+  postInitialUploadCallback = null
 ) {
   const regex = new RegExp(`^${escapeRegExp(src)}`);
   if (notify) {
@@ -163,6 +164,11 @@ function watch(
         logErrorInstance(error, {
           accountId,
         });
+      })
+      .finally(() => {
+        if (postInitialUploadCallback) {
+          postInitialUploadCallback();
+        }
       });
   }
 

--- a/packages/cli-lib/lib/watch.js
+++ b/packages/cli-lib/lib/watch.js
@@ -152,10 +152,13 @@ function watch(
   if (!disableInitial) {
     // Use uploadFolder so that failures of initial upload are retried
     uploadFolder(accountId, src, dest, { mode }, commandOptions, filePaths)
-      .then(() => {
+      .then(result => {
         logger.success(
           `Completed uploading files in ${src} to ${dest} in ${accountId}`
         );
+        if (postInitialUploadCallback) {
+          postInitialUploadCallback(result);
+        }
       })
       .catch(error => {
         logger.error(
@@ -164,11 +167,6 @@ function watch(
         logErrorInstance(error, {
           accountId,
         });
-      })
-      .finally(() => {
-        if (postInitialUploadCallback) {
-          postInitialUploadCallback();
-        }
       });
   }
 


### PR DESCRIPTION
## Description and Context
Adds optional argument to watch function in `cli-lib` for a callback after the initial upload completes. This allows the VSCode extension to add a hook for informing the user that the initial upload has completed and for the remote file system display to refresh the view with the uploaded folder. See that PR here: https://github.com/HubSpot/hubspot-cms-vscode/pull/216
