### PR TITLE
fixing app option for project logs command

### DIFF
--- a/packages/cli/lib/prompts/projectsLogsPrompt.js
+++ b/packages/cli/lib/prompts/projectsLogsPrompt.js
@@ -66,7 +66,7 @@ const projectLogsPrompt = (accountId, promptOptions = {}) => {
 
         if (deployedBuild && deployedBuild.subbuildStatuses) {
           return deployedBuild.subbuildStatuses
-            .filter(subbuild => subbuild.buildType === 'APP')
+            .filter(subbuild => subbuild.buildType === 'PRIVATE_APP')
             .map(subbuild => ({
               name: subbuild.buildName,
               value: subbuild.buildName,


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
This is for the `hs project logs` command. There was an issue where we weren't showing the user the list of available apps in their project (See screenshot of it working correctly).

## Screenshots
<!-- Provide images of the before and after functionality -->
<img width="494" alt="image" src="https://user-images.githubusercontent.com/6654014/230417846-29e68b9a-922f-4c67-a17a-a7bf19288ab4.png">

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
