### PR TITLE
V2 of `hs sandbox create`

### DIFF
--- a/packages/cli-lib/api/sandbox-hubs.js
+++ b/packages/cli-lib/api/sandbox-hubs.js
@@ -1,17 +1,19 @@
 const http = require('../http');
 const SANDBOX_API_PATH = 'sandbox-hubs/v1';
+const SANDBOX_API_PATH_V2 = 'sandbox-hubs/v2';
 
 /**
  * Creates a new Sandbox portal instance.
  * @param {String} accountId - Parent portal ID to create the sandbox
  * @param {String} name - Name to use for the sandbox.
- * @returns {Object} A new Sandbox portal instance.
+ * @param {String} type - Sandbox type (standard | developer).
+ * @returns {Object} A new Sandbox portal instance with a pre-generated PAK.
  */
-async function createSandbox(accountId, name) {
+async function createSandbox(accountId, name, type) {
   return http.post(accountId, {
-    body: { name },
+    body: { name, type, generatePersonalAccessKey: true }, // For CLI, generatePersonalAccessKey will always be true since we'll be saving the entry to the config
     timeout: 60000,
-    uri: SANDBOX_API_PATH,
+    uri: SANDBOX_API_PATH_V2, // Create uses v2 for sandbox type and PAK generation support
   });
 }
 

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -653,51 +653,6 @@ en:
                 describe: "Name to use for created sandbox"
               type:
                 describe: "Type of sandbox to create (standard | development)"
-            loading:
-              developer:
-                add: "Creating development sandbox {{#bold}}{{ sandboxName }}{{/bold}}"
-                fail: "Failed to create a development sandbox {{#bold}}{{ sandboxName }}{{/bold}}."
-                succeed: "Successfully created a development sandbox {{#bold}}{{ name }}{{/bold}} with portalId {{#bold}}{{ sandboxHubId }}{{/bold}}."
-              standard:
-                add: "Creating standard sandbox {{#bold}}{{ sandboxName }}{{/bold}}"
-                fail: "Failed to create a standard sandbox {{#bold}}{{ sandboxName }}{{/bold}}."
-                succeed: "Successfully created a standard sandbox {{#bold}}{{ name }}{{/bold}} with portalId {{#bold}}{{ sandboxHubId }}{{/bold}}."
-            success:
-              configFileUpdated: "{{ configFilename }} updated with {{ authMethod }} for account {{ account }}."
-            failure:
-              optionMissing:
-                type: "Invalid or missing sandbox --type option in command. Please try again."
-                name: "Invalid or missing sandbox --name option in command. Please try again."
-              creatingWithinSandbox: "Sandboxes must be created from a production account. Your current default account {{#bold}}{{ sandboxName }}{{/bold}} is a {{ sandboxType }} sandbox.
-                \n- Run {{#bold}}hs accounts use{{/bold}} to switch to your default account to your production account.
-                \n- Run {{#bold}}hs auth{{/bold}} to connect a production account to the HubSpot CLI.\n"
-              limit:
-                developer:
-                  one: "{{#bold}}{{ accountName }}{{/bold}} reached the limit of {{ limit }} development sandbox per account. View sandbox details at {{ link }}. To connect a sandbox to your HubSpot CLI, run {{#bold}}hs auth{{/bold}} and follow the prompts."
-                other: "{{#bold}}{{ accountName }}{{/bold}} reached the limit of {{ limit }} development sandboxes per account. View sandbox details at {{ link }}. To connect a sandbox to your HubSpot CLI, run {{#bold}}hs auth{{/bold}} and follow the prompts."
-                standard:
-                  one: "{{#bold}}{{ accountName }}{{/bold}} reached the limit of {{ limit }} standard sandbox per account. View sandbox details at {{ link }}. To connect a sandbox to your HubSpot CLI, run {{#bold}}hs auth{{/bold}} and follow the prompts."
-                  other: "{{#bold}}{{ accountName }}{{/bold}} reached the limit of {{ limit }} standard sandboxes per account. View sandbox details at {{ link }}. To connect a sandbox to your HubSpot CLI, run {{#bold}}hs auth{{/bold}} and follow the prompts."
-              alreadyInConfig:
-                developer:
-                  one: "{{#bold}}{{ accountName }}{{/bold}} reached the limit of {{ limit }} development sandbox per account.
-                  \n- To use an existing development sandbox, run {{#bold}}hs accounts use{{/bold}}.
-                  \n- To delete an existing sandbox, run {{#bold}}hs sandbox delete{{/bold}}."
-                  other: "{{#bold}}{{ accountName }}{{/bold}} reached the limit of {{ limit }} development sandboxes per account.
-                  \n- To use an existing development sandbox, run {{#bold}}hs accounts use{{/bold}}.
-                  \n- To delete an existing sandbox, run {{#bold}}hs sandbox delete{{/bold}}."
-                standard:
-                  one: "{{#bold}}{{ accountName }}{{/bold}} reached the limit of {{ limit }} standard sandbox per account.
-                  \n- To use an existing standard sandbox, run {{#bold}}hs accounts use{{/bold}}.
-                  \n- To delete an existing sandbox, run {{#bold}}hs sandbox delete{{/bold}}."
-                  other: "{{#bold}}{{ accountName }}{{/bold}} reached the limit of {{ limit }} standard sandboxes per account.
-                  \n- To use an existing standard sandbox, run {{#bold}}hs accounts use{{/bold}}.
-                  \n- To delete an existing sandbox, run {{#bold}}hs sandbox delete{{/bold}}."
-              scopes:
-                message: "The personal access key you provided doesn't include sandbox permissions."
-                instructions: "To update CLI permissions for \"{{ accountName }}\":
-                  \n- Go to {{ url }}, deactivate the existing personal access key, and create a new one that includes Sandboxes permissions.
-                  \n- Update the CLI config for this account by running {{#bold}}hs auth{{/bold}} and entering the new key.\n"
           delete:
             describe: "Delete a sandbox account"
             debug:
@@ -724,9 +679,6 @@ en:
                 describe: "Account name or id to delete"
           sync:
             describe: "Sync to a sandbox account"
-            debug:
-              syncing: "Syncing sandbox account \"{{ account }}\"."
-              error: "Error syncing sandbox account."
             examples:
               default: "Initiates a sync to a sandbox account."
               force: "Skips all confirmation prompts when initiating a sync."
@@ -738,56 +690,17 @@ en:
                 \n- Target sandbox: {{#cyan}}{{#bold}}{{ sandboxName }}{{/bold}}{{/cyan}}
                 \n- Source account: {{#bold}}{{ parentAccountName }}{{/bold}}
                 \n\nRun {{#bold}}hs accounts use{{/bold}} to change your default account and sync to a different target sandbox."
-              syncStatus: "View the sync status details at: {{#bold}}{{ url }}{{/bold}}"
-              earlyExit: "Syncing may take some time. Hit {{#bold}}Enter{{/bold}} or {{#bold}}Ctrl+C{{/bold}} to exit and continue the sync in the background."
             warning:
               developmentSandbox: "Syncing will update previously synced object definitions and add new ones from production to your development sandbox. Object definitions that were created in your sandbox will stay the same."
               standardSandbox: "Syncing can have a big impact. Updates from your production account may overwrite changes in your standard sandbox. Standard sandboxes are usually shared with other Super Admins."
             confirm:
               developmentSandbox: "Sync CRM object definitions to {{#cyan}}{{#bold}}{{ sandboxName }}{{/bold}}{{/cyan}} from {{#bold}}{{ parentAccountName }}{{/bold}}?"
               standardSandbox: "Sync all supported assets to {{#cyan}}{{#bold}}{{ sandboxName }}{{/bold}}{{/cyan}} from {{#bold}}{{ parentAccountName }}{{/bold}}?"
-              standardSandboxCreateFlow: "Sync all supported assets to {{#cyan}}{{#bold}}{{ sandboxName }}{{/bold}}{{/cyan}} from {{#bold}}{{ parentAccountName }}{{/bold}}? Syncing may take some time"
-              standardSandboxCreateFlowReconfirm: "Confirm the sync of all supported assets to {{#cyan}}{{#bold}}{{ sandboxName }}{{/bold}}{{/cyan}} from {{#bold}}{{ parentAccountName }}{{/bold}}?"
-            loading:
-              startSync: "Initiating sync..."
-              fail: "Failed to sync sandbox."
-              succeed: "Sandbox sync initiated."
-            polling:
-              syncing: "Syncing sandbox..."
-              fail: "Failed to fetch sync updates. View the sync status at: {{ url }}"
-              succeed: "Sandbox sync complete."
             failure:
               notSandbox: "Sync must be run in a sandbox account. Your default account is a production account. Run {{#bold}}hs auth{{/bold}} to connect your sandbox account to the CLI or {{#bold}}hs accounts use{{/bold}} to change your default account, then try again."
               missingParentPortal: "The production account associated to {{#bold}}{{ sandboxName }}{{/bold}} is not connected to your HubSpot CLI.
                 \n- Run {{#bold}}hs auth{{/bold}} to connect that account to your terminal, then try again.
                 \n- Run {{#bold}}hs accounts use{{/bold}} to change your default account, if you want to sync to a different sandbox. Then try again.\n"
-              missingScopes: "Couldn’t run the sync because there are scopes missing in your production account. To update scopes, deactivate your current personal access key for {{#bold}}{{ accountName }}{{/bold}}, and generate a new one. Then run `hs auth` to update the CLI with the new key."
-              syncInProgress: "Couldn’t run the sync because there’s another sync in progress. Wait for the current sync to finish and then try again. To check the sync status, visit the sync activity log: {{ url }}."
-              notSuperAdmin: "Couldn't run the sync because you are not a super admin in {{ account }}. Ask the account owner for super admin access to the sandbox."
-              objectNotFound: "Couldn't sync the sandbox because {{#bold}}{{ account }}{{/bold}} may have been be deleted through the UI. Run {{#bold}}hs sandbox delete{{/bold}} to remove this account from the config. "
-            types:
-              parcels:
-                label: "Account tools and features"
-              super-admins:
-                label: "Super Admins"
-              object-schemas:
-                label: "Object definitions"
-              object-records:
-                label: "Contacts and associated records"
-              cms-developer-assets:
-                label: "Themes, templates, and modules"
-              object-pipelines:
-                label: "Pipelines"
-              object-lists:
-                label: "Lists"
-              workflows:
-                label: "Workflows"
-              forms:
-                label: "Forms"
-              lead-flows:
-                label: "Lead Flows"
-              marketing-email:
-                label: "Marketing emails"
       secrets:
         describe: "Manage HubSpot secrets."
         subcommands:
@@ -1126,5 +1039,97 @@ en:
       debug:
         templates:
           creatingPath: "Making {{ path }} if needed"
+      sandbox:
+        create:
+          loading:
+            developer:
+              add: "Creating development sandbox {{#bold}}{{ sandboxName }}{{/bold}}"
+              fail: "Failed to create a development sandbox {{#bold}}{{ sandboxName }}{{/bold}}."
+              succeed: "Successfully created a development sandbox {{#bold}}{{ name }}{{/bold}} with portalId {{#bold}}{{ sandboxHubId }}{{/bold}}."
+            standard:
+              add: "Creating standard sandbox {{#bold}}{{ sandboxName }}{{/bold}}"
+              fail: "Failed to create a standard sandbox {{#bold}}{{ sandboxName }}{{/bold}}."
+              succeed: "Successfully created a standard sandbox {{#bold}}{{ name }}{{/bold}} with portalId {{#bold}}{{ sandboxHubId }}{{/bold}}."
+          success:
+            configFileUpdated: "{{ configFilename }} updated with {{ authMethod }} for account {{ account }}."
+          failure:
+            optionMissing:
+              type: "Invalid or missing sandbox --type option in command. Please try again."
+              name: "Invalid or missing sandbox --name option in command. Please try again."
+            creatingWithinSandbox: "Sandboxes must be created from a production account. Your current default account {{#bold}}{{ sandboxName }}{{/bold}} is a {{ sandboxType }} sandbox.
+              \n- Run {{#bold}}hs accounts use{{/bold}} to switch to your default account to your production account.
+              \n- Run {{#bold}}hs auth{{/bold}} to connect a production account to the HubSpot CLI.\n"
+            limit:
+              developer:
+                one: "{{#bold}}{{ accountName }}{{/bold}} reached the limit of {{ limit }} development sandbox per account. View sandbox details at {{ link }}. To connect a sandbox to your HubSpot CLI, run {{#bold}}hs auth{{/bold}} and follow the prompts."
+              other: "{{#bold}}{{ accountName }}{{/bold}} reached the limit of {{ limit }} development sandboxes per account. View sandbox details at {{ link }}. To connect a sandbox to your HubSpot CLI, run {{#bold}}hs auth{{/bold}} and follow the prompts."
+              standard:
+                one: "{{#bold}}{{ accountName }}{{/bold}} reached the limit of {{ limit }} standard sandbox per account. View sandbox details at {{ link }}. To connect a sandbox to your HubSpot CLI, run {{#bold}}hs auth{{/bold}} and follow the prompts."
+                other: "{{#bold}}{{ accountName }}{{/bold}} reached the limit of {{ limit }} standard sandboxes per account. View sandbox details at {{ link }}. To connect a sandbox to your HubSpot CLI, run {{#bold}}hs auth{{/bold}} and follow the prompts."
+            alreadyInConfig:
+              developer:
+                one: "{{#bold}}{{ accountName }}{{/bold}} reached the limit of {{ limit }} development sandbox per account.
+                \n- To use an existing development sandbox, run {{#bold}}hs accounts use{{/bold}}.
+                \n- To delete an existing sandbox, run {{#bold}}hs sandbox delete{{/bold}}."
+                other: "{{#bold}}{{ accountName }}{{/bold}} reached the limit of {{ limit }} development sandboxes per account.
+                \n- To use an existing development sandbox, run {{#bold}}hs accounts use{{/bold}}.
+                \n- To delete an existing sandbox, run {{#bold}}hs sandbox delete{{/bold}}."
+              standard:
+                one: "{{#bold}}{{ accountName }}{{/bold}} reached the limit of {{ limit }} standard sandbox per account.
+                \n- To use an existing standard sandbox, run {{#bold}}hs accounts use{{/bold}}.
+                \n- To delete an existing sandbox, run {{#bold}}hs sandbox delete{{/bold}}."
+                other: "{{#bold}}{{ accountName }}{{/bold}} reached the limit of {{ limit }} standard sandboxes per account.
+                \n- To use an existing standard sandbox, run {{#bold}}hs accounts use{{/bold}}.
+                \n- To delete an existing sandbox, run {{#bold}}hs sandbox delete{{/bold}}."
+            scopes:
+              message: "The personal access key you provided doesn't include sandbox permissions."
+              instructions: "To update CLI permissions for \"{{ accountName }}\":
+                \n- Go to {{ url }}, deactivate the existing personal access key, and create a new one that includes Sandboxes permissions.
+                \n- Update the CLI config for this account by running {{#bold}}hs auth{{/bold}} and entering the new key.\n"
+        sync:
+          info:
+            syncStatus: "View the sync status details at: {{#bold}}{{ url }}{{/bold}}"
+            earlyExit: "Syncing may take some time. Hit {{#bold}}Enter{{/bold}} or {{#bold}}Ctrl+C{{/bold}} to exit and continue the sync in the background."
+          confirm:
+            standardSandboxCreateFlow: "Sync all supported assets to {{#cyan}}{{#bold}}{{ sandboxName }}{{/bold}}{{/cyan}} from {{#bold}}{{ parentAccountName }}{{/bold}}? Syncing may take some time"
+          loading:
+            startSync: "Initiating sync..."
+            fail: "Failed to sync sandbox."
+            succeed: "Sandbox sync initiated."
+          polling:
+            syncing: "Syncing sandbox..."
+            fail: "Failed to fetch sync updates. View the sync status at: {{ url }}"
+            succeed: "Sandbox sync complete."
+          failure:
+              \n- Run {{#bold}}hs auth{{/bold}} to connect that account to your terminal, then try again.
+              \n- Run {{#bold}}hs accounts use{{/bold}} to change your default account, if you want to sync to a different sandbox. Then try again.\n"
+            missingScopes: "Couldn’t run the sync because there are scopes missing in your production account. To update scopes, deactivate your current personal access key for {{#bold}}{{ accountName }}{{/bold}}, and generate a new one. Then run `hs auth` to update the CLI with the new key."
+            syncInProgress: "Couldn’t run the sync because there’s another sync in progress. Wait for the current sync to finish and then try again. To check the sync status, visit the sync activity log: {{ url }}."
+            notSuperAdmin: "Couldn't run the sync because you are not a super admin in {{ account }}. Ask the account owner for super admin access to the sandbox."
+            objectNotFound: "Couldn't sync the sandbox because {{#bold}}{{ account }}{{/bold}} may have been be deleted through the UI. Run {{#bold}}hs sandbox delete{{/bold}} to remove this account from the config. "
+          types:
+            parcels:
+              label: "Account tools and features"
+            super-admins:
+              label: "Super Admins"
+            object-schemas:
+              label: "Object definitions"
+            object-records:
+              label: "Contacts and associated records"
+            cms-developer-assets:
+              label: "Themes, templates, and modules"
+            object-pipelines:
+              label: "Pipelines"
+            object-lists:
+              label: "Lists"
+            workflows:
+              label: "Workflows"
+            forms:
+              label: "Forms"
+            lead-flows:
+              label: "Lead Flows"
+            marketing-email:
+              label: "Marketing emails"
+
 
 

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -651,6 +651,8 @@ en:
             options:
               name:
                 describe: "Name to use for created sandbox"
+              type:
+                describe: "Type of sandbox to create (standard | development)"
             loading:
               add: "Creating development sandbox {{#bold}}{{ sandboxName }}{{/bold}}"
               fail: "Failed to create a development sandbox {{#bold}}{{ sandboxName }}{{/bold}}."
@@ -1043,11 +1045,16 @@ en:
           errors:
             invalidValue: "You entered an invalid value. Please try again."
         sandboxesPrompt:
-          enterName: "Enter a name to use for the development sandbox: "
-          errors:
-            invalidName: "You entered an invalid name. Please try again."
-          selectAccountName: "Select the sandbox account you want to delete"
-          selectParentAccountName: "Select the account that the sandbox belongs to"
+          name:
+            message: "Enter a name to use for the development sandbox: "
+            errors:
+              invalidName: "You entered an invalid name. Please try again."
+            selectAccountName: "Select the sandbox account you want to delete"
+            selectParentAccountName: "Select the account that the sandbox belongs to"
+          type:
+            message: "What type of sandbox would you like to create?"
+            developer: "Development sandbox (Isolated environment for developers)"
+            standard: "Standard sandbox (Testing environment for all Super Admins)"
         uploadPrompt:
           enterDest: "[--dest] Enter the destination path: "
           enterSrc: "[--src] Enter the source path: "

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -1077,6 +1077,8 @@ en:
             message: "Name your sandbox"
             errors:
               invalidName: "You entered an invalid name. Please try again."
+              nameRequired: "The name may not be blank. Please try again."
+              accountNameExists: "Account name \"{{ name }}\" already exists, please enter a different name."
             selectAccountName: "Select the sandbox account you want to delete"
             selectParentAccountName: "Select the account that the sandbox belongs to"
           type:

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -1101,8 +1101,6 @@ en:
             fail: "Failed to fetch sync updates. View the sync status at: {{ url }}"
             succeed: "Sandbox sync complete."
           failure:
-              \n- Run {{#bold}}hs auth{{/bold}} to connect that account to your terminal, then try again.
-              \n- Run {{#bold}}hs accounts use{{/bold}} to change your default account, if you want to sync to a different sandbox. Then try again.\n"
             missingScopes: "Couldn’t run the sync because there are scopes missing in your production account. To update scopes, deactivate your current personal access key for {{#bold}}{{ accountName }}{{/bold}}, and generate a new one. Then run `hs auth` to update the CLI with the new key."
             syncInProgress: "Couldn’t run the sync because there’s another sync in progress. Wait for the current sync to finish and then try again. To check the sync status, visit the sync activity log: {{ url }}."
             notSuperAdmin: "Couldn't run the sync because you are not a super admin in {{ account }}. Ask the account owner for super admin access to the sandbox."

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -642,7 +642,7 @@ en:
           create:
             describe: "Create a sandbox account"
             examples:
-              default: "Creates a sandbox account named MySandboxAccount."
+              default: "Creates a standard sandbox account named MySandboxAccount."
               force: "Skips all confirmation prompts when creating a sandbox account."
             debug:
               error: "Error creating sandbox:"

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -641,7 +641,6 @@ en:
         subcommands:
           create:
             describe: "Create a sandbox account"
-            sandboxLimitation: "The CLI only supports creation of development sandboxes at this time."
             examples:
               default: "Creates a sandbox account named MySandboxAccount."
             debug:
@@ -654,23 +653,40 @@ en:
               type:
                 describe: "Type of sandbox to create (standard | development)"
             loading:
-              add: "Creating development sandbox {{#bold}}{{ sandboxName }}{{/bold}}"
-              fail: "Failed to create a development sandbox {{#bold}}{{ sandboxName }}{{/bold}}."
-              succeed: "Successfully created a development sandbox {{#bold}}{{ name }}{{/bold}} with portalId {{#bold}}{{ sandboxHubId }}{{/bold}}."
+              developer:
+                add: "Creating development sandbox {{#bold}}{{ sandboxName }}{{/bold}}"
+                fail: "Failed to create a development sandbox {{#bold}}{{ sandboxName }}{{/bold}}."
+                succeed: "Successfully created a development sandbox {{#bold}}{{ name }}{{/bold}} with portalId {{#bold}}{{ sandboxHubId }}{{/bold}}."
+              standard:
+                add: "Creating standard sandbox {{#bold}}{{ sandboxName }}{{/bold}}"
+                fail: "Failed to create a standard sandbox {{#bold}}{{ sandboxName }}{{/bold}}."
+                succeed: "Successfully created a standard sandbox {{#bold}}{{ name }}{{/bold}} with portalId {{#bold}}{{ sandboxHubId }}{{/bold}}."
             success:
               configFileUpdated: "{{ configFilename }} updated with {{ authMethod }} for account {{ account }}."
             failure:
-              creatingWithinSandbox: "Development sandboxes must be created from a production account. You’re using a {{ sandboxType }} sandbox right now. Run {{#bold}}hs auth{{/bold}} to connect a production account or {{#bold}}hs accounts use{{/bold}} to switch to your production account, then try again."
+              creatingWithinSandbox: "Sandboxes must be created from a production account. You’re using a {{ sandboxType }} sandbox right now. Run {{#bold}}hs auth{{/bold}} to connect a production account or {{#bold}}hs accounts use{{/bold}} to switch to your production account, then try again."
               limit:
-                one: "{{#bold}}{{ accountName }}{{/bold}} reached the limit of {{ limit }} development sandbox per account. View sandbox details at {{ devSandboxesLink }}. To connect a sandbox to your HubSpot CLI, run {{#bold}}hs auth{{/bold}} and follow the prompts."
-                other: "{{#bold}}{{ accountName }}{{/bold}} reached the limit of {{ limit }} development sandboxes per account. View sandbox details at {{ devSandboxesLink }}. To connect a sandbox to your HubSpot CLI, run {{#bold}}hs auth{{/bold}} and follow the prompts."
+                developer:
+                  one: "{{#bold}}{{ accountName }}{{/bold}} reached the limit of {{ limit }} development sandbox per account. View sandbox details at {{ link }}. To connect a sandbox to your HubSpot CLI, run {{#bold}}hs auth{{/bold}} and follow the prompts."
+                other: "{{#bold}}{{ accountName }}{{/bold}} reached the limit of {{ limit }} development sandboxes per account. View sandbox details at {{ link }}. To connect a sandbox to your HubSpot CLI, run {{#bold}}hs auth{{/bold}} and follow the prompts."
+                standard:
+                  one: "{{#bold}}{{ accountName }}{{/bold}} reached the limit of {{ limit }} standard sandbox per account. View sandbox details at {{ link }}. To connect a sandbox to your HubSpot CLI, run {{#bold}}hs auth{{/bold}} and follow the prompts."
+                  other: "{{#bold}}{{ accountName }}{{/bold}} reached the limit of {{ limit }} standard sandboxes per account. View sandbox details at {{ link }}. To connect a sandbox to your HubSpot CLI, run {{#bold}}hs auth{{/bold}} and follow the prompts."
               alreadyInConfig:
-                one: "{{#bold}}{{ accountName }}{{/bold}} reached the limit of {{ limit }} development sandbox per account.
-                \n- To use an existing development sandbox, run {{#bold}}hs accounts use{{/bold}}.
-                \n- To delete an existing sandbox, run {{#bold}}hs sandbox delete{{/bold}}."
-                other: "{{#bold}}{{ accountName }}{{/bold}} reached the limit of {{ limit }} development sandboxes per account.
-                \n- To use an existing development sandbox, run {{#bold}}hs accounts use{{/bold}}.
-                \n- To delete an existing sandbox, run {{#bold}}hs sandbox delete{{/bold}}."
+                developer:
+                  one: "{{#bold}}{{ accountName }}{{/bold}} reached the limit of {{ limit }} development sandbox per account.
+                  \n- To use an existing development sandbox, run {{#bold}}hs accounts use{{/bold}}.
+                  \n- To delete an existing sandbox, run {{#bold}}hs sandbox delete{{/bold}}."
+                  other: "{{#bold}}{{ accountName }}{{/bold}} reached the limit of {{ limit }} development sandboxes per account.
+                  \n- To use an existing development sandbox, run {{#bold}}hs accounts use{{/bold}}.
+                  \n- To delete an existing sandbox, run {{#bold}}hs sandbox delete{{/bold}}."
+                standard:
+                  one: "{{#bold}}{{ accountName }}{{/bold}} reached the limit of {{ limit }} standard sandbox per account.
+                  \n- To use an existing standard sandbox, run {{#bold}}hs accounts use{{/bold}}.
+                  \n- To delete an existing sandbox, run {{#bold}}hs sandbox delete{{/bold}}."
+                  other: "{{#bold}}{{ accountName }}{{/bold}} reached the limit of {{ limit }} standard sandboxes per account.
+                  \n- To use an existing standard sandbox, run {{#bold}}hs accounts use{{/bold}}.
+                  \n- To delete an existing sandbox, run {{#bold}}hs sandbox delete{{/bold}}."
               scopes:
                 message: "The personal access key you provided doesn't include sandbox permissions."
                 instructions: "To update CLI permissions for \"{{ accountName }}\":
@@ -1058,7 +1074,7 @@ en:
             invalidValue: "You entered an invalid value. Please try again."
         sandboxesPrompt:
           name:
-            message: "Enter a name to use for the development sandbox: "
+            message: "Name your sandbox"
             errors:
               invalidName: "You entered an invalid name. Please try again."
             selectAccountName: "Select the sandbox account you want to delete"

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -668,7 +668,9 @@ en:
               optionMissing:
                 type: "Invalid or missing sandbox --type option in command. Please try again."
                 name: "Invalid or missing sandbox --name option in command. Please try again."
-              creatingWithinSandbox: "Sandboxes must be created from a production account. You’re using a {{ sandboxType }} sandbox right now. Run {{#bold}}hs auth{{/bold}} to connect a production account or {{#bold}}hs accounts use{{/bold}} to switch to your production account, then try again."
+              creatingWithinSandbox: "Sandboxes must be created from a production account. Your current default account {{#bold}}{{ sandboxName }}{{/bold}} is a {{ sandboxType }} sandbox.
+                \n- Run {{#bold}}hs accounts use{{/bold}} to switch to your default account to your production account.
+                \n- Run {{#bold}}hs auth{{/bold}} to connect a production account to the HubSpot CLI.\n"
               limit:
                 developer:
                   one: "{{#bold}}{{ accountName }}{{/bold}} reached the limit of {{ limit }} development sandbox per account. View sandbox details at {{ link }}. To connect a sandbox to your HubSpot CLI, run {{#bold}}hs auth{{/bold}} and follow the prompts."

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -710,7 +710,8 @@ en:
               force: "Skips all confirmation prompts when initiating a sync."
             info:
               developmentSandbox: "This will sync CRM object definitions."
-              standardSandbox: "This will sync all supported assets. To sync only specific assets, follow this link: {{#bold}}{{ url }}{{/bold}}"
+              standardSandbox: "This will sync all supported assets.
+                \nTo sync only specific assets, follow this link: {{#bold}}{{ url }}{{/bold}}"
               sync: "\nSync direction:
                 \n- Target sandbox: {{#cyan}}{{#bold}}{{ sandboxName }}{{/bold}}{{/cyan}}
                 \n- Source account: {{#bold}}{{ parentAccountName }}{{/bold}}
@@ -723,6 +724,8 @@ en:
             confirm:
               developmentSandbox: "Sync CRM object definitions to {{#cyan}}{{#bold}}{{ sandboxName }}{{/bold}}{{/cyan}} from {{#bold}}{{ parentAccountName }}{{/bold}}?"
               standardSandbox: "Sync all supported assets to {{#cyan}}{{#bold}}{{ sandboxName }}{{/bold}}{{/cyan}} from {{#bold}}{{ parentAccountName }}{{/bold}}?"
+              standardSandboxCreateFlow: "Sync all supported assets to {{#cyan}}{{#bold}}{{ sandboxName }}{{/bold}}{{/cyan}} from {{#bold}}{{ parentAccountName }}{{/bold}}? Syncing may take some time"
+              standardSandboxCreateFlowReconfirm: "Confirm the sync of all supported assets to {{#cyan}}{{#bold}}{{ sandboxName }}{{/bold}}{{/cyan}} from {{#bold}}{{ parentAccountName }}{{/bold}}?"
             loading:
               startSync: "Initiating sync..."
               fail: "Failed to sync sandbox."

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -945,6 +945,15 @@ en:
             projectUploadCommand:
               command: "hs project upload"
               message: "Run {{ command }} to upload your project to HubSpot and trigger builds"
+            projectDevCommand:
+              command: "hs project dev"
+              message: "Run {{ command }} to start testing your project locally."
+            sandboxSyncDevelopmentCommand:
+              command: "hs sandbox sync"
+              message: "Run {{ command }} to to update CRM object definitions in your sandbox."
+            sandboxSyncStandardCommand:
+              command: "hs sandbox sync"
+              message: "Run {{ command }} to to update all supported assets to your sandbox from production."
       commonOpts:
         options:
           portal:

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -643,6 +643,7 @@ en:
             describe: "Create a sandbox account"
             examples:
               default: "Creates a sandbox account named MySandboxAccount."
+              force: "Skips all confirmation prompts when creating a sandbox account."
             debug:
               error: "Error creating sandbox:"
             info:
@@ -664,6 +665,9 @@ en:
             success:
               configFileUpdated: "{{ configFilename }} updated with {{ authMethod }} for account {{ account }}."
             failure:
+              optionMissing:
+                type: "Invalid or missing sandbox --type option in command. Please try again."
+                name: "Invalid or missing sandbox --name option in command. Please try again."
               creatingWithinSandbox: "Sandboxes must be created from a production account. You’re using a {{ sandboxType }} sandbox right now. Run {{#bold}}hs auth{{/bold}} to connect a production account or {{#bold}}hs accounts use{{/bold}} to switch to your production account, then try again."
               limit:
                 developer:

--- a/packages/cli-lib/sandboxes.js
+++ b/packages/cli-lib/sandboxes.js
@@ -9,11 +9,11 @@ const {
   fetchTypes: _fetchTypes,
 } = require('./api/sandboxes-sync');
 
-async function createSandbox(accountId, name) {
+async function createSandbox(accountId, name, type) {
   let resp;
 
   try {
-    resp = await _createSandbox(accountId, name);
+    resp = await _createSandbox(accountId, name, type);
   } catch (err) {
     throw err;
   }

--- a/packages/cli/commands/accounts/list.js
+++ b/packages/cli/commands/accounts/list.js
@@ -12,7 +12,7 @@ const {
 } = require('../../lib/commonOpts');
 const { trackCommandUsage } = require('../../lib/usageTracking');
 const { loadAndValidateOptions } = require('../../lib/validation');
-const { getSandboxType } = require('../../lib/sandboxes');
+const { getSandboxTypeAsString } = require('../../lib/sandboxes');
 const { i18n } = require('@hubspot/cli-lib/lib/lang');
 
 const i18nKey = 'cli.commands.accounts.subcommands.list';
@@ -58,7 +58,7 @@ const getPortalData = mappedPortalData => {
         portalData.push([portal.name, portal.portalId, portal.authType]);
       } else {
         portalData.push([
-          `↳ ${portal.name} [${getSandboxType(
+          `↳ ${portal.name} [${getSandboxTypeAsString(
             portal.sandboxAccountType
           )} sandbox]`,
           portal.portalId,

--- a/packages/cli/commands/sandbox/create.js
+++ b/packages/cli/commands/sandbox/create.js
@@ -16,7 +16,7 @@ const { sandboxTypeMap, DEVELOPER_SANDBOX } = require('../../lib/sandboxes');
 
 const i18nKey = 'cli.commands.sandbox.subcommands.create';
 
-exports.command = 'create [--name]';
+exports.command = 'create [--name] [--type]';
 exports.describe = i18n(`${i18nKey}.describe`);
 
 exports.handler = async options => {

--- a/packages/cli/commands/sandbox/create.js
+++ b/packages/cli/commands/sandbox/create.js
@@ -7,12 +7,12 @@ const {
 } = require('../../lib/commonOpts');
 const { loadAndValidateOptions } = require('../../lib/validation');
 const { i18n } = require('@hubspot/cli-lib/lib/lang');
-const { ENVIRONMENTS } = require('@hubspot/cli-lib/lib/constants');
 const { EXIT_CODES } = require('../../lib/enums/exitCodes');
-const { getAccountConfig } = require('@hubspot/cli-lib');
+const { getAccountConfig, getEnv } = require('@hubspot/cli-lib');
 const { buildSandbox } = require('../../lib/sandbox-create');
 const { uiFeatureHighlight } = require('../../lib/ui');
 const { sandboxTypeMap, DEVELOPER_SANDBOX } = require('../../lib/sandboxes');
+const { getValidEnv } = require('@hubspot/cli-lib/lib/environment');
 
 const i18nKey = 'cli.commands.sandbox.subcommands.create';
 
@@ -25,7 +25,7 @@ exports.handler = async options => {
   const { name, type, force } = options;
   const accountId = getAccountId(options);
   const accountConfig = getAccountConfig(accountId);
-  const env = options.qa ? ENVIRONMENTS.QA : ENVIRONMENTS.PROD;
+  const env = getValidEnv(getEnv(accountId));
 
   try {
     const { result } = await buildSandbox({

--- a/packages/cli/commands/sandbox/create.js
+++ b/packages/cli/commands/sandbox/create.js
@@ -43,6 +43,7 @@ exports.handler = async options => {
         ? 'sandboxSyncDevelopmentCommand'
         : 'sandboxSyncStandardCommand',
     ]);
+    process.exit(EXIT_CODES.SUCCESS);
   } catch (error) {
     // Errors are logged in buildSandbox
     process.exit(EXIT_CODES.ERROR);

--- a/packages/cli/commands/sandbox/create.js
+++ b/packages/cli/commands/sandbox/create.js
@@ -38,7 +38,8 @@ exports.handler = async options => {
 
     const sandboxType = sandboxTypeMap[result.sandbox.type];
     uiFeatureHighlight([
-      'projectDevCommand',
+      // 'projectDevCommand',
+      'projectUploadCommand',
       sandboxType === DEVELOPER_SANDBOX
         ? 'sandboxSyncDevelopmentCommand'
         : 'sandboxSyncStandardCommand',

--- a/packages/cli/commands/sandbox/create.js
+++ b/packages/cli/commands/sandbox/create.js
@@ -9,14 +9,10 @@ const { loadAndValidateOptions } = require('../../lib/validation');
 const { i18n } = require('@hubspot/cli-lib/lib/lang');
 const { ENVIRONMENTS } = require('@hubspot/cli-lib/lib/constants');
 const { EXIT_CODES } = require('../../lib/enums/exitCodes');
-const { getAccountConfig, getConfig } = require('@hubspot/cli-lib');
+const { getAccountConfig } = require('@hubspot/cli-lib');
 const { buildSandbox } = require('../../lib/sandbox-create');
-const { logger } = require('@hubspot/cli-lib/logger');
-const {
-  setAsDefaultAccountPrompt,
-} = require('../../lib/prompts/setAsDefaultAccountPrompt');
 const { uiFeatureHighlight } = require('../../lib/ui');
-const { sandboxTypeMap } = require('../../lib/sandboxes');
+const { sandboxTypeMap, DEVELOPER_SANDBOX } = require('../../lib/sandboxes');
 
 const i18nKey = 'cli.commands.sandbox.subcommands.create';
 
@@ -32,37 +28,17 @@ exports.handler = async options => {
   const env = options.qa ? ENVIRONMENTS.QA : ENVIRONMENTS.PROD;
 
   try {
-    const { result, sandboxConfigName } = await buildSandbox({
+    const { result } = await buildSandbox({
       name,
       type,
       accountConfig,
       env,
     });
 
-    const setAsDefault = await setAsDefaultAccountPrompt(sandboxConfigName);
-
-    logger.log('');
-    if (setAsDefault) {
-      logger.success(
-        i18n(`cli.lib.prompts.setAsDefaultAccountPrompt.setAsDefaultAccount`, {
-          accountName: sandboxConfigName,
-        })
-      );
-    } else {
-      const config = getConfig();
-      logger.info(
-        i18n(
-          `cli.lib.prompts.setAsDefaultAccountPrompt.keepingCurrentDefault`,
-          {
-            accountName: config.defaultPortal,
-          }
-        )
-      );
-    }
     const sandboxType = sandboxTypeMap[result.sandbox.type];
     uiFeatureHighlight([
       'projectDevCommand',
-      sandboxType === 'development'
+      sandboxType === DEVELOPER_SANDBOX
         ? 'sandboxSyncDevelopmentCommand'
         : 'sandboxSyncStandardCommand',
     ]);

--- a/packages/cli/commands/sandbox/create.js
+++ b/packages/cli/commands/sandbox/create.js
@@ -68,7 +68,7 @@ exports.builder = yargs => {
 
   yargs.example([
     [
-      '$0 sandbox create --name=MySandboxAccount',
+      '$0 sandbox create --name=MySandboxAccount --type=STANDARD',
       i18n(`${i18nKey}.examples.default`),
     ],
   ]);

--- a/packages/cli/commands/sandbox/create.js
+++ b/packages/cli/commands/sandbox/create.js
@@ -22,7 +22,7 @@ exports.describe = i18n(`${i18nKey}.describe`);
 exports.handler = async options => {
   await loadAndValidateOptions(options);
 
-  const { name, type } = options;
+  const { name, type, force } = options;
   const accountId = getAccountId(options);
   const accountConfig = getAccountConfig(accountId);
   const env = options.qa ? ENVIRONMENTS.QA : ENVIRONMENTS.PROD;
@@ -33,6 +33,7 @@ exports.handler = async options => {
       type,
       accountConfig,
       env,
+      force,
     });
 
     const sandboxType = sandboxTypeMap[result.sandbox.type];
@@ -49,6 +50,11 @@ exports.handler = async options => {
 };
 
 exports.builder = yargs => {
+  yargs.option('f', {
+    type: 'boolean',
+    alias: 'force',
+    describe: i18n(`${i18nKey}.examples.force`),
+  });
   yargs.option('name', {
     describe: i18n(`${i18nKey}.options.name.describe`),
     type: 'string',

--- a/packages/cli/commands/sandbox/create.js
+++ b/packages/cli/commands/sandbox/create.js
@@ -5,31 +5,12 @@ const {
   addUseEnvironmentOptions,
   addTestingOptions,
 } = require('../../lib/commonOpts');
-const { trackCommandUsage } = require('../../lib/usageTracking');
-const { logger } = require('@hubspot/cli-lib/logger');
-const Spinnies = require('spinnies');
-const { createSandbox } = require('@hubspot/cli-lib/sandboxes');
 const { loadAndValidateOptions } = require('../../lib/validation');
-const { createSandboxPrompt } = require('../../lib/prompts/sandboxesPrompt');
-const {
-  getSandboxType,
-  sandboxCreatePersonalAccessKeyFlow,
-  getHasDevelopmentSandboxes,
-  getDevSandboxLimit,
-} = require('../../lib/sandboxes');
 const { i18n } = require('@hubspot/cli-lib/lib/lang');
-const { logErrorInstance } = require('@hubspot/cli-lib/errorHandlers');
-const {
-  debugErrorAndContext,
-} = require('@hubspot/cli-lib/errorHandlers/standardErrors');
 const { ENVIRONMENTS } = require('@hubspot/cli-lib/lib/constants');
 const { EXIT_CODES } = require('../../lib/enums/exitCodes');
-const { getAccountConfig, getEnv } = require('@hubspot/cli-lib');
-const { getHubSpotWebsiteOrigin } = require('@hubspot/cli-lib/lib/urls');
-const {
-  isMissingScopeError,
-  isSpecifiedError,
-} = require('@hubspot/cli-lib/errorHandlers/apiErrors');
+const { getAccountConfig } = require('@hubspot/cli-lib');
+const { buildSandbox } = require('../../lib/sandbox-create');
 
 const i18nKey = 'cli.commands.sandbox.subcommands.create';
 
@@ -39,136 +20,20 @@ exports.describe = i18n(`${i18nKey}.describe`);
 exports.handler = async options => {
   await loadAndValidateOptions(options);
 
-  const { name } = options;
+  const { name, type } = options;
   const accountId = getAccountId(options);
   const accountConfig = getAccountConfig(accountId);
   const env = options.qa ? ENVIRONMENTS.QA : ENVIRONMENTS.PROD;
-  const spinnies = new Spinnies({
-    succeedColor: 'white',
-  });
-
-  trackCommandUsage('sandbox-create', null, accountId);
-
-  if (
-    accountConfig.sandboxAccountType &&
-    accountConfig.sandboxAccountType !== null
-  ) {
-    trackCommandUsage('sandbox-create', { successful: false }, accountId);
-
-    logger.error(
-      i18n(`${i18nKey}.failure.creatingWithinSandbox`, {
-        sandboxType: getSandboxType(accountConfig.sandboxAccountType),
-      })
-    );
-
-    process.exit(EXIT_CODES.ERROR);
-  }
-
-  let namePrompt;
-
-  logger.log(i18n(`${i18nKey}.sandboxLimitation`));
-  logger.log('');
-
-  if (!name) {
-    namePrompt = await createSandboxPrompt();
-  }
-
-  const sandboxName = name || namePrompt.name;
-
-  let result;
 
   try {
-    spinnies.add('sandboxCreate', {
-      text: i18n(`${i18nKey}.loading.add`, {
-        sandboxName,
-      }),
-    });
-
-    result = await createSandbox(accountId, sandboxName);
-
-    logger.log('');
-    spinnies.succeed('sandboxCreate', {
-      text: i18n(`${i18nKey}.loading.succeed`, {
-        name: result.name,
-        sandboxHubId: result.sandboxHubId,
-      }),
-    });
-  } catch (err) {
-    debugErrorAndContext(err);
-
-    trackCommandUsage('sandbox-create', { successful: false }, accountId);
-
-    spinnies.fail('sandboxCreate', {
-      text: i18n(`${i18nKey}.loading.fail`, {
-        sandboxName,
-      }),
-    });
-
-    if (isMissingScopeError(err)) {
-      logger.error(
-        i18n(`${i18nKey}.failure.scopes.message`, {
-          accountName: accountConfig.name || accountId,
-        })
-      );
-      const websiteOrigin = getHubSpotWebsiteOrigin(env);
-      const url = `${websiteOrigin}/personal-access-key/${accountId}`;
-      logger.info(
-        i18n(`${i18nKey}.failure.scopes.instructions`, {
-          accountName: accountConfig.name || accountId,
-          url,
-        })
-      );
-    } else if (
-      isSpecifiedError(
-        err,
-        400,
-        'VALIDATION_ERROR',
-        'SandboxErrors.NUM_DEVELOPMENT_SANDBOXES_LIMIT_EXCEEDED_ERROR'
-      ) &&
-      err.error &&
-      err.error.message
-    ) {
-      logger.log('');
-      const devSandboxLimit = getDevSandboxLimit(err.error);
-      const plural = devSandboxLimit !== 1;
-      const hasDevelopmentSandboxes = getHasDevelopmentSandboxes(accountConfig);
-      if (hasDevelopmentSandboxes) {
-        logger.error(
-          i18n(
-            `${i18nKey}.failure.alreadyInConfig.${plural ? 'other' : 'one'}`,
-            {
-              accountName: accountConfig.name || accountId,
-              limit: devSandboxLimit,
-            }
-          )
-        );
-      } else {
-        const baseUrl = getHubSpotWebsiteOrigin(
-          getEnv(accountId) === 'qa' ? ENVIRONMENTS.QA : ENVIRONMENTS.PROD
-        );
-        logger.error(
-          i18n(`${i18nKey}.failure.limit.${plural ? 'other' : 'one'}`, {
-            accountName: accountConfig.name || accountId,
-            limit: devSandboxLimit,
-            devSandboxesLink: `${baseUrl}/sandboxes-developer/${accountId}/development`,
-          })
-        );
-      }
-      logger.log('');
-    } else {
-      logErrorInstance(err);
-    }
-    process.exit(EXIT_CODES.ERROR);
-  }
-  try {
-    await sandboxCreatePersonalAccessKeyFlow(
+    await buildSandbox({
+      name,
+      type,
+      accountConfig,
       env,
-      result.sandboxHubId,
-      result.name
-    );
-    process.exit(EXIT_CODES.SUCCESS);
-  } catch (err) {
-    logErrorInstance(err);
+    });
+  } catch (error) {
+    // Errors are logged in buildSandbox
     process.exit(EXIT_CODES.ERROR);
   }
 };
@@ -176,6 +41,10 @@ exports.handler = async options => {
 exports.builder = yargs => {
   yargs.option('name', {
     describe: i18n(`${i18nKey}.options.name.describe`),
+    type: 'string',
+  });
+  yargs.option('type', {
+    describe: i18n(`${i18nKey}.options.type.describe`),
     type: 'string',
   });
 

--- a/packages/cli/commands/sandbox/delete.js
+++ b/packages/cli/commands/sandbox/delete.js
@@ -117,11 +117,12 @@ exports.handler = async options => {
   );
 
   if (isDefaultAccount) {
-    logger.log(
+    logger.info(
       i18n(`${i18nKey}.defaultAccountWarning`, {
         account: getAccountName(accountConfig),
       })
     );
+    logger.log('');
   }
 
   try {

--- a/packages/cli/commands/sandbox/delete.js
+++ b/packages/cli/commands/sandbox/delete.js
@@ -26,12 +26,12 @@ const {
 const { EXIT_CODES } = require('../../lib/enums/exitCodes');
 const { promptUser } = require('../../lib/prompts/promptUtils');
 const { getHubSpotWebsiteOrigin } = require('@hubspot/cli-lib/lib/urls');
-const { ENVIRONMENTS } = require('@hubspot/cli-lib/lib/constants');
 const {
   isSpecifiedError,
 } = require('@hubspot/cli-lib/errorHandlers/apiErrors');
 const { HubSpotAuthError } = require('@hubspot/cli-lib/lib/models/Errors');
 const { getAccountName } = require('../../lib/sandboxes');
+const { getValidEnv } = require('@hubspot/cli-lib/lib/environment');
 
 const i18nKey = 'cli.commands.sandbox.subcommands.delete';
 
@@ -71,7 +71,7 @@ exports.handler = async options => {
   trackCommandUsage('sandbox-delete', null, sandboxAccountId);
 
   const baseUrl = getHubSpotWebsiteOrigin(
-    getEnv(sandboxAccountId) === 'qa' ? ENVIRONMENTS.QA : ENVIRONMENTS.PROD
+    getValidEnv(getEnv(sandboxAccountId))
   );
 
   let parentAccountId;

--- a/packages/cli/commands/sandbox/sync.js
+++ b/packages/cli/commands/sandbox/sync.js
@@ -9,7 +9,6 @@ const { trackCommandUsage } = require('../../lib/usageTracking');
 const { logger } = require('@hubspot/cli-lib/logger');
 const { loadAndValidateOptions } = require('../../lib/validation');
 const { i18n } = require('@hubspot/cli-lib/lib/lang');
-const { ENVIRONMENTS } = require('@hubspot/cli-lib/lib/constants');
 const { EXIT_CODES } = require('../../lib/enums/exitCodes');
 const { getAccountConfig, getEnv } = require('@hubspot/cli-lib');
 const { getHubSpotWebsiteOrigin } = require('@hubspot/cli-lib/lib/urls');
@@ -22,6 +21,7 @@ const {
   STANDARD_SANDBOX,
 } = require('../../lib/sandboxes');
 const { syncSandbox } = require('../../lib/sandbox-sync');
+const { getValidEnv } = require('@hubspot/cli-lib/lib/environment');
 
 const i18nKey = 'cli.commands.sandbox.subcommands.sync';
 
@@ -34,7 +34,7 @@ exports.handler = async options => {
   const { force } = options; // For scripting purposes
   const accountId = getAccountId(options);
   const accountConfig = getAccountConfig(accountId);
-  const env = getEnv(accountId) === 'qa' ? ENVIRONMENTS.QA : ENVIRONMENTS.PROD;
+  const env = getValidEnv(getEnv(accountId));
 
   trackCommandUsage('sandbox-sync', null, accountId);
 

--- a/packages/cli/commands/sandbox/sync.js
+++ b/packages/cli/commands/sandbox/sync.js
@@ -7,26 +7,16 @@ const {
 } = require('../../lib/commonOpts');
 const { trackCommandUsage } = require('../../lib/usageTracking');
 const { logger } = require('@hubspot/cli-lib/logger');
-const Spinnies = require('spinnies');
-const { initiateSync } = require('@hubspot/cli-lib/sandboxes');
 const { loadAndValidateOptions } = require('../../lib/validation');
 const { i18n } = require('@hubspot/cli-lib/lib/lang');
-const { logErrorInstance } = require('@hubspot/cli-lib/errorHandlers');
 const { ENVIRONMENTS } = require('@hubspot/cli-lib/lib/constants');
 const { EXIT_CODES } = require('../../lib/enums/exitCodes');
 const { getAccountConfig, getEnv } = require('@hubspot/cli-lib');
 const { getHubSpotWebsiteOrigin } = require('@hubspot/cli-lib/lib/urls');
 const { promptUser } = require('../../lib/prompts/promptUtils');
 const { uiLine } = require('../../lib/ui');
-const {
-  getAccountName,
-  getAvailableSyncTypes,
-  pollSyncTaskStatus,
-} = require('../../lib/sandboxes');
-const {
-  isMissingScopeError,
-  isSpecifiedError,
-} = require('@hubspot/cli-lib/errorHandlers/apiErrors');
+const { getAccountName } = require('../../lib/sandboxes');
+const { syncSandbox } = require('../../lib/sandbox-sync');
 
 const i18nKey = 'cli.commands.sandbox.subcommands.sync';
 
@@ -39,9 +29,7 @@ exports.handler = async options => {
   const { force } = options; // For scripting purposes
   const accountId = getAccountId(options);
   const accountConfig = getAccountConfig(accountId);
-  const spinnies = new Spinnies({
-    succeedColor: 'white',
-  });
+  const env = getEnv(accountId) === 'qa' ? ENVIRONMENTS.QA : ENVIRONMENTS.PROD;
 
   trackCommandUsage('sandbox-sync', null, accountId);
 
@@ -51,10 +39,8 @@ exports.handler = async options => {
     accountConfig.sandboxAccountType === undefined ||
     accountConfig.sandboxAccountType === null
   ) {
-    trackCommandUsage('sandbox-sync', { successful: false }, accountId);
-
     logger.error(i18n(`${i18nKey}.failure.notSandbox`));
-
+    trackCommandUsage('sandbox-sync', { successful: false }, accountId);
     process.exit(EXIT_CODES.ERROR);
   }
 
@@ -67,6 +53,7 @@ exports.handler = async options => {
         sandboxName: getAccountName(accountConfig),
       })
     );
+    trackCommandUsage('sandbox-sync', { successful: false }, accountId);
     process.exit(EXIT_CODES.ERROR);
   }
 
@@ -100,12 +87,13 @@ exports.handler = async options => {
         },
       ]);
       if (!confirmed) {
+        trackCommandUsage('sandbox-sync', { successful: false }, accountId);
         process.exit(EXIT_CODES.SUCCESS);
       }
     }
   } else if (isStandardSandbox) {
     const standardSyncUrl = `${getHubSpotWebsiteOrigin(
-      getEnv(accountId) === 'qa' ? ENVIRONMENTS.QA : ENVIRONMENTS.PROD
+      env
     )}/sandboxes-developer/${parentAccountId}/sync?step=select_sync_path&id=${parentAccountId}_${accountId}`;
 
     logger.log(
@@ -137,147 +125,26 @@ exports.handler = async options => {
         },
       ]);
       if (!confirmed) {
+        trackCommandUsage('sandbox-sync', { successful: false }, accountId);
         process.exit(EXIT_CODES.SUCCESS);
       }
     }
   } else {
     logger.error('Sync must be run in a sandbox account.');
-    process.exit(EXIT_CODES.ERROR);
-  }
-
-  let initiateSyncResponse;
-
-  const baseUrl = getHubSpotWebsiteOrigin(
-    getEnv(accountId) === 'qa' ? ENVIRONMENTS.QA : ENVIRONMENTS.PROD
-  );
-  const syncStatusUrl = `${baseUrl}/sandboxes-developer/${parentAccountId}/${
-    isDevelopmentSandbox ? 'development' : 'standard'
-  }`;
-
-  try {
-    logger.log('');
-    spinnies.add('sandboxSync', {
-      text: i18n(`${i18nKey}.loading.startSync`),
-    });
-
-    // Fetches sync types based on default account. Parent account required for fetch
-    const tasks = await getAvailableSyncTypes(
-      parentAccountConfig,
-      accountConfig
-    );
-
-    initiateSyncResponse = await initiateSync(
-      parentAccountId,
-      accountId,
-      tasks,
-      accountId
-    );
-
-    logger.log(i18n(`${i18nKey}.info.earlyExit`));
-    logger.log('');
-    spinnies.succeed('sandboxSync', {
-      text: i18n(`${i18nKey}.loading.succeed`),
-    });
-  } catch (err) {
     trackCommandUsage('sandbox-sync', { successful: false }, accountId);
-
-    spinnies.fail('sandboxSync', {
-      text: i18n(`${i18nKey}.loading.fail`),
-    });
-
-    logger.log('');
-    if (isMissingScopeError(err)) {
-      logger.error(
-        i18n(`${i18nKey}.failure.missingScopes`, {
-          accountName: getAccountName(parentAccountConfig),
-        })
-      );
-    } else if (
-      isSpecifiedError(
-        err,
-        429,
-        'RATE_LIMITS',
-        'sandboxes-sync-api.SYNC_IN_PROGRESS'
-      )
-    ) {
-      logger.error(
-        i18n(`${i18nKey}.failure.syncInProgress`, {
-          url: `${baseUrl}/sandboxes-developer/${parentAccountId}/syncactivitylog`,
-        })
-      );
-    } else if (
-      isSpecifiedError(
-        err,
-        403,
-        'BANNED',
-        'sandboxes-sync-api.SYNC_NOT_ALLOWED_INVALID_USERID'
-      )
-    ) {
-      // This will only trigger if a user is not a super admin of the target account.
-      logger.error(
-        i18n(`${i18nKey}.failure.notSuperAdmin`, {
-          account: getAccountName(accountConfig),
-        })
-      );
-    } else if (
-      isSpecifiedError(
-        err,
-        404,
-        'OBJECT_NOT_FOUND',
-        'SandboxErrors.SANDBOX_NOT_FOUND'
-      )
-    ) {
-      logger.error(
-        i18n(`${i18nKey}.failure.objectNotFound`, {
-          account: getAccountName(accountConfig),
-        })
-      );
-    } else {
-      logErrorInstance(err);
-    }
-    logger.log('');
-
     process.exit(EXIT_CODES.ERROR);
   }
 
   try {
-    logger.log('');
-    logger.log('Sync progress:');
-    // Poll sync task status to show progress bars
-    await pollSyncTaskStatus(
-      parentAccountId,
-      initiateSyncResponse.id,
-      syncStatusUrl
-    );
-
-    logger.log('');
-    spinnies.add('syncComplete', {
-      text: i18n(`${i18nKey}.polling.syncing`),
+    await syncSandbox({
+      accountConfig,
+      parentAccountConfig,
+      env,
+      allowEarlyTermination: true,
     });
-    spinnies.succeed('syncComplete', {
-      text: i18n(`${i18nKey}.polling.succeed`),
-    });
-    logger.log('');
-    logger.log(
-      i18n(`${i18nKey}.info.syncStatus`, {
-        url: syncStatusUrl,
-      })
-    );
-
     process.exit(EXIT_CODES.SUCCESS);
-  } catch (err) {
-    // If polling fails at this point, we do not track a failed sync since it is running in the background.
-    logErrorInstance(err);
-
-    spinnies.add('syncComplete', {
-      text: i18n(`${i18nKey}.polling.syncing`),
-    });
-    spinnies.fail('syncComplete', {
-      text: i18n(`${i18nKey}.polling.fail`, {
-        url: syncStatusUrl,
-      }),
-    });
-
+  } catch (error) {
+    trackCommandUsage('sandbox-sync', { successful: false }, accountId);
     process.exit(EXIT_CODES.ERROR);
   }
 };

--- a/packages/cli/commands/sandbox/sync.js
+++ b/packages/cli/commands/sandbox/sync.js
@@ -15,7 +15,12 @@ const { getAccountConfig, getEnv } = require('@hubspot/cli-lib');
 const { getHubSpotWebsiteOrigin } = require('@hubspot/cli-lib/lib/urls');
 const { promptUser } = require('../../lib/prompts/promptUtils');
 const { uiLine } = require('../../lib/ui');
-const { getAccountName } = require('../../lib/sandboxes');
+const {
+  getAccountName,
+  sandboxTypeMap,
+  DEVELOPER_SANDBOX,
+  STANDARD_SANDBOX,
+} = require('../../lib/sandboxes');
 const { syncSandbox } = require('../../lib/sandbox-sync');
 
 const i18nKey = 'cli.commands.sandbox.subcommands.sync';
@@ -58,8 +63,10 @@ exports.handler = async options => {
   }
 
   const parentAccountConfig = getAccountConfig(parentAccountId);
-  const isDevelopmentSandbox = accountConfig.sandboxAccountType === 'DEVELOPER';
-  const isStandardSandbox = accountConfig.sandboxAccountType === 'STANDARD';
+  const isDevelopmentSandbox =
+    sandboxTypeMap[accountConfig.sandboxAccountType] === DEVELOPER_SANDBOX;
+  const isStandardSandbox =
+    sandboxTypeMap[accountConfig.sandboxAccountType] === STANDARD_SANDBOX;
 
   if (isDevelopmentSandbox) {
     logger.log(i18n(`${i18nKey}.info.developmentSandbox`));

--- a/packages/cli/lib/CliProgressMultibarManager.js
+++ b/packages/cli/lib/CliProgressMultibarManager.js
@@ -1,0 +1,65 @@
+const cliProgress = require('cli-progress');
+
+class CliProgressMultibarManager {
+  constructor() {
+    this.multibar = null;
+    this.barInstances = {};
+  }
+
+  init(options) {
+    if (!this.multibar) {
+      this.multibar = new cliProgress.MultiBar(
+        {
+          hideCursor: true,
+          format: '[{bar}] {percentage}% | {label}',
+          gracefulExit: true,
+          ...options,
+        },
+        cliProgress.Presets.rect
+      );
+    }
+
+    return {
+      get: this.get.bind(this),
+      create: this.create.bind(this),
+      update: this.update.bind(this),
+      increment: this.increment.bind(this),
+      remove: this.multibar.remove.bind(this.multibar),
+      stop: this.multibar.stop.bind(this.multibar),
+      log: this.multibar.log.bind(this.multibar),
+    };
+  }
+
+  get(barName) {
+    return this.barInstances[barName];
+  }
+
+  create(barName, total = 100, startValue = 0, options = {}) {
+    if (!this.multibar) {
+      return;
+    }
+    if (!this.barInstances[barName]) {
+      this.barInstances[barName] = this.multibar.create(
+        total,
+        startValue,
+        options
+      );
+    }
+  }
+
+  update(barName, value, options = {}) {
+    const barInstance = this.barInstances[barName];
+    if (barInstance) {
+      barInstance.update(value, options);
+    }
+  }
+
+  increment(barName, value, options = {}) {
+    const barInstance = this.barInstances[barName];
+    if (barInstance) {
+      barInstance.increment(value, options);
+    }
+  }
+}
+
+module.exports = new CliProgressMultibarManager();

--- a/packages/cli/lib/CliProgressMultibarManager.js
+++ b/packages/cli/lib/CliProgressMultibarManager.js
@@ -1,4 +1,5 @@
-const cliProgress = require('cli-progress');
+// https://github.com/npkgz/cli-progress/blob/master/README.md
+const ProgressMultibarManager = require('cli-progress');
 
 class CliProgressMultibarManager {
   constructor() {
@@ -8,14 +9,14 @@ class CliProgressMultibarManager {
 
   init(options) {
     if (!this.multibar) {
-      this.multibar = new cliProgress.MultiBar(
+      this.multibar = new ProgressMultibarManager.MultiBar(
         {
           hideCursor: true,
           format: '[{bar}] {percentage}% | {label}',
           gracefulExit: true,
           ...options,
         },
-        cliProgress.Presets.rect
+        ProgressMultibarManager.Presets.rect
       );
     }
 

--- a/packages/cli/lib/prompts/accountsPrompt.js
+++ b/packages/cli/lib/prompts/accountsPrompt.js
@@ -1,12 +1,14 @@
 const { updateDefaultAccount } = require('@hubspot/cli-lib/lib/config');
 const { promptUser } = require('./promptUtils');
 const { i18n } = require('@hubspot/cli-lib/lib/lang');
-const { getSandboxType } = require('../sandboxes');
+const { getSandboxTypeAsString } = require('../sandboxes');
 
 const mapAccountChoices = portals =>
   portals.map(p => {
     const isSandbox = p.sandboxAccountType && p.sandboxAccountType !== null;
-    const sandboxName = `[${getSandboxType(p.sandboxAccountType)} sandbox] `;
+    const sandboxName = `[${getSandboxTypeAsString(
+      p.sandboxAccountType
+    )} sandbox] `;
     return {
       name: `${p.name} ${isSandbox ? sandboxName : ''}(${p.portalId})`,
       value: p.name || p.portalId,

--- a/packages/cli/lib/prompts/sandboxesPrompt.js
+++ b/packages/cli/lib/prompts/sandboxesPrompt.js
@@ -1,6 +1,7 @@
 const { promptUser } = require('./promptUtils');
 const { i18n } = require('@hubspot/cli-lib/lib/lang');
 const { getSandboxTypeAsString } = require('../sandboxes');
+const { accountNameExistsInConfig } = require('@hubspot/cli-lib/lib/config');
 
 const i18nKey = 'cli.lib.prompts.sandboxesPrompt';
 
@@ -37,8 +38,12 @@ const sandboxNamePrompt = () => {
       validate(val) {
         if (typeof val !== 'string') {
           return i18n(`${i18nKey}.name.errors.invalidName`);
+        } else if (!val.length) {
+          return i18n(`${i18nKey}.name.errors.nameRequired`);
         }
-        return true;
+        return accountNameExistsInConfig(val)
+          ? i18n(`${i18nKey}.name.errors.accountNameExists`, { name: val })
+          : true;
       },
       default: 'New sandbox',
     },

--- a/packages/cli/lib/prompts/sandboxesPrompt.js
+++ b/packages/cli/lib/prompts/sandboxesPrompt.js
@@ -1,6 +1,6 @@
 const { promptUser } = require('./promptUtils');
 const { i18n } = require('@hubspot/cli-lib/lib/lang');
-const { getSandboxType } = require('../sandboxes');
+const { getSandboxTypeAsString } = require('../sandboxes');
 
 const i18nKey = 'cli.lib.prompts.sandboxesPrompt';
 
@@ -8,7 +8,9 @@ const mapSandboxAccountChoices = portals =>
   portals
     .filter(p => p.sandboxAccountType && p.sandboxAccountType !== null)
     .map(p => {
-      const sandboxName = `[${getSandboxType(p.sandboxAccountType)} sandbox] `;
+      const sandboxName = `[${getSandboxTypeAsString(
+        p.sandboxAccountType
+      )} sandbox] `;
       return {
         name: `${p.name} ${sandboxName}(${p.portalId})`,
         value: p.name || p.portalId,
@@ -27,18 +29,42 @@ const mapNonSandboxAccountChoices = portals =>
       };
     });
 
-const createSandboxPrompt = () => {
+const sandboxNamePrompt = () => {
   return promptUser([
     {
       name: 'name',
-      message: i18n(`${i18nKey}.enterName`),
+      message: i18n(`${i18nKey}.name.message`),
       validate(val) {
         if (typeof val !== 'string') {
-          return i18n(`${i18nKey}.errors.invalidName`);
+          return i18n(`${i18nKey}.name.errors.invalidName`);
         }
         return true;
       },
       default: 'New sandbox',
+    },
+  ]);
+};
+
+const sandboxTypeChoices = [
+  {
+    name: i18n(`${i18nKey}.type.developer`),
+    value: 'DEVELOPER',
+  },
+  {
+    name: i18n(`${i18nKey}.type.standard`),
+    value: 'STANDARD',
+  },
+];
+
+const sandboxTypePrompt = () => {
+  return promptUser([
+    {
+      name: 'type',
+      message: i18n(`${i18nKey}.type.message`),
+      type: 'list',
+      look: false,
+      choices: sandboxTypeChoices,
+      default: 'DEVELOPER',
     },
   ]);
 };
@@ -55,8 +81,8 @@ const deleteSandboxPrompt = (config, promptParentAccount = false) => {
       name: 'account',
       message: i18n(
         promptParentAccount
-          ? `${i18nKey}.selectParentAccountName`
-          : `${i18nKey}.selectAccountName`
+          ? `${i18nKey}.name.selectParentAccountName`
+          : `${i18nKey}.name.selectAccountName`
       ),
       type: 'list',
       look: false,
@@ -68,7 +94,7 @@ const deleteSandboxPrompt = (config, promptParentAccount = false) => {
 };
 
 module.exports = {
-  createSandboxPrompt,
+  sandboxNamePrompt,
+  sandboxTypePrompt,
   deleteSandboxPrompt,
-  getSandboxType,
 };

--- a/packages/cli/lib/sandbox-create.js
+++ b/packages/cli/lib/sandbox-create.js
@@ -1,0 +1,176 @@
+const Spinnies = require('spinnies');
+const {
+  sandboxNamePrompt,
+  sandboxTypePrompt,
+} = require('./prompts/sandboxesPrompt');
+const {
+  sandboxTypeMap,
+  getDevSandboxLimit,
+  getHasDevelopmentSandboxes,
+  saveSandboxToConfig,
+  sandboxApiTypeMap,
+  getSandboxTypeAsString,
+} = require('./sandboxes');
+const { i18n } = require('@hubspot/cli-lib/lib/lang');
+const { logger } = require('@hubspot/cli-lib/logger');
+const {
+  debugErrorAndContext,
+  logErrorInstance,
+} = require('@hubspot/cli-lib/errorHandlers/standardErrors');
+const { trackCommandUsage } = require('./usageTracking');
+const {
+  isMissingScopeError,
+  isSpecifiedError,
+} = require('@hubspot/cli-lib/errorHandlers/apiErrors');
+const { getHubSpotWebsiteOrigin } = require('@hubspot/cli-lib/lib/urls');
+const { ENVIRONMENTS } = require('@hubspot/cli-lib/lib/constants');
+const { getEnv } = require('@hubspot/cli-lib');
+const { createSandbox } = require('@hubspot/cli-lib/sandboxes');
+
+const i18nKey = 'cli.commands.sandbox.subcommands.create';
+
+/**
+ * @param {String} name - Name of sandbox
+ * @param {String} type - Standard or development sandbox type
+ * @param {Object} accountConfig - Account config of parent portal
+ * @param {String} env - Environment (QA/Prod)
+ */
+const buildSandbox = async ({ name, type, accountConfig, env }) => {
+  const spinnies = new Spinnies({
+    succeedColor: 'white',
+  });
+  const accountId = accountConfig.portalId;
+
+  trackCommandUsage('sandbox-create', null, accountId);
+
+  if (
+    accountConfig.sandboxAccountType &&
+    accountConfig.sandboxAccountType !== null
+  ) {
+    trackCommandUsage('sandbox-create', { successful: false }, accountId);
+
+    logger.error(
+      i18n(`${i18nKey}.failure.creatingWithinSandbox`, {
+        sandboxType: getSandboxTypeAsString(accountConfig.sandboxAccountType),
+      })
+    );
+
+    throw new Error(
+      i18n(`${i18nKey}.failure.creatingWithinSandbox`, {
+        sandboxType: getSandboxTypeAsString(accountConfig.sandboxAccountType),
+      })
+    );
+  }
+
+  let namePrompt;
+  let typePrompt;
+
+  if (!name) {
+    namePrompt = await sandboxNamePrompt();
+  }
+  if ((type && !sandboxTypeMap[type]) || !type) {
+    typePrompt = await sandboxTypePrompt();
+  }
+
+  const sandboxName = name || namePrompt.name;
+  const sandboxType = sandboxTypeMap[type] || sandboxTypeMap[typePrompt.type];
+
+  let result;
+
+  try {
+    spinnies.add('sandboxCreate', {
+      text: i18n(`${i18nKey}.loading.add`, {
+        sandboxName,
+      }),
+    });
+
+    const sandboxApiType = sandboxApiTypeMap[sandboxType]; // API expects type as 1 or 2
+    result = await createSandbox(accountId, sandboxName, sandboxApiType);
+
+    logger.log('');
+    spinnies.succeed('sandboxCreate', {
+      text: i18n(`${i18nKey}.loading.succeed`, {
+        name: result.name,
+        sandboxHubId: result.sandboxHubId,
+      }),
+    });
+  } catch (err) {
+    console.log('ERROR: ', err);
+    debugErrorAndContext(err);
+
+    trackCommandUsage('sandbox-create', { successful: false }, accountId);
+
+    spinnies.fail('sandboxCreate', {
+      text: i18n(`${i18nKey}.loading.fail`, {
+        sandboxName,
+      }),
+    });
+
+    if (isMissingScopeError(err)) {
+      logger.error(
+        i18n(`${i18nKey}.failure.scopes.message`, {
+          accountName: accountConfig.name || accountId,
+        })
+      );
+      const websiteOrigin = getHubSpotWebsiteOrigin(env);
+      const url = `${websiteOrigin}/personal-access-key/${accountId}`;
+      logger.info(
+        i18n(`${i18nKey}.failure.scopes.instructions`, {
+          accountName: accountConfig.name || accountId,
+          url,
+        })
+      );
+    } else if (
+      isSpecifiedError(
+        err,
+        400,
+        'VALIDATION_ERROR',
+        'SandboxErrors.NUM_DEVELOPMENT_SANDBOXES_LIMIT_EXCEEDED_ERROR'
+      ) &&
+      err.error &&
+      err.error.message
+    ) {
+      logger.log('');
+      const devSandboxLimit = getDevSandboxLimit(err.error);
+      const plural = devSandboxLimit !== 1;
+      const hasDevelopmentSandboxes = getHasDevelopmentSandboxes(accountConfig);
+      if (hasDevelopmentSandboxes) {
+        logger.error(
+          i18n(
+            `${i18nKey}.failure.alreadyInConfig.${plural ? 'other' : 'one'}`,
+            {
+              accountName: accountConfig.name || accountId,
+              limit: devSandboxLimit,
+            }
+          )
+        );
+      } else {
+        const baseUrl = getHubSpotWebsiteOrigin(
+          getEnv(accountId) === 'qa' ? ENVIRONMENTS.QA : ENVIRONMENTS.PROD
+        );
+        logger.error(
+          i18n(`${i18nKey}.failure.limit.${plural ? 'other' : 'one'}`, {
+            accountName: accountConfig.name || accountId,
+            limit: devSandboxLimit,
+            devSandboxesLink: `${baseUrl}/sandboxes-developer/${accountId}/development`,
+          })
+        );
+      }
+      logger.log('');
+    } else {
+      logErrorInstance(err);
+    }
+    throw err;
+  }
+  try {
+    // Response contains PAK, save to config here
+    await saveSandboxToConfig(env, result);
+  } catch (err) {
+    logErrorInstance(err);
+    throw err;
+  }
+};
+
+module.exports = {
+  buildSandbox,
+};

--- a/packages/cli/lib/sandbox-create.js
+++ b/packages/cli/lib/sandbox-create.js
@@ -26,7 +26,12 @@ const {
   isSpecifiedError,
 } = require('@hubspot/cli-lib/errorHandlers/apiErrors');
 const { getHubSpotWebsiteOrigin } = require('@hubspot/cli-lib/lib/urls');
-const { getEnv, getAccountConfig, getConfig } = require('@hubspot/cli-lib');
+const {
+  getEnv,
+  getAccountConfig,
+  getConfig,
+  getAccountId,
+} = require('@hubspot/cli-lib');
 const { createSandbox } = require('@hubspot/cli-lib/sandboxes');
 const { promptUser } = require('./prompts/promptUtils');
 const { syncSandbox } = require('./sandbox-sync');
@@ -61,7 +66,7 @@ const buildSandbox = async ({
   const spinnies = new Spinnies({
     succeedColor: 'white',
   });
-  const accountId = accountConfig.portalId;
+  const accountId = getAccountId(accountConfig.portalId);
 
   trackCommandUsage('sandbox-create', null, accountId);
 

--- a/packages/cli/lib/sandbox-create.js
+++ b/packages/cli/lib/sandbox-create.js
@@ -41,7 +41,7 @@ const {
 const { updateDefaultAccount } = require('@hubspot/cli-lib/lib/config');
 const { getValidEnv } = require('@hubspot/cli-lib/lib/environment');
 
-const i18nKey = 'cli.commands.sandbox.subcommands.create';
+const i18nKey = 'cli.lib.sandbox.create';
 
 /**
  * @param {String} name - Name of sandbox
@@ -285,7 +285,7 @@ const buildSandbox = async ({
   // If creating standard sandbox, prompt user to sync assets
   if (allowSyncAssets) {
     if (sandboxType === STANDARD_SANDBOX) {
-      const syncI18nKey = 'cli.commands.sandbox.subcommands.sync';
+      const syncI18nKey = 'cli.lib.sandbox.sync';
       const sandboxAccountConfig = getAccountConfig(
         result.sandbox.sandboxHubId
       );

--- a/packages/cli/lib/sandbox-create.js
+++ b/packages/cli/lib/sandbox-create.js
@@ -274,11 +274,6 @@ const buildSandbox = async ({
       const sandboxAccountConfig = getAccountConfig(
         result.sandbox.sandboxHubId
       );
-      // const standardSyncUrl = `${getHubSpotWebsiteOrigin(
-      //   env
-      // )}/sandboxes-developer/${accountId}/sync?step=select_sync_path&id=${accountId}_${
-      //   result.sandbox.sandboxHubId
-      // }`;
       logger.log('');
       const { sandboxSyncPrompt } = await promptUser([
         {
@@ -293,29 +288,6 @@ const buildSandbox = async ({
       if (!sandboxSyncPrompt) {
         process.exit(EXIT_CODES.SUCCESS);
       }
-      // logger.log('');
-      // logger.log(
-      //   i18n(`${syncI18nKey}.info.standardSandbox`, {
-      //     url: standardSyncUrl,
-      //   })
-      // );
-      // logger.log('');
-      // const { confirmSandboxSyncPrompt } = await promptUser([
-      //   {
-      //     name: 'confirmSandboxSyncPrompt',
-      //     type: 'confirm',
-      //     message: i18n(
-      //       `${syncI18nKey}.confirm.standardSandboxCreateFlowReconfirm`,
-      //       {
-      //         parentAccountName: getAccountName(accountConfig),
-      //         sandboxName: getAccountName(sandboxAccountConfig),
-      //       }
-      //     ),
-      //   },
-      // ]);
-      // if (!confirmSandboxSyncPrompt) {
-      //   process.exit(EXIT_CODES.SUCCESS);
-      // }
       await syncSandbox({
         accountConfig: sandboxAccountConfig,
         parentAccountConfig: accountConfig,

--- a/packages/cli/lib/sandbox-create.js
+++ b/packages/cli/lib/sandbox-create.js
@@ -54,6 +54,7 @@ const buildSandbox = async ({
   env,
   allowEarlyTermination = true,
   skipDefaultAccountPrompt = false,
+  skipSyncStandardSandbox = false,
   force = false,
 }) => {
   const spinnies = new Spinnies({
@@ -291,23 +292,27 @@ const buildSandbox = async ({
     };
     try {
       logger.log('');
-      if (!force) {
-        // Skip prompt if force flag is passed
-        const { sandboxSyncPrompt } = await promptUser([
-          {
-            name: 'sandboxSyncPrompt',
-            type: 'confirm',
-            message: i18n(`${syncI18nKey}.confirm.standardSandboxCreateFlow`, {
-              parentAccountName: getAccountName(accountConfig),
-              sandboxName: getAccountName(sandboxAccountConfig),
-            }),
-          },
-        ]);
-        if (sandboxSyncPrompt) {
+      if (!skipSyncStandardSandbox) {
+        if (!force) {
+          const { sandboxSyncPrompt } = await promptUser([
+            {
+              name: 'sandboxSyncPrompt',
+              type: 'confirm',
+              message: i18n(
+                `${syncI18nKey}.confirm.standardSandboxCreateFlow`,
+                {
+                  parentAccountName: getAccountName(accountConfig),
+                  sandboxName: getAccountName(sandboxAccountConfig),
+                }
+              ),
+            },
+          ]);
+          if (sandboxSyncPrompt) {
+            await handleSyncSandbox();
+          }
+        } else {
           await handleSyncSandbox();
         }
-      } else {
-        await handleSyncSandbox();
       }
     } catch (err) {
       logErrorInstance(err);

--- a/packages/cli/lib/sandbox-create.js
+++ b/packages/cli/lib/sandbox-create.js
@@ -40,12 +40,12 @@ const i18nKey = 'cli.commands.sandbox.subcommands.create';
 
 /**
  * @param {String} name - Name of sandbox
- * @param {String} type - Standard or development sandbox type
+ * @param {String} type - Sandbox type to be created (standard/developer)
  * @param {Object} accountConfig - Account config of parent portal
  * @param {String} env - Environment (QA/Prod)
  * @param {Boolean} allowEarlyTermination - Option to allow a keypress to terminate early
- * @param {Boolean} skipDefaultAccountPrompt - Option to skip prompt and auto set account as default
- * @returns {Object} sandboxConfigName string and sandbox instance from API
+ * @param {Boolean} skipDefaultAccountPrompt - Option to skip default account prompt and auto set new sandbox account as default
+ * @returns {Object} Object containing sandboxConfigName string and sandbox instance from API
  */
 const buildSandbox = async ({
   name,
@@ -73,11 +73,13 @@ const buildSandbox = async ({
     logger.error(
       i18n(`${i18nKey}.failure.creatingWithinSandbox`, {
         sandboxType: getSandboxTypeAsString(accountConfig.sandboxAccountType),
+        sandboxName: accountConfig.name,
       })
     );
     throw new Error(
       i18n(`${i18nKey}.failure.creatingWithinSandbox`, {
         sandboxType: getSandboxTypeAsString(accountConfig.sandboxAccountType),
+        sandboxName: accountConfig.name,
       })
     );
   }

--- a/packages/cli/lib/sandbox-create.js
+++ b/packages/cli/lib/sandbox-create.js
@@ -26,7 +26,6 @@ const {
   isSpecifiedError,
 } = require('@hubspot/cli-lib/errorHandlers/apiErrors');
 const { getHubSpotWebsiteOrigin } = require('@hubspot/cli-lib/lib/urls');
-const { ENVIRONMENTS } = require('@hubspot/cli-lib/lib/constants');
 const { getEnv, getAccountConfig, getConfig } = require('@hubspot/cli-lib');
 const { createSandbox } = require('@hubspot/cli-lib/sandboxes');
 const { promptUser } = require('./prompts/promptUtils');
@@ -35,6 +34,7 @@ const {
   setAsDefaultAccountPrompt,
 } = require('./prompts/setAsDefaultAccountPrompt');
 const { updateDefaultAccount } = require('@hubspot/cli-lib/lib/config');
+const { getValidEnv } = require('@hubspot/cli-lib/lib/environment');
 
 const i18nKey = 'cli.commands.sandbox.subcommands.create';
 
@@ -181,9 +181,7 @@ const buildSandbox = async ({
           )
         );
       } else {
-        const baseUrl = getHubSpotWebsiteOrigin(
-          getEnv(accountId) === 'qa' ? ENVIRONMENTS.QA : ENVIRONMENTS.PROD
-        );
+        const baseUrl = getHubSpotWebsiteOrigin(getValidEnv(getEnv(accountId)));
         logger.error(
           i18n(
             `${i18nKey}.failure.limit.developer.${plural ? 'other' : 'one'}`,
@@ -226,9 +224,7 @@ const buildSandbox = async ({
           )
         );
       } else {
-        const baseUrl = getHubSpotWebsiteOrigin(
-          getEnv(accountId) === 'qa' ? ENVIRONMENTS.QA : ENVIRONMENTS.PROD
-        );
+        const baseUrl = getHubSpotWebsiteOrigin(getValidEnv(getEnv(accountId)));
         logger.error(
           i18n(
             `${i18nKey}.failure.limit.standard.${plural ? 'other' : 'one'}`,

--- a/packages/cli/lib/sandbox-sync.js
+++ b/packages/cli/lib/sandbox-sync.js
@@ -14,6 +14,7 @@ const {
   isMissingScopeError,
 } = require('@hubspot/cli-lib/errorHandlers/apiErrors');
 const { getSandboxTypeAsString } = require('./sandboxes');
+const { getAccountId } = require('@hubspot/cli-lib');
 
 const i18nKey = 'cli.commands.sandbox.subcommands.sync';
 
@@ -30,8 +31,8 @@ const syncSandbox = async ({
   env,
   allowEarlyTermination = true,
 }) => {
-  const accountId = accountConfig.portalId;
-  const parentAccountId = parentAccountConfig.portalId;
+  const accountId = getAccountId(accountConfig.portalId);
+  const parentAccountId = getAccountId(parentAccountConfig.portalId);
   const spinnies = new Spinnies({
     succeedColor: 'white',
   });

--- a/packages/cli/lib/sandbox-sync.js
+++ b/packages/cli/lib/sandbox-sync.js
@@ -13,6 +13,7 @@ const {
   isSpecifiedError,
   isMissingScopeError,
 } = require('@hubspot/cli-lib/errorHandlers/apiErrors');
+const { getSandboxTypeAsString } = require('./sandboxes');
 
 const i18nKey = 'cli.commands.sandbox.subcommands.sync';
 
@@ -34,13 +35,12 @@ const syncSandbox = async ({
   const spinnies = new Spinnies({
     succeedColor: 'white',
   });
-  const isDevelopmentSandbox = accountConfig.sandboxAccountType === 'DEVELOPER';
   let initiateSyncResponse;
 
   const baseUrl = getHubSpotWebsiteOrigin(env);
-  const syncStatusUrl = `${baseUrl}/sandboxes-developer/${parentAccountId}/${
-    isDevelopmentSandbox ? 'development' : 'standard'
-  }`;
+  const syncStatusUrl = `${baseUrl}/sandboxes-developer/${parentAccountId}/${getSandboxTypeAsString(
+    accountConfig.sandboxAccountType
+  )}`;
 
   try {
     logger.log('');

--- a/packages/cli/lib/sandbox-sync.js
+++ b/packages/cli/lib/sandbox-sync.js
@@ -1,0 +1,164 @@
+const Spinnies = require('spinnies');
+const { getHubSpotWebsiteOrigin } = require('@hubspot/cli-lib/lib/urls');
+const { logger } = require('@hubspot/cli-lib/logger');
+const { i18n } = require('@hubspot/cli-lib/lib/lang');
+const {
+  getAvailableSyncTypes,
+  pollSyncTaskStatus,
+  getAccountName,
+} = require('./sandboxes');
+const { initiateSync } = require('@hubspot/cli-lib/sandboxes');
+const { logErrorInstance } = require('@hubspot/cli-lib/errorHandlers');
+const {
+  isSpecifiedError,
+  isMissingScopeError,
+} = require('@hubspot/cli-lib/errorHandlers/apiErrors');
+
+const i18nKey = 'cli.commands.sandbox.subcommands.sync';
+
+const syncSandbox = async ({
+  accountConfig,
+  parentAccountConfig,
+  env,
+  allowEarlyTermination = true,
+}) => {
+  const accountId = accountConfig.portalId;
+  const parentAccountId = parentAccountConfig.portalId;
+  const spinnies = new Spinnies({
+    succeedColor: 'white',
+  });
+  const isDevelopmentSandbox = accountConfig.sandboxAccountType === 'DEVELOPER';
+  let initiateSyncResponse;
+
+  const baseUrl = getHubSpotWebsiteOrigin(env);
+  const syncStatusUrl = `${baseUrl}/sandboxes-developer/${parentAccountId}/${
+    isDevelopmentSandbox ? 'development' : 'standard'
+  }`;
+
+  try {
+    logger.log('');
+    spinnies.add('sandboxSync', {
+      text: i18n(`${i18nKey}.loading.startSync`),
+    });
+
+    // Fetches sync types based on default account. Parent account required for fetch
+    const tasks = await getAvailableSyncTypes(
+      parentAccountConfig,
+      accountConfig
+    );
+
+    initiateSyncResponse = await initiateSync(
+      parentAccountId,
+      accountId,
+      tasks,
+      accountId
+    );
+
+    logger.log(i18n(`${i18nKey}.info.earlyExit`));
+    logger.log('');
+    spinnies.succeed('sandboxSync', {
+      text: i18n(`${i18nKey}.loading.succeed`),
+    });
+  } catch (err) {
+    spinnies.fail('sandboxSync', {
+      text: i18n(`${i18nKey}.loading.fail`),
+    });
+
+    logger.log('');
+    if (isMissingScopeError(err)) {
+      logger.error(
+        i18n(`${i18nKey}.failure.missingScopes`, {
+          accountName: getAccountName(parentAccountConfig),
+        })
+      );
+    } else if (
+      isSpecifiedError(
+        err,
+        429,
+        'RATE_LIMITS',
+        'sandboxes-sync-api.SYNC_IN_PROGRESS'
+      )
+    ) {
+      logger.error(
+        i18n(`${i18nKey}.failure.syncInProgress`, {
+          url: `${baseUrl}/sandboxes-developer/${parentAccountId}/syncactivitylog`,
+        })
+      );
+    } else if (
+      isSpecifiedError(
+        err,
+        403,
+        'BANNED',
+        'sandboxes-sync-api.SYNC_NOT_ALLOWED_INVALID_USERID'
+      )
+    ) {
+      // This will only trigger if a user is not a super admin of the target account.
+      logger.error(
+        i18n(`${i18nKey}.failure.notSuperAdmin`, {
+          account: getAccountName(accountConfig),
+        })
+      );
+    } else if (
+      isSpecifiedError(
+        err,
+        404,
+        'OBJECT_NOT_FOUND',
+        'SandboxErrors.SANDBOX_NOT_FOUND'
+      )
+    ) {
+      logger.error(
+        i18n(`${i18nKey}.failure.objectNotFound`, {
+          account: getAccountName(accountConfig),
+        })
+      );
+    } else {
+      logErrorInstance(err);
+    }
+    logger.log('');
+    throw err;
+  }
+
+  try {
+    logger.log('');
+    logger.log('Sync progress:');
+    // Poll sync task status to show progress bars
+    await pollSyncTaskStatus(
+      parentAccountId,
+      initiateSyncResponse.id,
+      syncStatusUrl,
+      allowEarlyTermination
+    );
+
+    logger.log('');
+    spinnies.add('syncComplete', {
+      text: i18n(`${i18nKey}.polling.syncing`),
+    });
+    spinnies.succeed('syncComplete', {
+      text: i18n(`${i18nKey}.polling.succeed`),
+    });
+    logger.log('');
+    logger.log(
+      i18n(`${i18nKey}.info.syncStatus`, {
+        url: syncStatusUrl,
+      })
+    );
+  } catch (err) {
+    // If polling fails at this point, we do not track a failed sync since it is running in the background.
+    logErrorInstance(err);
+
+    spinnies.add('syncComplete', {
+      text: i18n(`${i18nKey}.polling.syncing`),
+    });
+    spinnies.fail('syncComplete', {
+      text: i18n(`${i18nKey}.polling.fail`, {
+        url: syncStatusUrl,
+      }),
+    });
+
+    throw err;
+  }
+};
+
+module.exports = {
+  syncSandbox,
+};

--- a/packages/cli/lib/sandbox-sync.js
+++ b/packages/cli/lib/sandbox-sync.js
@@ -16,7 +16,7 @@ const {
 const { getSandboxTypeAsString } = require('./sandboxes');
 const { getAccountId } = require('@hubspot/cli-lib');
 
-const i18nKey = 'cli.commands.sandbox.subcommands.sync';
+const i18nKey = 'cli.lib.sandbox.sync';
 
 /**
  * @param {Object} accountConfig - Account config of sandbox portal

--- a/packages/cli/lib/sandbox-sync.js
+++ b/packages/cli/lib/sandbox-sync.js
@@ -16,6 +16,13 @@ const {
 
 const i18nKey = 'cli.commands.sandbox.subcommands.sync';
 
+/**
+ * @param {Object} accountConfig - Account config of sandbox portal
+ * @param {Object} parentAccountConfig - Account config of parent portal
+ * @param {String} env - Environment (QA/Prod)
+ * @param {Boolean} allowEarlyTermination - Option to allow a keypress to terminate early
+ * @returns
+ */
 const syncSandbox = async ({
   accountConfig,
   parentAccountConfig,
@@ -54,7 +61,9 @@ const syncSandbox = async ({
       accountId
     );
 
-    logger.log(i18n(`${i18nKey}.info.earlyExit`));
+    if (allowEarlyTermination) {
+      logger.log(i18n(`${i18nKey}.info.earlyExit`));
+    }
     logger.log('');
     spinnies.succeed('sandboxSync', {
       text: i18n(`${i18nKey}.loading.succeed`),

--- a/packages/cli/lib/sandboxes.js
+++ b/packages/cli/lib/sandboxes.js
@@ -83,6 +83,7 @@ async function getAvailableSyncTypes(parentAccountConfig, config) {
 /**
  * @param {String} env - Environment (QA/Prod)
  * @param {Object} result - Sandbox instance returned from API
+ * @param {Boolean} force - Force flag to skip prompt
  * @returns {String} validName saved into config
  */
 const saveSandboxToConfig = async (env, result, force = false) => {
@@ -145,7 +146,13 @@ const isTaskComplete = task => {
   return task.status === 'COMPLETE';
 };
 
-// Returns a promise to poll a sync task with taskId. Interval runs until sync task status is equal to 'COMPLETE'
+/**
+ * @param {Number} accountId - Parent portal ID (needs sandbox scopes)
+ * @param {String} taksId - Task ID to poll
+ * @param {String} syncStatusUrl - Link to UI to check polling status
+ * @param {Boolean} allowEarlyTermination - Option to allow a keypress to terminate early
+ * @returns {Promise} Interval runs until sync task status is equal to 'COMPLETE'
+ */
 function pollSyncTaskStatus(
   accountId,
   taskId,
@@ -153,6 +160,7 @@ function pollSyncTaskStatus(
   allowEarlyTermination = true
 ) {
   const i18nKey = 'cli.commands.sandbox.subcommands.sync.types';
+  // TODO: Extract cli progress into util
   const multibar = new cliProgress.MultiBar(
     {
       hideCursor: true,

--- a/packages/cli/lib/sandboxes.js
+++ b/packages/cli/lib/sandboxes.js
@@ -17,10 +17,6 @@ const { accountNameExistsInConfig } = require('@hubspot/cli-lib/lib/config');
 const {
   personalAccessKeyPrompt,
 } = require('./prompts/personalAccessKeyPrompt');
-const {
-  DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME,
-  PERSONAL_ACCESS_KEY_AUTH_METHOD,
-} = require('@hubspot/cli-lib/lib/constants');
 
 const STANDARD_SANDBOX = 'standard';
 const DEVELOPER_SANDBOX = 'developer';
@@ -53,7 +49,7 @@ function getAccountName(config) {
   return `${config.name} ${isSandbox ? sandboxName : ''}(${config.portalId})`;
 }
 
-function getHasDevelopmentSandboxes(parentAccountConfig) {
+function getHasSandboxesByType(parentAccountConfig, type) {
   const config = getConfig();
   const parentPortalId = parentAccountConfig.portalId;
   for (const portal of config.portals) {
@@ -62,7 +58,7 @@ function getHasDevelopmentSandboxes(parentAccountConfig) {
         portal.parentAccountId !== undefined) &&
       portal.parentAccountId === parentPortalId &&
       portal.sandboxAccountType &&
-      portal.sandboxAccountType === 'DEVELOPER'
+      sandboxTypeMap[portal.sandboxAccountType] === type
     ) {
       return true;
     }
@@ -70,7 +66,7 @@ function getHasDevelopmentSandboxes(parentAccountConfig) {
   return false;
 }
 
-function getDevSandboxLimit(error) {
+function getSandboxLimit(error) {
   // Error context should contain a limit property with a list of one number. That number is the current limit
   const limit = error.context && error.context.limit && error.context.limit[0];
   return limit ? parseInt(limit, 10) : 1; // Default to 1
@@ -128,14 +124,13 @@ const saveSandboxToConfig = async (env, result) => {
   });
   writeConfig();
 
-  logger.log('');
-  logger.success(
-    i18n('cli.commands.sandbox.subcommands.create.success.configFileUpdated', {
-      configFilename: DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME,
-      authMethod: PERSONAL_ACCESS_KEY_AUTH_METHOD.name,
-      account: validName,
-    })
-  );
+  // logger.success(
+  //   i18n('cli.commands.sandbox.subcommands.create.success.configFileUpdated', {
+  //     configFilename: DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME,
+  //     authMethod: PERSONAL_ACCESS_KEY_AUTH_METHOD.name,
+  //     account: validName,
+  //   })
+  // );
   logger.log('');
   return validName;
 };
@@ -320,9 +315,8 @@ module.exports = {
   getSandboxTypeAsString,
   getAccountName,
   saveSandboxToConfig,
-  getHasDevelopmentSandboxes,
-  getDevSandboxLimit,
+  getHasSandboxesByType,
+  getSandboxLimit,
   getAvailableSyncTypes,
-  // sandboxCreatePersonalAccessKeyFlow,
   pollSyncTaskStatus,
 };

--- a/packages/cli/lib/sandboxes.js
+++ b/packages/cli/lib/sandboxes.js
@@ -2,6 +2,7 @@ const {
   getConfig,
   writeConfig,
   updateAccountConfig,
+  getAccountId,
 } = require('@hubspot/cli-lib');
 const { i18n } = require('@hubspot/cli-lib/lib/lang');
 const { logger } = require('@hubspot/cli-lib/logger');
@@ -51,7 +52,7 @@ function getAccountName(config) {
 
 function getHasSandboxesByType(parentAccountConfig, type) {
   const config = getConfig();
-  const parentPortalId = parentAccountConfig.portalId;
+  const parentPortalId = getAccountId(parentAccountConfig.portalId);
   for (const portal of config.portals) {
     if (
       (portal.parentAccountId !== null ||
@@ -74,8 +75,8 @@ function getSandboxLimit(error) {
 
 // Fetches available sync types for a given sandbox portal
 async function getAvailableSyncTypes(parentAccountConfig, config) {
-  const parentPortalId = parentAccountConfig.portalId;
-  const portalId = config.portalId;
+  const parentPortalId = getAccountId(parentAccountConfig.portalId);
+  const portalId = getAccountId(config.portalId);
   const syncTypes = await fetchTypes(parentPortalId, portalId);
   return syncTypes.map(t => ({ type: t.name }));
 }

--- a/packages/cli/lib/sandboxes.js
+++ b/packages/cli/lib/sandboxes.js
@@ -122,7 +122,7 @@ const saveSandboxToConfig = async (env, result, force = false) => {
         validName = promptName;
       } else {
         // Basic invalid name handling when force flag is passed
-        validName = nameForConfig + Math.floor(Math.random() * 10);
+        validName = nameForConfig + `_${Date.now()}`;
       }
     }
   }

--- a/packages/cli/lib/sandboxes.js
+++ b/packages/cli/lib/sandboxes.js
@@ -164,8 +164,7 @@ function pollSyncTaskStatus(
   syncStatusUrl,
   allowEarlyTermination = true
 ) {
-  const i18nKey = 'cli.commands.sandbox.subcommands.sync.types';
-  // TODO: Extract cli progress into util
+  const i18nKey = 'cli.lib.sandbox.sync.types';
   const progressBar = CliProgressMultibarManager.init();
   const mergeTasks = {
     'lead-flows': 'forms', // lead-flows are a subset of forms. We combine these in the UI as a single item, so we want to merge here for consistency.

--- a/packages/cli/lib/sandboxes.js
+++ b/packages/cli/lib/sandboxes.js
@@ -92,6 +92,7 @@ const saveSandboxToConfig = async (env, result) => {
     env,
     account: result.sandbox.sandboxHubId,
   });
+  // End temporary section
   const updatedConfig = await updateConfigWithPersonalAccessKey(configData);
   if (!updatedConfig) {
     process.exit(EXIT_CODES.ERROR);
@@ -124,74 +125,9 @@ const saveSandboxToConfig = async (env, result) => {
   });
   writeConfig();
 
-  // logger.success(
-  //   i18n('cli.commands.sandbox.subcommands.create.success.configFileUpdated', {
-  //     configFilename: DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME,
-  //     authMethod: PERSONAL_ACCESS_KEY_AUTH_METHOD.name,
-  //     account: validName,
-  //   })
-  // );
   logger.log('');
   return validName;
 };
-
-// const sandboxCreatePersonalAccessKeyFlow = async (env, account, name) => {
-//   const configData = await personalAccessKeyPrompt({ env, account });
-//   const updatedConfig = await updateConfigWithPersonalAccessKey(configData);
-
-//   if (!updatedConfig) {
-//     process.exit(EXIT_CODES.SUCCESS);
-//   }
-
-//   let validName = updatedConfig.name;
-
-//   if (!updatedConfig.name) {
-//     const nameForConfig = name
-//       .toLowerCase()
-//       .split(' ')
-//       .join('-');
-//     const { name: promptName } = await enterAccountNamePrompt(nameForConfig);
-//     validName = promptName;
-//   }
-
-//   updateAccountConfig({
-//     ...updatedConfig,
-//     environment: updatedConfig.env,
-//     tokenInfo: updatedConfig.auth.tokenInfo,
-//     name: validName,
-//   });
-//   writeConfig();
-
-//   const setAsDefault = await setAsDefaultAccountPrompt(validName);
-
-//   logger.log('');
-//   if (setAsDefault) {
-//     logger.success(
-//       i18n(`cli.lib.prompts.setAsDefaultAccountPrompt.setAsDefaultAccount`, {
-//         accountName: validName,
-//       })
-//     );
-//   } else {
-//     const config = getConfig();
-//     logger.info(
-//       i18n(`cli.lib.prompts.setAsDefaultAccountPrompt.keepingCurrentDefault`, {
-//         accountName: config.defaultPortal,
-//       })
-//     );
-//   }
-//   logger.success(
-//     i18n('cli.commands.sandbox.subcommands.create.success.configFileUpdated', {
-//       configFilename: DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME,
-//       authMethod: PERSONAL_ACCESS_KEY_AUTH_METHOD.name,
-//       account: validName,
-//     })
-//   );
-//   uiFeatureHighlight([
-//     'accountsUseCommand',
-//     'accountOption',
-//     'accountsListCommand',
-//   ]);
-// };
 
 const ACTIVE_TASK_POLL_INTERVAL = 1000;
 


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
To bring the CLI closer to feature parity with the UI, sandboxes will now support the creation of standard sandboxes with the `hs sandbox create` command. A new flow has been designed where users will be prompted for a sandbox type before being prompted for a name. 

- Support creation of standard sandboxes with a picker, one of standard or development
  - Can use new `--type` flag to specify which type
  - Update to use sandbox hubs v2 API
  - Using v2 API, PAKs are generated automatically on BE and CLI can bypass the prompt to generate and copy a PAK in the browser. 
  - After creating a standard sandbox, we now prompt the user if they want to sync assets
- Duplicate name checking for items existing in config
  - Removal of the second name prompt, where sandbox name and config name were different. We now automatically transform the sandbox name to a config friendly version and save (with duplicate name check). 
- Updated lang file to support both standard and development sandboxes, and rearranged various messaging after design review with PD
- Extraction of sandbox create logic into util. Can be called in other commands such as `hs project dev`. 
- Extraction of sandbox sync logic into util. Can be called in other commands such as `hs sandbox create`.
- Continue to support `-f` or `--force` flags to skip all confirmation prompts for scripting.
- Add fix for sync polling where items would hit 100% before the sync task completed


## Screenshots
<!-- Provide images of the before and after functionality -->

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

Auto PAK generation is not yet complete on BE, still have yet to remove PAK prompt from sandbox create flow. 

## Who to Notify
<!-- /cc those you wish to know about the PR -->
