### PR TITLE
Sandboxes: prompt user for contact records sync 

### DIFF
--- a/packages/cli-lib/api/sandbox-hubs.js
+++ b/packages/cli-lib/api/sandbox-hubs.js
@@ -29,7 +29,19 @@ async function deleteSandbox(parentAccountId, sandboxAccountId) {
   });
 }
 
+/**
+ * Fetch sandbox usage limits
+ * @param {Number} parentAccountId - Parent portal ID.
+ * @returns {Object} Object containing limits for each sandbox type
+ */
+async function getSandboxUsageLimits(parentAccountId) {
+  return http.get(parentAccountId, {
+    uri: `${SANDBOX_API_PATH}/parent/${parentAccountId}/usage`,
+  });
+}
+
 module.exports = {
   createSandbox,
   deleteSandbox,
+  getSandboxUsageLimits,
 };

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -1091,7 +1091,12 @@ en:
             syncStatus: "View the sync status details at: {{#bold}}{{ url }}{{/bold}}"
             earlyExit: "Syncing may take some time. Hit {{#bold}}Enter{{/bold}} or {{#bold}}Ctrl+C{{/bold}} to exit and continue the sync in the background."
           confirm:
-            standardSandboxCreateFlow: "Sync all supported assets to {{#cyan}}{{#bold}}{{ sandboxName }}{{/bold}}{{/cyan}} from {{#bold}}{{ parentAccountName }}{{/bold}}? Syncing may take some time"
+            createFlow:
+              standard: "Sync all supported assets to {{#cyan}}{{#bold}}{{ sandboxName }}{{/bold}}{{/cyan}} from {{#bold}}{{ parentAccountName }}{{/bold}}?"
+              developer: "Sync CRM object definitions to {{#cyan}}{{#bold}}{{ sandboxName }}{{/bold}}{{/cyan}} from {{#bold}}{{ parentAccountName }}{{/bold}}?"
+            syncContactRecords:
+              standard: "Do you want the sync to include up to 5000 contact records and associations? Syncing may take some time"
+              developer: "Do you want the sync to include up to 100 contact records and associations?"
           loading:
             startSync: "Initiating sync..."
             fail: "Failed to sync sandbox."

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -653,6 +653,13 @@ en:
                 describe: "Name to use for created sandbox"
               type:
                 describe: "Type of sandbox to create (standard | development)"
+            failure:
+              optionMissing:
+                type: "Invalid or missing sandbox --type option in command. Please try again."
+                name: "Invalid or missing sandbox --name option in command. Please try again."
+              creatingWithinSandbox: "Sandboxes must be created from a production account. Your current default account {{#bold}}{{ sandboxName }}{{/bold}} is a {{ sandboxType }} sandbox.
+                \n- Run {{#bold}}hs accounts use{{/bold}} to switch to your default account to your production account.
+                \n- Run {{#bold}}hs auth{{/bold}} to connect a production account to the HubSpot CLI.\n"
           delete:
             describe: "Delete a sandbox account"
             debug:
@@ -1053,12 +1060,6 @@ en:
           success:
             configFileUpdated: "{{ configFilename }} updated with {{ authMethod }} for account {{ account }}."
           failure:
-            optionMissing:
-              type: "Invalid or missing sandbox --type option in command. Please try again."
-              name: "Invalid or missing sandbox --name option in command. Please try again."
-            creatingWithinSandbox: "Sandboxes must be created from a production account. Your current default account {{#bold}}{{ sandboxName }}{{/bold}} is a {{ sandboxType }} sandbox.
-              \n- Run {{#bold}}hs accounts use{{/bold}} to switch to your default account to your production account.
-              \n- Run {{#bold}}hs auth{{/bold}} to connect a production account to the HubSpot CLI.\n"
             limit:
               developer:
                 one: "{{#bold}}{{ accountName }}{{/bold}} reached the limit of {{ limit }} development sandbox per account. View sandbox details at {{ link }}. To connect a sandbox to your HubSpot CLI, run {{#bold}}hs auth{{/bold}} and follow the prompts."
@@ -1095,8 +1096,8 @@ en:
               standard: "Sync all supported assets to {{#cyan}}{{#bold}}{{ sandboxName }}{{/bold}}{{/cyan}} from {{#bold}}{{ parentAccountName }}{{/bold}}?"
               developer: "Sync CRM object definitions to {{#cyan}}{{#bold}}{{ sandboxName }}{{/bold}}{{/cyan}} from {{#bold}}{{ parentAccountName }}{{/bold}}?"
             syncContactRecords:
-              standard: "Do you want the sync to include up to 5000 contact records and associations? Syncing may take some time"
-              developer: "Do you want the sync to include up to 100 contact records and associations?"
+              standard: "Include up to 5000 contact records and associations in this sync? Syncing contact records may take some time"
+              developer: "Include up to 100 contact records and associations in this sync? Syncing contact records may take some time"
           loading:
             startSync: "Initiating sync..."
             fail: "Failed to sync sandbox."

--- a/packages/cli-lib/sandboxes.js
+++ b/packages/cli-lib/sandboxes.js
@@ -2,6 +2,7 @@
 const {
   createSandbox: _createSandbox,
   deleteSandbox: _deleteSandbox,
+  getSandboxUsageLimits: _getSandboxUsageLimits,
 } = require('./api/sandbox-hubs');
 const {
   initiateSync: _initiateSync,
@@ -38,6 +39,18 @@ async function deleteSandbox(parentAccountId, sandboxAccountId) {
     sandboxAccountId,
     ...resp,
   };
+}
+
+async function getSandboxUsageLimits(parentAccountId, sandboxAccountId) {
+  let resp;
+
+  try {
+    resp = await _getSandboxUsageLimits(parentAccountId, sandboxAccountId);
+  } catch (err) {
+    throw err;
+  }
+
+  return resp.usage;
 }
 
 async function initiateSync(fromHubId, toHubId, tasks, sandboxHubId) {
@@ -79,6 +92,7 @@ async function fetchTypes(accountId, toHubId) {
 module.exports = {
   createSandbox,
   deleteSandbox,
+  getSandboxUsageLimits,
   initiateSync,
   fetchTaskStatus,
   fetchTypes,

--- a/packages/cli/commands/sandbox/sync.js
+++ b/packages/cli/commands/sandbox/sync.js
@@ -19,6 +19,8 @@ const {
   sandboxTypeMap,
   DEVELOPER_SANDBOX,
   STANDARD_SANDBOX,
+  getAvailableSyncTypes,
+  getSyncTypesWithContactRecordsPrompt,
 } = require('../../lib/sandboxes');
 const { syncSandbox } = require('../../lib/sandbox-sync');
 const { getValidEnv } = require('@hubspot/cli-lib/lib/environment');
@@ -143,12 +145,24 @@ exports.handler = async options => {
   }
 
   try {
+    const availableSyncTasks = await getAvailableSyncTypes(
+      parentAccountConfig,
+      accountConfig
+    );
+    const syncTasks = await getSyncTypesWithContactRecordsPrompt(
+      accountConfig,
+      availableSyncTasks,
+      force
+    );
+
     await syncSandbox({
       accountConfig,
       parentAccountConfig,
       env,
+      syncTasks,
       allowEarlyTermination: true,
     });
+
     process.exit(EXIT_CODES.SUCCESS);
   } catch (error) {
     trackCommandUsage('sandbox-sync', { successful: false }, accountId);

--- a/packages/cli/lib/sandbox-create.js
+++ b/packages/cli/lib/sandbox-create.js
@@ -26,19 +26,10 @@ const {
   isSpecifiedError,
 } = require('@hubspot/cli-lib/errorHandlers/apiErrors');
 const { getHubSpotWebsiteOrigin } = require('@hubspot/cli-lib/lib/urls');
-const {
-  getEnv,
-  getAccountConfig,
-  getConfig,
-  getAccountId,
-} = require('@hubspot/cli-lib');
+const { getEnv, getAccountConfig, getAccountId } = require('@hubspot/cli-lib');
 const { createSandbox } = require('@hubspot/cli-lib/sandboxes');
 const { promptUser } = require('./prompts/promptUtils');
 const { syncSandbox } = require('./sandbox-sync');
-const {
-  setAsDefaultAccountPrompt,
-} = require('./prompts/setAsDefaultAccountPrompt');
-const { updateDefaultAccount } = require('@hubspot/cli-lib/lib/config');
 const { getValidEnv } = require('@hubspot/cli-lib/lib/environment');
 
 const i18nKey = 'cli.lib.sandbox.create';
@@ -51,7 +42,6 @@ const i18nKey = 'cli.lib.sandbox.create';
  * @param {Boolean} allowEarlyTermination - Option to allow a keypress to terminate early
  * @param {Boolean} allowSyncAssets - Option to allow user to sync assets after creation
  * @param {Boolean} allowContactRecordsSyncPrompt - Option to show prompt for syncing contact records, otherwise sync automatically
- * @param {Boolean} skipDefaultAccountPrompt - Option to skip default account prompt and auto set new sandbox account as default
  * @returns {Object} Object containing sandboxConfigName string and sandbox instance from API
  */
 const buildSandbox = async ({
@@ -62,7 +52,6 @@ const buildSandbox = async ({
   allowEarlyTermination = true,
   allowSyncAssets = true,
   allowContactRecordsSyncPrompt = true,
-  skipDefaultAccountPrompt = false,
   force = false,
 }) => {
   const spinnies = new Spinnies({
@@ -259,29 +248,6 @@ const buildSandbox = async ({
   } catch (err) {
     logErrorInstance(err);
     throw err;
-  }
-
-  if (skipDefaultAccountPrompt || force) {
-    updateDefaultAccount(sandboxConfigName);
-  } else {
-    const setAsDefault = await setAsDefaultAccountPrompt(sandboxConfigName);
-    if (setAsDefault) {
-      logger.success(
-        i18n(`cli.lib.prompts.setAsDefaultAccountPrompt.setAsDefaultAccount`, {
-          accountName: sandboxConfigName,
-        })
-      );
-    } else {
-      const config = getConfig();
-      logger.info(
-        i18n(
-          `cli.lib.prompts.setAsDefaultAccountPrompt.keepingCurrentDefault`,
-          {
-            accountName: config.defaultPortal,
-          }
-        )
-      );
-    }
   }
 
   // If creating standard sandbox, prompt user to sync assets

--- a/packages/cli/lib/sandbox-create.js
+++ b/packages/cli/lib/sandbox-create.js
@@ -50,6 +50,7 @@ const i18nKey = 'cli.lib.sandbox.create';
  * @param {String} env - Environment (QA/Prod)
  * @param {Boolean} allowEarlyTermination - Option to allow a keypress to terminate early
  * @param {Boolean} allowSyncAssets - Option to allow user to sync assets after creation
+ * @param {Boolean} allowContactRecordsSyncPrompt - Option to show prompt for syncing contact records, otherwise sync automatically
  * @param {Boolean} skipDefaultAccountPrompt - Option to skip default account prompt and auto set new sandbox account as default
  * @returns {Object} Object containing sandboxConfigName string and sandbox instance from API
  */
@@ -60,6 +61,7 @@ const buildSandbox = async ({
   env,
   allowEarlyTermination = true,
   allowSyncAssets = true,
+  allowContactRecordsSyncPrompt = true,
   skipDefaultAccountPrompt = false,
   force = false,
 }) => {
@@ -284,45 +286,39 @@ const buildSandbox = async ({
 
   // If creating standard sandbox, prompt user to sync assets
   if (allowSyncAssets) {
-    if (sandboxType === STANDARD_SANDBOX) {
-      const syncI18nKey = 'cli.lib.sandbox.sync';
-      const sandboxAccountConfig = getAccountConfig(
-        result.sandbox.sandboxHubId
-      );
-      const handleSyncSandbox = async () => {
-        await syncSandbox({
-          accountConfig: sandboxAccountConfig,
-          parentAccountConfig: accountConfig,
-          env,
-          allowEarlyTermination,
-        });
-      };
-      try {
+    const syncI18nKey = 'cli.lib.sandbox.sync';
+    const sandboxAccountConfig = getAccountConfig(result.sandbox.sandboxHubId);
+    const handleSyncSandbox = async () => {
+      await syncSandbox({
+        accountConfig: sandboxAccountConfig,
+        parentAccountConfig: accountConfig,
+        env,
+        allowEarlyTermination,
+        allowContactRecordsSyncPrompt,
+      });
+    };
+    try {
+      if (!force) {
         logger.log('');
-        if (!force) {
-          const { sandboxSyncPrompt } = await promptUser([
-            {
-              name: 'sandboxSyncPrompt',
-              type: 'confirm',
-              message: i18n(
-                `${syncI18nKey}.confirm.standardSandboxCreateFlow`,
-                {
-                  parentAccountName: getAccountName(accountConfig),
-                  sandboxName: getAccountName(sandboxAccountConfig),
-                }
-              ),
-            },
-          ]);
-          if (sandboxSyncPrompt) {
-            await handleSyncSandbox();
-          }
-        } else {
+        const { sandboxSyncPrompt } = await promptUser([
+          {
+            name: 'sandboxSyncPrompt',
+            type: 'confirm',
+            message: i18n(`${syncI18nKey}.confirm.createFlow.${sandboxType}`, {
+              parentAccountName: getAccountName(accountConfig),
+              sandboxName: getAccountName(sandboxAccountConfig),
+            }),
+          },
+        ]);
+        if (sandboxSyncPrompt) {
           await handleSyncSandbox();
         }
-      } catch (err) {
-        logErrorInstance(err);
-        throw err;
+      } else {
+        await handleSyncSandbox();
       }
+    } catch (err) {
+      logErrorInstance(err);
+      throw err;
     }
   }
 

--- a/packages/cli/lib/sandbox-sync.js
+++ b/packages/cli/lib/sandbox-sync.js
@@ -61,7 +61,6 @@ const syncSandbox = async ({
       );
     }
 
-    logger.log('');
     spinnies.add('sandboxSync', {
       text: i18n(`${i18nKey}.loading.startSync`),
     });

--- a/packages/cli/lib/sandboxes.js
+++ b/packages/cli/lib/sandboxes.js
@@ -22,6 +22,10 @@ const CliProgressMultibarManager = require('./CliProgressMultibarManager');
 const STANDARD_SANDBOX = 'standard';
 const DEVELOPER_SANDBOX = 'developer';
 
+const syncTypes = {
+  OBJECT_RECORDS: 'object-records',
+};
+
 const sandboxTypeMap = {
   DEV: DEVELOPER_SANDBOX,
   dev: DEVELOPER_SANDBOX,
@@ -250,7 +254,7 @@ function pollSyncTaskStatus(
             // Randomly increment bar while sync is in progress. Sandboxes currently does not have an accurate measurement for progress.
             progressCounter[taskType] = incrementBy(
               progressCounter[taskType],
-              taskType === 'object-records' ? 2 : 3 // slower progress for object-records, sync can take up to a few minutes
+              taskType === syncTypes.OBJECT_RECORDS ? 2 : 3 // slower progress for object-records, sync can take up to a few minutes
             );
             progressBar.update(taskType, progressCounter[taskType], {
               label: i18n(`${i18nKey}.${taskType}.label`),
@@ -276,6 +280,7 @@ module.exports = {
   DEVELOPER_SANDBOX,
   sandboxTypeMap,
   sandboxApiTypeMap,
+  syncTypes,
   getSandboxTypeAsString,
   getAccountName,
   saveSandboxToConfig,

--- a/packages/cli/lib/sandboxes.js
+++ b/packages/cli/lib/sandboxes.js
@@ -221,7 +221,7 @@ function pollSyncTaskStatus(
     logger.log('Exiting, sync will continue in the background.');
     logger.log('');
     logger.log(
-      i18n('cli.commands.sandbox.subcommands.sync.info.syncStatus', {
+      i18n('cli.lib.sandbox.sync.info.syncStatus', {
         url: syncStatusUrl,
       })
     );


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
Adds option to sync contact records when creating or syncing a sandbox. 

- Add user prompt to include or exclude object records from sync for both development sandboxes and standard sandboxes
- Refactored util function and moved most of the logic back to the command file. We will be handling automatic syncing in a separate file when I get to work on linking up `hs project dev` with these items. 
- We make an additional sandbox usage call to verify whether or not a user is at their portal limit. If they are, we error out immediately. 


## Screenshots
<!-- Provide images of the before and after functionality -->

<img width="1179" alt="Screenshot 2023-04-26 at 13 30 05" src="https://user-images.githubusercontent.com/16788677/234656111-b8e68b81-6a46-454e-8b7e-61e22dfc328e.png">

<img width="1177" alt="Screenshot 2023-04-26 at 13 30 34" src="https://user-images.githubusercontent.com/16788677/234656114-e54e2641-6848-4f9b-826d-8070d151edb6.png">


## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->
PAK generation is still not ready on BE, waiting to implement that

## Who to Notify
<!-- /cc those you wish to know about the PR -->
