### PR TITLE
Add projects list prompt to download command

### DIFF
--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -608,14 +608,13 @@ en:
             errors:
               downloadFailed: "Something went wrong downloading the project"
               projectNotFound: "Your project {{ projectName }} could not be found in {{ accountId }}"
-            positionals:
+            options:
+              buildNumber:
+                describe: "The build number to download"
               name:
                 describe: "The name of the project to download"
               dest:
                 describe: "Destination folder for the project"
-            options:
-              buildNumber:
-                describe: "The build number to download"
           open:
             describe: "Open available projects for the specified account"
             options:
@@ -1002,6 +1001,10 @@ en:
             nameRequired: "A project name is required"
             locationRequired: "A project location is required"
             invalidTemplate: "[--template] Could not find template {{ template }}. Please choose an available template."
+        downloadProjectPrompt:
+          selectProject: "Select a project to download:"
+          errors:
+            projectNotFound: "Your project {{ projectName }} could not be found in {{ accountId }}"
         projectAddPrompt:
           selectType: "[--type] Select your component type:"
           enterName: "[--name] Give your component a name: "

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -611,7 +611,7 @@ en:
             options:
               buildNumber:
                 describe: "The build number to download"
-              name:
+              project:
                 describe: "The name of the project to download"
               dest:
                 describe: "Destination folder for the project"
@@ -1004,7 +1004,7 @@ en:
         downloadProjectPrompt:
           selectProject: "Select a project to download:"
           errors:
-            projectNotFound: "Your project {{ projectName }} could not be found in {{ accountId }}"
+            projectNotFound: "Your project {{ projectName }} could not be found in {{ accountId }}. Please select a valid project:"
         projectAddPrompt:
           selectType: "[--type] Select your component type:"
           enterName: "[--name] Give your component a name: "

--- a/packages/cli/commands/project/download.js
+++ b/packages/cli/commands/project/download.js
@@ -30,15 +30,15 @@ const { i18n } = require('@hubspot/cli-lib/lib/lang');
 const i18nKey = 'cli.commands.project.subcommands.download';
 const { EXIT_CODES } = require('../../lib/enums/exitCodes');
 
-exports.command = 'download';
+exports.command = 'download [--project]';
 exports.describe = i18n(`${i18nKey}.describe`);
 
 exports.handler = async options => {
   await loadAndValidateOptions(options);
 
-  const { name, dest, buildNumber } = options;
-  const { name: promptedProjectName } = await downloadProjectPrompt(options);
-  const projectName = promptedProjectName || name;
+  const { project, dest, buildNumber } = options;
+  let { project: promptedProjectName } = await downloadProjectPrompt(options);
+  let projectName = promptedProjectName || project;
 
   const accountId = getAccountId(options);
 
@@ -56,7 +56,8 @@ exports.handler = async options => {
         accountId: chalk.bold(accountId),
       })
     );
-    process.exit(EXIT_CODES.ERROR);
+    let { name: promptedProjectName } = await downloadProjectPrompt(options);
+    let projectName = promptedProjectName || project;
   }
 
   const absoluteDestPath = dest ? path.resolve(getCwd(), dest) : getCwd();
@@ -126,8 +127,8 @@ exports.builder = yargs => {
   addUseEnvironmentOptions(yargs, true);
 
   yargs.options({
-    name: {
-      describe: i18n(`${i18nKey}.options.name.describe`),
+    project: {
+      describe: i18n(`${i18nKey}.options.project.describe`),
       type: 'string',
     },
     dest: {
@@ -142,7 +143,7 @@ exports.builder = yargs => {
 
   yargs.example([
     [
-      '$0 project download myProject myProjectFolder',
+      '$0 project download --project=myProject --dest=myProjectFolder',
       i18n(`${i18nKey}.examples.default`),
     ],
   ]);

--- a/packages/cli/commands/project/download.js
+++ b/packages/cli/commands/project/download.js
@@ -22,18 +22,24 @@ const {
   ensureProjectExists,
 } = require('../../lib/projects');
 const { loadAndValidateOptions } = require('../../lib/validation');
+const {
+  downloadProjectPrompt,
+} = require('../../lib/prompts/downloadProjectPrompt');
 const { i18n } = require('@hubspot/cli-lib/lib/lang');
 
 const i18nKey = 'cli.commands.project.subcommands.download';
 const { EXIT_CODES } = require('../../lib/enums/exitCodes');
 
-exports.command = 'download <name> [dest]';
+exports.command = 'download';
 exports.describe = i18n(`${i18nKey}.describe`);
 
 exports.handler = async options => {
   await loadAndValidateOptions(options);
 
-  const { name: projectName, dest, buildNumber } = options;
+  const { name, dest, buildNumber } = options;
+  const { name: promptedProjectName } = await downloadProjectPrompt(options);
+  const projectName = promptedProjectName || name;
+
   const accountId = getAccountId(options);
 
   trackCommandUsage('project-download', null, accountId);
@@ -119,23 +125,27 @@ exports.handler = async options => {
 exports.builder = yargs => {
   addUseEnvironmentOptions(yargs, true);
 
-  yargs.positional('name', {
-    describe: i18n(`${i18nKey}.positionals.name.describe`),
-    type: 'string',
+  yargs.options({
+    name: {
+      describe: i18n(`${i18nKey}.options.name.describe`),
+      type: 'string',
+    },
+    dest: {
+      describe: i18n(`${i18nKey}.options.dest.describe`),
+      type: 'string',
+    },
+    buildNumber: {
+      describe: i18n(`${i18nKey}.options.buildNumber.describe`),
+      type: 'number',
+    },
   });
-  yargs.positional('dest', {
-    describe: i18n(`${i18nKey}.positionals.dest.describe`),
-    type: 'string',
-  });
-  yargs.option('buildNumber', {
-    describe: i18n(`${i18nKey}.options.buildNumber.describe`),
-    type: 'number',
-  });
+
   yargs.example([
     [
       '$0 project download myProject myProjectFolder',
       i18n(`${i18nKey}.examples.default`),
     ],
   ]);
+
   return yargs;
 };

--- a/packages/cli/lib/prompts/downloadProjectPrompt.js
+++ b/packages/cli/lib/prompts/downloadProjectPrompt.js
@@ -15,19 +15,19 @@ const downloadProjectPrompt = async (promptOptions = {}) => {
 
   return promptUser([
     {
-      name: 'name',
+      name: 'project',
       message: () => {
-        return promptOptions.name &&
+        return promptOptions.project &&
           !projectsList.find(p => p.name === promptOptions.name)
           ? i18n(`${i18nKey}.errors.projectNotFound`, {
-              projectName: promptOptions.name,
+              projectName: promptOptions.project,
               accountId: getAccountId(),
             })
           : i18n(`${i18nKey}.selectProject`);
       },
       when:
-        !promptOptions.name ||
-        !projectsList.find(p => p.name === promptOptions.name),
+        !promptOptions.project ||
+        !projectsList.find(p => p.name === promptOptions.project),
       type: 'list',
       choices: projectsList.map(project => {
         return {

--- a/packages/cli/lib/prompts/downloadProjectPrompt.js
+++ b/packages/cli/lib/prompts/downloadProjectPrompt.js
@@ -1,0 +1,44 @@
+const { promptUser } = require('./promptUtils');
+const { getAccountId } = require('@hubspot/cli-lib/lib/config');
+const { fetchProjects } = require('@hubspot/cli-lib/api/dfs');
+const { i18n } = require('@hubspot/cli-lib/lib/lang');
+
+const i18nKey = 'cli.lib.prompts.downloadProjectPrompt';
+
+const createProjectsList = async () => {
+  const projects = await fetchProjects(getAccountId());
+  return projects.results;
+};
+
+const downloadProjectPrompt = async (promptOptions = {}) => {
+  const projectsList = await createProjectsList();
+
+  return promptUser([
+    {
+      name: 'name',
+      message: () => {
+        return promptOptions.name &&
+          !projectsList.find(p => p.name === promptOptions.name)
+          ? i18n(`${i18nKey}.errors.projectNotFound`, {
+              projectName: promptOptions.name,
+              accountId: getAccountId(),
+            })
+          : i18n(`${i18nKey}.selectProject`);
+      },
+      when:
+        !promptOptions.name ||
+        !projectsList.find(p => p.name === promptOptions.name),
+      type: 'list',
+      choices: projectsList.map(project => {
+        return {
+          name: project.name,
+          value: project.name,
+        };
+      }),
+    },
+  ]);
+};
+
+module.exports = {
+  downloadProjectPrompt,
+};


### PR DESCRIPTION
## Description and Context
I've added a prompt with a list of projects from which the customer can choose when using the `project download` command. 

An important note: I changed the functionality of this command a bit by making two positionals optional now (`name` and `dest`). Pros: This would bring the `download` command more in line with our current style guidelines. Cons: This would also constitute a breaking change and makes for a more complicated release. I'm wondering whether this is the best path forward. Would love some feedback, @brandenrodgers, @camden11. 

## Screenshots
<!-- Provide images of the before and after functionality -->
Before:

<img width="1167" alt="Screenshot 2023-04-28 at 4 23 44 PM" src="https://user-images.githubusercontent.com/25392256/235247856-d3d1bc5d-ee50-4cbf-a7ff-9fdea4852de5.png">

After:

<img width="1097" alt="Screenshot 2023-04-28 at 4 24 13 PM" src="https://user-images.githubusercontent.com/25392256/235247605-c95fffe5-0254-4a1f-a13c-49dbd6e14710.png">
<img width="1047" alt="Screenshot 2023-04-28 at 4 25 14 PM" src="https://user-images.githubusercontent.com/25392256/235247653-09f02944-bb39-4767-bef0-404c6827443b.png">


## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->
 
- [x] I will possibly need to revise to bring back positional arguments. 

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@camden11 @brandenrodgers 
