### PR TITLE
Lazy load lang data, allow overriding of lang files

### DIFF
--- a/packages/cli-lib/lib/lang.js
+++ b/packages/cli-lib/lib/lang.js
@@ -68,6 +68,10 @@ const getTextValue = lookupDotNotation => {
 };
 
 const i18n = (lookupDotNotation, options = {}) => {
+  if (!languageObj) {
+    loadLanguageFromYaml();
+  }
+
   if (typeof lookupDotNotation !== 'string') {
     throw new Error(
       `i18n must be passed a string value for lookupDotNotation, received ${typeof lookupDotNotation}`
@@ -80,8 +84,12 @@ const i18n = (lookupDotNotation, options = {}) => {
   return shouldInterpolate ? interpolate(textValue, options) : textValue;
 };
 
-loadLanguageFromYaml();
+const setLangData = (newLocale, newLangObj) => {
+  locale = newLocale;
+  languageObj = newLangObj;
+};
 
 module.exports = {
   i18n,
+  setLangData,
 };


### PR DESCRIPTION
## Description and Context
Updates `cli-lib/lib/lang.js` to wait until `i18n` is first called to load language data if it isn't present, instead of at import.

This allows for the VSCode extension to manually set the language data ahead of use. `loadLanguageFromYaml()` will error out when used in VSCode because `cli-lib` gets bundled with extension code using webpack, and the `en.lyaml` gets fetched directly from the filesystem. I've set up VSCode to keep and maintain a copy of `en.lyaml` so it can be bundled properly here: https://github.com/HubSpot/hubspot-cms-vscode/pull/226

This should hopefully just be a bandaid solution until migration is complete and we can add a build step on `cli-lib`'s end, but I've set it up to automatically download the `en.lyaml` of the resolved `cli-lib` version on precommit so it should be OK to stay as long as needed.
