### PR TITLE
Add flag for custom repo 

### DIFF
--- a/packages/cli-lib/github.js
+++ b/packages/cli-lib/github.js
@@ -135,13 +135,11 @@ async function cloneGitHubRepo(dest, type, repoName, sourceDir, options = {}) {
   return success;
 }
 
-async function getGitHubRepoContentsAtPath(repoName, path, repoPath = '') {
-  let contentsRequestUrl;
-  if (repoPath) {
-    contentsRequestUrl = `https://api.github.com/repos/${repoPath}/contents/${path}`;
-  } else {
-    contentsRequestUrl = `https://api.github.com/repos/HubSpot/${repoName}/contents/${path}`;
-  }
+async function getGitHubRepoContentsAtPath(
+  repoPath = 'HubSpot/hubspot-project-components',
+  path
+) {
+  const contentsRequestUrl = `https://api.github.com/repos/${repoPath}/contents/${path}`;
 
   return request.get(contentsRequestUrl, {
     json: true,
@@ -170,7 +168,6 @@ async function downloadGitHubRepoContents(
   dest,
   options = {
     filter: false,
-    repoPath: '',
   }
 ) {
   fs.ensureDirSync(path.dirname(dest));
@@ -178,8 +175,7 @@ async function downloadGitHubRepoContents(
   try {
     const contentsResp = await getGitHubRepoContentsAtPath(
       repoName,
-      contentPath,
-      options.repoPath
+      contentPath
     );
 
     const downloadContentRecursively = async contentPiece => {

--- a/packages/cli-lib/github.js
+++ b/packages/cli-lib/github.js
@@ -34,11 +34,13 @@ async function fetchJsonFromRepository(
       headers: { ...DEFAULT_USER_AGENT_HEADERS, ...GITHUB_AUTH_HEADERS },
     });
   } catch (err) {
-    logger.error('An error occured fetching JSON file.');
     if (repoPath && err.statusCode === 404) {
-      return logger.error(
+      logger.error(
         i18n(`cli.lib.prompts.createProjectPrompt.errors.failedToFetchJson`)
       );
+      process.exit(1);
+    } else {
+      logger.error('An error occured fetching JSON file.');
     }
     logErrorInstance(err);
   }

--- a/packages/cli-lib/github.js
+++ b/packages/cli-lib/github.js
@@ -19,9 +19,18 @@ const GITHUB_AUTH_HEADERS = {
  * @param {String} repoName - name of the github repository
  * @returns {Buffer|Null} Zip data buffer
  */
-async function fetchJsonFromRepository(repoName, filePath) {
+async function fetchJsonFromRepository(
+  repoName,
+  filePath,
+  customRepoPath = false
+) {
   try {
-    const URI = `https://raw.githubusercontent.com/HubSpot/${repoName}/${filePath}`;
+    let URI;
+    if (customRepoPath) {
+      URI = `https://raw.githubusercontent.com/${repoName}/${filePath}`;
+    } else {
+      URI = `https://raw.githubusercontent.com/HubSpot/${repoName}/${filePath}`;
+    }
     logger.debug(`Fetching ${URI}...`);
 
     return request.get(URI, {

--- a/packages/cli-lib/github.js
+++ b/packages/cli-lib/github.js
@@ -20,14 +20,13 @@ const GITHUB_AUTH_HEADERS = {
  * @param {String} repoName - name of the github repository
  * @returns {Buffer|Null} Zip data buffer
  */
-async function fetchJsonFromRepository(repoName, filePath, repoPath = false) {
+async function fetchJsonFromRepository(
+  repoName = 'HubSpot/hubspot-project-components',
+  filePath,
+  repoPath = false
+) {
   try {
-    let URI;
-    if (repoPath) {
-      URI = `https://raw.githubusercontent.com/${repoName}/${filePath}`;
-    } else {
-      URI = `https://raw.githubusercontent.com/HubSpot/${repoName}/${filePath}`;
-    }
+    const URI = `https://raw.githubusercontent.com/${repoName}/${filePath}`;
     logger.debug(`Fetching ${URI}...`);
 
     return await request.get(URI, {

--- a/packages/cli-lib/github.js
+++ b/packages/cli-lib/github.js
@@ -1,13 +1,13 @@
 const request = require('request-promise-native');
 const path = require('path');
 const fs = require('fs-extra');
-const { i18n } = require('@hubspot/cli-lib/lib/lang');
 
 const { logger } = require('./logger');
 const { logErrorInstance } = require('./errorHandlers');
 const { extractZipArchive } = require('./archive');
 
 const { GITHUB_RELEASE_TYPES } = require('./lib/constants');
+const { i18n } = require('./lib/lang');
 const { DEFAULT_USER_AGENT_HEADERS } = require('./http/requestOptions');
 
 const GITHUB_AUTH_HEADERS = {

--- a/packages/cli-lib/github.js
+++ b/packages/cli-lib/github.js
@@ -133,8 +133,17 @@ async function cloneGitHubRepo(dest, type, repoName, sourceDir, options = {}) {
   return success;
 }
 
-async function getGitHubRepoContentsAtPath(repoName, path) {
-  const contentsRequestUrl = `https://api.github.com/repos/HubSpot/${repoName}/contents/${path}`;
+async function getGitHubRepoContentsAtPath(
+  repoName,
+  path,
+  customRepoPath = ''
+) {
+  let contentsRequestUrl;
+  if (customRepoPath) {
+    contentsRequestUrl = `https://api.github.com/repos/${customRepoPath}/contents/${path}`;
+  } else {
+    contentsRequestUrl = `https://api.github.com/repos/HubSpot/${repoName}/contents/${path}`;
+  }
 
   return request.get(contentsRequestUrl, {
     json: true,
@@ -163,6 +172,7 @@ async function downloadGitHubRepoContents(
   dest,
   options = {
     filter: false,
+    customRepoPath: '',
   }
 ) {
   fs.ensureDirSync(path.dirname(dest));
@@ -170,7 +180,8 @@ async function downloadGitHubRepoContents(
   try {
     const contentsResp = await getGitHubRepoContentsAtPath(
       repoName,
-      contentPath
+      contentPath,
+      options.customRepoPath
     );
 
     const downloadContentRecursively = async contentPiece => {

--- a/packages/cli-lib/github.js
+++ b/packages/cli-lib/github.js
@@ -19,14 +19,10 @@ const GITHUB_AUTH_HEADERS = {
  * @param {String} repoName - name of the github repository
  * @returns {Buffer|Null} Zip data buffer
  */
-async function fetchJsonFromRepository(
-  repoName,
-  filePath,
-  customRepoPath = false
-) {
+async function fetchJsonFromRepository(repoName, filePath, repoPath = false) {
   try {
     let URI;
-    if (customRepoPath) {
+    if (repoPath) {
       URI = `https://raw.githubusercontent.com/${repoName}/${filePath}`;
     } else {
       URI = `https://raw.githubusercontent.com/HubSpot/${repoName}/${filePath}`;
@@ -133,14 +129,10 @@ async function cloneGitHubRepo(dest, type, repoName, sourceDir, options = {}) {
   return success;
 }
 
-async function getGitHubRepoContentsAtPath(
-  repoName,
-  path,
-  customRepoPath = ''
-) {
+async function getGitHubRepoContentsAtPath(repoName, path, repoPath = '') {
   let contentsRequestUrl;
-  if (customRepoPath) {
-    contentsRequestUrl = `https://api.github.com/repos/${customRepoPath}/contents/${path}`;
+  if (repoPath) {
+    contentsRequestUrl = `https://api.github.com/repos/${repoPath}/contents/${path}`;
   } else {
     contentsRequestUrl = `https://api.github.com/repos/HubSpot/${repoName}/contents/${path}`;
   }
@@ -172,7 +164,7 @@ async function downloadGitHubRepoContents(
   dest,
   options = {
     filter: false,
-    customRepoPath: '',
+    repoPath: '',
   }
 ) {
   fs.ensureDirSync(path.dirname(dest));
@@ -181,7 +173,7 @@ async function downloadGitHubRepoContents(
     const contentsResp = await getGitHubRepoContentsAtPath(
       repoName,
       contentPath,
-      options.customRepoPath
+      options.repoPath
     );
 
     const downloadContentRecursively = async contentPiece => {

--- a/packages/cli-lib/github.js
+++ b/packages/cli-lib/github.js
@@ -1,6 +1,7 @@
 const request = require('request-promise-native');
 const path = require('path');
 const fs = require('fs-extra');
+const { i18n } = require('@hubspot/cli-lib/lib/lang');
 
 const { logger } = require('./logger');
 const { logErrorInstance } = require('./errorHandlers');
@@ -29,12 +30,17 @@ async function fetchJsonFromRepository(repoName, filePath, repoPath = false) {
     }
     logger.debug(`Fetching ${URI}...`);
 
-    return request.get(URI, {
+    return await request.get(URI, {
       json: true,
       headers: { ...DEFAULT_USER_AGENT_HEADERS, ...GITHUB_AUTH_HEADERS },
     });
   } catch (err) {
     logger.error('An error occured fetching JSON file.');
+    if (repoPath && err.statusCode === 404) {
+      return logger.error(
+        i18n(`cli.lib.prompts.createProjectPrompt.errors.failedtofetchJson`)
+      );
+    }
     logErrorInstance(err);
   }
   return null;

--- a/packages/cli-lib/github.js
+++ b/packages/cli-lib/github.js
@@ -37,7 +37,7 @@ async function fetchJsonFromRepository(
     logger.error('An error occured fetching JSON file.');
     if (repoPath && err.statusCode === 404) {
       return logger.error(
-        i18n(`cli.lib.prompts.createProjectPrompt.errors.failedtofetchJson`)
+        i18n(`cli.lib.prompts.createProjectPrompt.errors.failedToFetchJson`)
       );
     }
     logErrorInstance(err);

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -461,7 +461,7 @@ en:
                 describe: "Project name (cannot be changed)"
               template:
                 describe: "The starting template"
-              customRepoPath:
+              repoPath:
                 describe: "Path to custom GitHub repository from which to create project template"
           add:
             describe: "Create a new component within a project"

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -1011,6 +1011,8 @@ en:
             locationRequired: "A project location is required"
             invalidTemplate: "[--template] Could not find template {{ template }}. Please choose an available template."
             failedToFetchJson: "Please ensure that the repo path you've entered is correct, and there is a config.json file in the root of your repo."
+            noProjectsInConfig: "Please ensure that the config.json file contains a \"projects\" field."
+            missingPropertiesInConfig: "Please ensure that each of the projects in your config.json file contain the following properties: [\"name\", \"label\", \"path\", \"insertPath\"]."
         downloadProjectPrompt:
           selectProject: "Select a project to download:"
           errors:

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -1010,8 +1010,7 @@ en:
             nameRequired: "A project name is required"
             locationRequired: "A project location is required"
             invalidTemplate: "[--template] Could not find template {{ template }}. Please choose an available template."
-            failedtofetchJson: "Please ensure that the repo path you've entered is correct.
-            \n Please also ensure that the config.json file is located in the root of your repo."
+            failedToFetchJson: "Please ensure that the repo path you've entered is correct, and there is a config.json file in the root of your repo."
         downloadProjectPrompt:
           selectProject: "Select a project to download:"
           errors:

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -461,8 +461,8 @@ en:
                 describe: "Project name (cannot be changed)"
               template:
                 describe: "The starting template"
-              customRepo:
-                describe: "Custom repository from which to create project template"
+              customRepoPath:
+                describe: "Path to custom GitHub repository from which to create project template"
           add:
             describe: "Create a new component within a project"
             options:

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -1010,6 +1010,8 @@ en:
             nameRequired: "A project name is required"
             locationRequired: "A project location is required"
             invalidTemplate: "[--template] Could not find template {{ template }}. Please choose an available template."
+            failedtofetchJson: "Please ensure that the repo path you've entered is correct.
+            \n Please also ensure that the config.json file is located in the root of your repo."
         downloadProjectPrompt:
           selectProject: "Select a project to download:"
           errors:

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -1011,7 +1011,7 @@ en:
             locationRequired: "A project location is required"
             invalidTemplate: "[--template] Could not find template {{ template }}. Please choose an available template."
             failedToFetchJson: "Please ensure that the repo path you've entered is correct, and there is a config.json file in the root of your repo."
-            noProjectsInConfig: "Please ensure that the config.json file contains a \"projects\" field."
+            noProjectsInConfig: "Please ensure that there is a config.json file that contains a \"projects\" field."
             missingPropertiesInConfig: "Please ensure that each of the projects in your config.json file contain the following properties: [\"name\", \"label\", \"path\", \"insertPath\"]."
         downloadProjectPrompt:
           selectProject: "Select a project to download:"

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -461,6 +461,8 @@ en:
                 describe: "Project name (cannot be changed)"
               template:
                 describe: "The starting template"
+              customRepo:
+                describe: "Custom repository from which to create project template"
           add:
             describe: "Create a new component within a project"
             options:

--- a/packages/cli-lib/lib/constants.js
+++ b/packages/cli-lib/lib/constants.js
@@ -124,6 +124,8 @@ const PROJECT_TEMPLATES = [
   },
 ];
 
+const PROJECT_PROPERTIES = ['name', 'label', 'path', 'insertPath'];
+
 const TEMPLATE_TYPES = {
   unmapped: 0,
   email_base_template: 1,
@@ -268,6 +270,7 @@ module.exports = {
   PROJECT_DEPLOY_TEXT,
   PROJECT_TASK_TYPES,
   PROJECT_COMPONENT_TYPES,
+  PROJECT_PROPERTIES,
   SCOPE_GROUPS,
   SPINNER_STATUS,
   TEMPLATE_TYPES,

--- a/packages/cli-lib/modules.js
+++ b/packages/cli-lib/modules.js
@@ -245,7 +245,7 @@ const createModule = async (
   );
 
   await downloadGitHubRepoContents(
-    'cms-sample-assets',
+    'HubSpot/cms-sample-assets',
     'modules/Sample.module',
     destPath,
     { filter: moduleFileFilter }

--- a/packages/cli-lib/templates.js
+++ b/packages/cli-lib/templates.js
@@ -89,7 +89,11 @@ const createTemplate = async (
       path: filePath,
     })
   );
-  await downloadGitHubRepoContents('cms-sample-assets', assetPath, filePath);
+  await downloadGitHubRepoContents(
+    'HubSpot/cms-sample-assets',
+    assetPath,
+    filePath
+  );
 };
 
 module.exports = {

--- a/packages/cli/commands/create/api-sample.js
+++ b/packages/cli/commands/create/api-sample.js
@@ -39,7 +39,7 @@ module.exports = {
     const downloadSpinner = ora(i18n(`${i18nKey}.loading.apiSamples`));
     downloadSpinner.start();
     const samplesConfig = await fetchJsonFromRepository(
-      'sample-apps-list',
+      'HubSpot/sample-apps-list',
       'main/samples.json'
     );
     downloadSpinner.stop();

--- a/packages/cli/commands/project/create.js
+++ b/packages/cli/commands/project/create.js
@@ -34,7 +34,8 @@ exports.handler = async options => {
   await createProjectConfig(
     path.resolve(getCwd(), options.location || location),
     options.name || name,
-    options.template || template
+    options.template || template,
+    options.customRepoPath
   );
 
   logger.log('');
@@ -61,8 +62,8 @@ exports.builder = yargs => {
       describe: i18n(`${i18nKey}.options.template.describe`),
       type: 'string',
     },
-    customRepo: {
-      describe: i18n(`${i18nKey}.options.customRepo.describe`),
+    customRepoPath: {
+      describe: i18n(`${i18nKey}.options.customRepoPath.describe`),
       type: 'string',
     },
   });

--- a/packages/cli/commands/project/create.js
+++ b/packages/cli/commands/project/create.js
@@ -61,6 +61,10 @@ exports.builder = yargs => {
       describe: i18n(`${i18nKey}.options.template.describe`),
       type: 'string',
     },
+    customRepo: {
+      describe: i18n(`${i18nKey}.options.customRepo.describe`),
+      type: 'string',
+    },
   });
 
   yargs.example([['$0 project create', i18n(`${i18nKey}.examples.default`)]]);

--- a/packages/cli/commands/project/create.js
+++ b/packages/cli/commands/project/create.js
@@ -35,7 +35,7 @@ exports.handler = async options => {
     path.resolve(getCwd(), options.location || location),
     options.name || name,
     options.template || template,
-    options.customRepoPath
+    options.repoPath
   );
 
   logger.log('');
@@ -62,8 +62,8 @@ exports.builder = yargs => {
       describe: i18n(`${i18nKey}.options.template.describe`),
       type: 'string',
     },
-    customRepoPath: {
-      describe: i18n(`${i18nKey}.options.customRepoPath.describe`),
+    repoPath: {
+      describe: i18n(`${i18nKey}.options.repoPath.describe`),
       type: 'string',
     },
   });

--- a/packages/cli/lib/projects.js
+++ b/packages/cli/lib/projects.js
@@ -84,7 +84,12 @@ const getProjectConfig = async _dir => {
   }
 };
 
-const createProjectConfig = async (projectPath, projectName, template) => {
+const createProjectConfig = async (
+  projectPath,
+  projectName,
+  template,
+  customRepoPath = ''
+) => {
   const { projectConfig, projectDir } = await getProjectConfig(projectPath);
 
   if (projectConfig) {
@@ -131,7 +136,8 @@ const createProjectConfig = async (projectPath, projectName, template) => {
     await downloadGitHubRepoContents(
       'hubspot-project-components',
       template.path,
-      projectPath
+      projectPath,
+      { customRepoPath }
     );
     const _config = JSON.parse(fs.readFileSync(projectConfigPath));
     writeProjectConfig(projectConfigPath, {

--- a/packages/cli/lib/projects.js
+++ b/packages/cli/lib/projects.js
@@ -88,7 +88,7 @@ const createProjectConfig = async (
   projectPath,
   projectName,
   template,
-  customRepoPath = ''
+  repoPath = ''
 ) => {
   const { projectConfig, projectDir } = await getProjectConfig(projectPath);
 
@@ -137,7 +137,7 @@ const createProjectConfig = async (
       'hubspot-project-components',
       template.path,
       projectPath,
-      { customRepoPath }
+      { repoPath }
     );
     const _config = JSON.parse(fs.readFileSync(projectConfigPath));
     writeProjectConfig(projectConfigPath, {

--- a/packages/cli/lib/projects.js
+++ b/packages/cli/lib/projects.js
@@ -88,7 +88,7 @@ const createProjectConfig = async (
   projectPath,
   projectName,
   template,
-  repoPath = ''
+  repoPath
 ) => {
   const { projectConfig, projectDir } = await getProjectConfig(projectPath);
 
@@ -133,12 +133,7 @@ const createProjectConfig = async (
       srcDir: 'src',
     });
   } else {
-    await downloadGitHubRepoContents(
-      'hubspot-project-components',
-      template.path,
-      projectPath,
-      { repoPath }
-    );
+    await downloadGitHubRepoContents(repoPath, template.path, projectPath);
     const _config = JSON.parse(fs.readFileSync(projectConfigPath));
     writeProjectConfig(projectConfigPath, {
       ..._config,
@@ -641,7 +636,7 @@ const createProjectComponent = async (component, name) => {
   );
 
   await downloadGitHubRepoContents(
-    'hubspot-project-components',
+    'HubSpot/hubspot-project-components',
     component.path,
     componentPath
   );

--- a/packages/cli/lib/prompts/createProjectPrompt.js
+++ b/packages/cli/lib/prompts/createProjectPrompt.js
@@ -7,24 +7,20 @@ const { i18n } = require('@hubspot/cli-lib/lib/lang');
 
 const i18nKey = 'cli.lib.prompts.createProjectPrompt';
 
-const createTemplateOptions = async customRepoPath => {
-  const repoName = customRepoPath
-    ? customRepoPath
-    : 'hubspot-project-components';
-  const isCustomRepoPath = !!customRepoPath;
+const createTemplateOptions = async repoPath => {
+  const repoName = repoPath ? repoPath : 'hubspot-project-components';
+  const isRepoPath = !!repoPath;
   const config = await fetchJsonFromRepository(
     repoName,
     'main/config.json',
-    isCustomRepoPath
+    isRepoPath
   );
 
   return config[PROJECT_COMPONENT_TYPES.PROJECTS];
 };
 
 const createProjectPrompt = async (promptOptions = {}) => {
-  const projectTemplates = await createTemplateOptions(
-    promptOptions.customRepoPath
-  );
+  const projectTemplates = await createTemplateOptions(promptOptions.repoPath);
 
   return promptUser([
     {

--- a/packages/cli/lib/prompts/createProjectPrompt.js
+++ b/packages/cli/lib/prompts/createProjectPrompt.js
@@ -7,13 +7,15 @@ const { i18n } = require('@hubspot/cli-lib/lib/lang');
 
 const i18nKey = 'cli.lib.prompts.createProjectPrompt';
 
-const createTemplateOptions = async repoPath => {
-  const repoName = repoPath ? repoPath : 'hubspot-project-components';
-  const isCustomRepo = !!repoPath;
+const createTemplateOptions = async customRepoPath => {
+  const repoName = customRepoPath
+    ? customRepoPath
+    : 'hubspot-project-components';
+  const isCustomRepoPath = !!customRepoPath;
   const config = await fetchJsonFromRepository(
     repoName,
     'main/config.json',
-    isCustomRepo
+    isCustomRepoPath
   );
 
   return config[PROJECT_COMPONENT_TYPES.PROJECTS];
@@ -21,7 +23,7 @@ const createTemplateOptions = async repoPath => {
 
 const createProjectPrompt = async (promptOptions = {}) => {
   const projectTemplates = await createTemplateOptions(
-    promptOptions.customRepo
+    promptOptions.customRepoPath
   );
 
   return promptUser([

--- a/packages/cli/lib/prompts/createProjectPrompt.js
+++ b/packages/cli/lib/prompts/createProjectPrompt.js
@@ -1,11 +1,23 @@
 const path = require('path');
 const { getCwd } = require('@hubspot/cli-lib/path');
-const { PROJECT_COMPONENT_TYPES } = require('@hubspot/cli-lib/lib/constants');
+const {
+  PROJECT_COMPONENT_TYPES,
+  PROJECT_PROPERTIES,
+} = require('@hubspot/cli-lib/lib/constants');
 const { promptUser } = require('./promptUtils');
 const { fetchJsonFromRepository } = require('@hubspot/cli-lib/github');
 const { i18n } = require('@hubspot/cli-lib/lib/lang');
+const { logger } = require('@hubspot/cli-lib/logger');
 
 const i18nKey = 'cli.lib.prompts.createProjectPrompt';
+
+const hasAllProperties = projectList => {
+  return projectList.every(config =>
+    PROJECT_PROPERTIES.every(p =>
+      Object.prototype.hasOwnProperty.call(config, p)
+    )
+  );
+};
 
 const createTemplateOptions = async repoPath => {
   const isRepoPath = !!repoPath;
@@ -14,6 +26,14 @@ const createTemplateOptions = async repoPath => {
     'main/config.json',
     isRepoPath
   );
+
+  if (!config[PROJECT_COMPONENT_TYPES.PROJECTS]) {
+    return logger.error(i18n(`${i18nKey}.errors.noProjectsInConfig`));
+  }
+
+  if (!hasAllProperties(config[PROJECT_COMPONENT_TYPES.PROJECTS])) {
+    return logger.error(i18n(`${i18nKey}.errors.missingPropertiesInConfig`));
+  }
 
   return config[PROJECT_COMPONENT_TYPES.PROJECTS];
 };

--- a/packages/cli/lib/prompts/createProjectPrompt.js
+++ b/packages/cli/lib/prompts/createProjectPrompt.js
@@ -8,10 +8,9 @@ const { i18n } = require('@hubspot/cli-lib/lib/lang');
 const i18nKey = 'cli.lib.prompts.createProjectPrompt';
 
 const createTemplateOptions = async repoPath => {
-  const repoName = repoPath ? repoPath : 'hubspot-project-components';
   const isRepoPath = !!repoPath;
   const config = await fetchJsonFromRepository(
-    repoName,
+    repoPath,
     'main/config.json',
     isRepoPath
   );

--- a/packages/cli/lib/prompts/createProjectPrompt.js
+++ b/packages/cli/lib/prompts/createProjectPrompt.js
@@ -8,6 +8,7 @@ const { promptUser } = require('./promptUtils');
 const { fetchJsonFromRepository } = require('@hubspot/cli-lib/github');
 const { i18n } = require('@hubspot/cli-lib/lib/lang');
 const { logger } = require('@hubspot/cli-lib/logger');
+const { EXIT_CODES } = require('../../lib/enums/exitCodes');
 
 const i18nKey = 'cli.lib.prompts.createProjectPrompt';
 
@@ -27,12 +28,14 @@ const createTemplateOptions = async repoPath => {
     isRepoPath
   );
 
-  if (!config[PROJECT_COMPONENT_TYPES.PROJECTS]) {
-    return logger.error(i18n(`${i18nKey}.errors.noProjectsInConfig`));
+  if (!config || !config[PROJECT_COMPONENT_TYPES.PROJECTS]) {
+    logger.error(i18n(`${i18nKey}.errors.noProjectsInConfig`));
+    process.exit(EXIT_CODES.ERROR);
   }
 
   if (!hasAllProperties(config[PROJECT_COMPONENT_TYPES.PROJECTS])) {
-    return logger.error(i18n(`${i18nKey}.errors.missingPropertiesInConfig`));
+    logger.error(i18n(`${i18nKey}.errors.missingPropertiesInConfig`));
+    process.exit(EXIT_CODES.ERROR);
   }
 
   return config[PROJECT_COMPONENT_TYPES.PROJECTS];

--- a/packages/cli/lib/prompts/createProjectPrompt.js
+++ b/packages/cli/lib/prompts/createProjectPrompt.js
@@ -7,17 +7,22 @@ const { i18n } = require('@hubspot/cli-lib/lib/lang');
 
 const i18nKey = 'cli.lib.prompts.createProjectPrompt';
 
-const createTemplateOptions = async () => {
+const createTemplateOptions = async repoPath => {
+  const repoName = repoPath ? repoPath : 'hubspot-project-components';
+  const isCustomRepo = !!repoPath;
   const config = await fetchJsonFromRepository(
-    'hubspot-project-components',
-    'main/config.json'
+    repoName,
+    'main/config.json',
+    isCustomRepo
   );
 
   return config[PROJECT_COMPONENT_TYPES.PROJECTS];
 };
 
 const createProjectPrompt = async (promptOptions = {}) => {
-  const projectTemplates = await createTemplateOptions();
+  const projectTemplates = await createTemplateOptions(
+    promptOptions.customRepo
+  );
 
   return promptUser([
     {

--- a/packages/cli/lib/prompts/projectAddPrompt.js
+++ b/packages/cli/lib/prompts/projectAddPrompt.js
@@ -7,7 +7,7 @@ const i18nKey = 'cli.lib.prompts.projectAddPrompt';
 
 const createTypeOptions = async () => {
   const config = await fetchJsonFromRepository(
-    'hubspot-project-components',
+    'HubSpot/hubspot-project-components',
     'main/config.json'
   );
 


### PR DESCRIPTION
## Description and Context
In this PR, I've added a custom `--repoPath` flag to the `hs project create` command, so that customers can generate project templates from a GitHub repository of their choice.

Some notes: 

1) The `repoPath` flag must follow this pattern: `'<ownerName>/<repoName>'`. For example, the path to the repo `hubspot-project-components` owned by `HubSpot` is written as: `HubSpot/hubspot-project-components`. 

2) The repository must have a `config.json` file at its root that follows the pattern of the [config.json](https://github.com/HubSpot/hubspot-project-components/blob/main/config.json) file in the `hubspot-project-components` repo. All projects must be listed under the `projects` property in the config file.

## Screenshots
<!-- Provide images of the before and after functionality -->

<img width="1786" alt="Screenshot 2023-05-09 at 12 38 23 PM" src="https://github.com/HubSpot/hubspot-cli/assets/25392256/a4c32e21-04f8-41ea-ad0d-b0c2f7a971c7">

Erroring out with incorrect repo path:

<img width="2427" alt="Screenshot 2023-05-09 at 12 38 40 PM" src="https://github.com/HubSpot/hubspot-cli/assets/25392256/63f01653-acd3-4676-bae2-89af4470575c">

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

- [x] Reasonable error handling if customer inputs an incorrect `repoPath` flag with information about how to fix the config.json file. 

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@brandenrodgers @camden11 
