### PR TITLE
Programmatically check for github integration

### DIFF
--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -878,10 +878,12 @@ en:
         status:
           clean: "{{#bold}}Status:{{/bold}} {{#green}}Everything up to date{{/green}}"
           uploadPending: "{{#bold}}Status:{{/bold}} {{#yellow}}Upload is pending{{/yellow}}"
-          uploadPrevented: "{{#bold}}Status:{{/bold}} {{#yellow}}Change requires manual upload{{/yellow}}"
+          noUploadsAllowed: "{{#bold}}Status:{{/bold}} {{#red}}Change requires upload, but uploads are not allowed{{/red}}"
+          manualUploadRequired: "{{#bold}}Status:{{/bold}} {{#yellow}}Change requires manual upload{{/yellow}}"
           supportedChange: "{{#bold}}Status:{{/bold}} {{#green}}Change handled by local dev server{{/green}}"
           manualUpload: "{{#bold}}Status:{{/bold}} {{#green}}Manually uploading prevented changes{{/green}}"
         upload:
+          noUploadsAllowed: "The change to {{ filePath }} requires an upload, but the CLI cannot upload to a project that is using a github integration."
           manualUploadSkipped: "Manual upload skipped. Some changes may not be visible."
           manualUploadRequired: "Project config files changed, manual upload and deploy is needed ..."
           manualUploadExplanation1: "{{#yellow}}> Dev server is running on a {{#bold}}non-sandbox account{{/bold}}.{{/yellow}}"

--- a/packages/cli/commands/project/dev.js
+++ b/packages/cli/commands/project/dev.js
@@ -10,7 +10,7 @@ const { loadAndValidateOptions } = require('../../lib/validation');
 const { i18n } = require('@hubspot/cli-lib/lib/lang');
 const { logger } = require('@hubspot/cli-lib/logger');
 const { getConfigAccounts } = require('@hubspot/cli-lib/lib/config');
-const { createProject } = require('@hubspot/cli-lib/api/dfs');
+const { createProject, fetchProject } = require('@hubspot/cli-lib/api/dfs');
 const { handleExit } = require('@hubspot/cli-lib/lib/process');
 const {
   getProjectConfig,
@@ -25,7 +25,10 @@ const {
   selectTargetAccountPrompt,
 } = require('../../lib/prompts/projectDevTargetAccountPrompt');
 const SpinniesManager = require('../../lib/SpinniesManager');
-const LocalDevManager = require('../../lib/LocalDevManager');
+const {
+  LocalDevManager,
+  UPLOAD_PERMISSIONS,
+} = require('../../lib/LocalDevManager');
 const { getAccountConfig, getEnv } = require('@hubspot/cli-lib');
 const { sandboxNamePrompt } = require('../../lib/prompts/sandboxesPrompt');
 const {
@@ -146,14 +149,6 @@ exports.handler = async options => {
     }
   }
 
-  const isNonSandboxAccount = shouldTargetNonSandboxAccount;
-  // TODO programatically determine whether the project is using a github integration
-  const isProjectUsingGitIntegration = false;
-
-  const preventUploads = isProjectUsingGitIntegration || isNonSandboxAccount;
-
-  const spinnies = SpinniesManager.init();
-
   const projectExists = await ensureProjectExists(
     targetAccountId,
     projectConfig.name,
@@ -162,6 +157,24 @@ exports.handler = async options => {
       noLogs: true,
     }
   );
+
+  const isNonSandboxAccount = shouldTargetNonSandboxAccount;
+
+  let uploadPermission = isNonSandboxAccount
+    ? UPLOAD_PERMISSIONS.manual
+    : UPLOAD_PERMISSIONS.always;
+
+  if (projectExists) {
+    const { sourceIntegration } = await fetchProject(
+      targetAccountId,
+      projectConfig.name
+    );
+    if (sourceIntegration) {
+      uploadPermission = UPLOAD_PERMISSIONS.never;
+    }
+  }
+
+  const spinnies = SpinniesManager.init();
 
   if (!projectExists) {
     uiLine();
@@ -214,7 +227,7 @@ exports.handler = async options => {
   });
 
   let result;
-  if (!preventUploads) {
+  if (uploadPermission === UPLOAD_PERMISSIONS.always) {
     result = await handleProjectUpload(
       targetAccountId,
       projectConfig,
@@ -234,12 +247,12 @@ exports.handler = async options => {
   }
 
   const LocalDev = new LocalDevManager({
-    targetAccountId,
-    projectConfig,
-    projectDir,
-    preventUploads,
     debug: options.debug,
     mockServers: options.mockServers,
+    projectConfig,
+    projectDir,
+    targetAccountId,
+    uploadPermission,
   });
 
   await LocalDev.start();

--- a/packages/cli/lib/LocalDevManager.js
+++ b/packages/cli/lib/LocalDevManager.js
@@ -40,12 +40,18 @@ const WATCH_EVENTS = {
   unlinkDir: 'unlinkDir',
 };
 
+const UPLOAD_PERMISSIONS = {
+  always: 'always',
+  manual: 'manual',
+  never: 'never',
+};
 class LocalDevManager {
   constructor(options) {
     this.targetAccountId = options.targetAccountId;
     this.projectConfig = options.projectConfig;
     this.projectDir = options.projectDir;
-    this.preventUploads = options.preventUploads;
+    this.uploadPermission =
+      options.uploadPermission || UPLOAD_PERMISSIONS.always;
     this.debug = options.debug || false;
     this.mockServers = options.mockServers || false;
     this.projectSourceDir = path.join(
@@ -190,7 +196,10 @@ class LocalDevManager {
       if ((key.ctrl && key.name === 'c') || key.name === 'q') {
         this.stop();
       } else if (key.name === 'y') {
-        if (this.preventUploads && this.hasAnyUnsupportedStandbyChanges()) {
+        if (
+          this.uploadPermission === UPLOAD_PERMISSIONS.manual &&
+          this.hasAnyUnsupportedStandbyChanges()
+        ) {
           this.clearConsoleContent();
           this.updateDevModeStatus('manualUpload');
           await this.createNewStagingBuild();
@@ -198,7 +207,10 @@ class LocalDevManager {
           await this.queueBuild();
         }
       } else if (key.name === 'n') {
-        if (this.preventUploads && this.hasAnyUnsupportedStandbyChanges()) {
+        if (
+          this.uploadPermission === UPLOAD_PERMISSIONS.manual &&
+          this.hasAnyUnsupportedStandbyChanges()
+        ) {
           this.clearConsoleContent();
           this.spinnies.add('manualUploadSkipped', {
             text: i18n(`${i18nKey}.upload.manualUploadSkipped`),
@@ -253,7 +265,7 @@ class LocalDevManager {
   }
 
   async startWatching() {
-    if (!this.preventUploads) {
+    if (this.uploadPermission === UPLOAD_PERMISSIONS.always) {
       await this.createNewStagingBuild();
     }
 
@@ -286,7 +298,7 @@ class LocalDevManager {
       return;
     }
 
-    if (this.preventUploads) {
+    if (this.uploadPermission !== UPLOAD_PERMISSIONS.always) {
       this.handlePreventedUpload(changeInfo);
       return;
     }
@@ -313,32 +325,47 @@ class LocalDevManager {
   }
 
   handlePreventedUpload(changeInfo) {
+    const { remotePath } = changeInfo;
+
     this.clearConsoleContent();
-    this.updateDevModeStatus('uploadPrevented');
+    if (this.uploadPermission === UPLOAD_PERMISSIONS.never) {
+      this.updateDevModeStatus('noUploadsAllowed');
 
-    this.addChangeToStandbyQueue({ ...changeInfo, supported: false });
+      this.spinnies.add('noUploadsAllowed', {
+        text: i18n(`${i18nKey}.upload.noUploadsAllowed`, {
+          filePath: remotePath,
+        }),
+        status: 'fail',
+        failColor: 'white',
+        noIndent: true,
+      });
+    } else {
+      this.updateDevModeStatus('manualUploadRequired');
 
-    this.spinnies.add('manualUploadRequired', {
-      text: i18n(`${i18nKey}.upload.manualUploadRequired`),
-      status: 'fail',
-      failColor: 'white',
-      noIndent: true,
-    });
-    this.spinnies.add('manualUploadExplanation1', {
-      text: i18n(`${i18nKey}.upload.manualUploadExplanation1`),
-      status: 'non-spinnable',
-      indent: 1,
-    });
-    this.spinnies.add('manualUploadExplanation2', {
-      text: i18n(`${i18nKey}.upload.manualUploadExplanation2`),
-      status: 'non-spinnable',
-      indent: 1,
-    });
-    this.spinnies.add('manualUploadPrompt', {
-      text: i18n(`${i18nKey}.upload.manualUploadPrompt`),
-      status: 'non-spinnable',
-      indent: 1,
-    });
+      this.addChangeToStandbyQueue({ ...changeInfo, supported: false });
+
+      this.spinnies.add('manualUploadRequired', {
+        text: i18n(`${i18nKey}.upload.manualUploadRequired`),
+        status: 'fail',
+        failColor: 'white',
+        noIndent: true,
+      });
+      this.spinnies.add('manualUploadExplanation1', {
+        text: i18n(`${i18nKey}.upload.manualUploadExplanation1`),
+        status: 'non-spinnable',
+        indent: 1,
+      });
+      this.spinnies.add('manualUploadExplanation2', {
+        text: i18n(`${i18nKey}.upload.manualUploadExplanation2`),
+        status: 'non-spinnable',
+        indent: 1,
+      });
+      this.spinnies.add('manualUploadPrompt', {
+        text: i18n(`${i18nKey}.upload.manualUploadPrompt`),
+        status: 'non-spinnable',
+        indent: 1,
+      });
+    }
   }
 
   addChangeToStandbyQueue(changeInfo) {
@@ -390,7 +417,7 @@ class LocalDevManager {
   }
 
   debounceQueueBuild() {
-    if (!this.preventUploads) {
+    if (this.uploadPermission === UPLOAD_PERMISSIONS.always) {
       this.updateDevModeStatus('uploadPending');
     }
 
@@ -438,7 +465,7 @@ class LocalDevManager {
       true
     );
 
-    if (!this.preventUploads) {
+    if (this.uploadPermission === UPLOAD_PERMISSIONS.always) {
       await this.createNewStagingBuild();
     }
 
@@ -457,7 +484,10 @@ class LocalDevManager {
       await this.uploadQueue.addAll(
         this.standbyChanges.map(changeInfo => {
           return async () => {
-            if (!this.preventUploads && !this.uploadQueue.isPaused) {
+            if (
+              this.uploadPermission === UPLOAD_PERMISSIONS.always &&
+              !this.uploadQueue.isPaused
+            ) {
               this.debounceQueueBuild();
             }
             await this.sendChanges(changeInfo);
@@ -493,4 +523,4 @@ class LocalDevManager {
   }
 }
 
-module.exports = LocalDevManager;
+module.exports = { LocalDevManager, UPLOAD_PERMISSIONS };


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
Our system blocks any direct uploads from the CLI whenever a project is using a git integration. Dev Mode needs to be smart enough to never attempt to upload to a project that it knows is using a git integration.

The Local Dev Manager now has three upload modes:
- always: always allow uploads without prompting the user. This is the mode that it's in when targeting a sandbox account
- manual: always ask the user if the CLI should upload changes. This is the mode that it's in when targeting a non-sandbox account
- never: never allow uploads, because the request would fail. This is the mode that it's in when targeting a project that's using a git integration.

## Screenshots
<!-- Provide images of the before and after functionality -->

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
