### PR TITLE
hs project deploy UX Improvements

### DIFF
--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -1056,7 +1056,7 @@ en:
           bugPrompt: "Create an issue on Github in your browser?"
           generalPrompt: "Open the projects feedback form in your browser?"
         buildIdPrompt:
-          enterBuildId: "[--build] Deploy which build? (26)"
+          enterBuildId: "[--build] Deploy which build?"
           errors:
             buildIdDoesNotExist: "Build {{ buildId }} does not exist for project {{ projectName }}."
             buildAlreadyDeployed: "Build {{ buildId }} is already deployed."

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -482,7 +482,8 @@ en:
               deploying: "Deploying project at path: {{ path }}"
             errors:
               deploy: "Deploy error: {{ details }}"
-              noBuildId: "No latest build ID was found."
+              noBuilds: "Deploy error: no builds for this project were found."
+              noBuildId: "You must specify a build to deploy"
             examples:
               default: "Deploy the latest build of the current project"
               withOptions: "Deploy build 5 of the project my-project"
@@ -1054,6 +1055,11 @@ en:
             general: "[--general] Tell us about your experience with HubSpot's developer tools"
           bugPrompt: "Create an issue on Github in your browser?"
           generalPrompt: "Open the projects feedback form in your browser?"
+        buildIdPrompt:
+          enterBuildId: "[--buildId] Enter the ID of the build to deploy:"
+          errors:
+            buildIdDoesNotExist: "Build {{ buildId }} does not exist for project {{ projectName }}."
+            buildAlreadyDeployed: "Build {{ buildId }} is already deployed."
       convertFields:
         positionals:
           src:

--- a/packages/cli-lib/lang/en.lyaml
+++ b/packages/cli-lib/lang/en.lyaml
@@ -1056,7 +1056,7 @@ en:
           bugPrompt: "Create an issue on Github in your browser?"
           generalPrompt: "Open the projects feedback form in your browser?"
         buildIdPrompt:
-          enterBuildId: "[--buildId] Enter the ID of the build to deploy:"
+          enterBuildId: "[--build] Deploy which build? (26)"
           errors:
             buildIdDoesNotExist: "Build {{ buildId }} does not exist for project {{ projectName }}."
             buildAlreadyDeployed: "Build {{ buildId }} is already deployed."

--- a/packages/cli/commands/project/deploy.js
+++ b/packages/cli/commands/project/deploy.js
@@ -14,6 +14,7 @@ const { deployProject, fetchProject } = require('@hubspot/cli-lib/api/dfs');
 const { loadAndValidateOptions } = require('../../lib/validation');
 const { getProjectConfig, pollDeployStatus } = require('../../lib/projects');
 const { projectNamePrompt } = require('../../lib/prompts/projectNamePrompt');
+const { buildIdPrompt } = require('../../lib/prompts/buildIdPrompt');
 const { i18n } = require('@hubspot/cli-lib/lib/lang');
 const { getAccountConfig } = require('@hubspot/cli-lib');
 
@@ -28,46 +29,59 @@ exports.handler = async options => {
 
   const accountId = getAccountId(options);
   const accountConfig = getAccountConfig(accountId);
-  const { project, buildId } = options;
+  const { project: projectOption, buildId: buildIdOption } = options;
   const sandboxType = accountConfig && accountConfig.sandboxAccountType;
 
   trackCommandUsage('project-deploy', { type: sandboxType }, accountId);
 
   const { projectConfig } = await getProjectConfig();
 
-  let projectName = project;
+  let projectName = projectOption;
 
-  if (!projectName && projectConfig) {
+  if (!projectOption && projectConfig) {
     projectName = projectConfig.name;
   }
 
-  const namePrompt = await projectNamePrompt(accountId, {
+  const namePromptResponse = await projectNamePrompt(accountId, {
     project: projectName,
   });
 
-  if (!projectName && namePrompt.projectName) {
-    projectName = namePrompt.projectName;
+  if (!projectName && namePromptResponse.projectName) {
+    projectName = namePromptResponse.projectName;
+  }
+
+  let buildIdToDeploy = buildIdOption;
+
+  if (!buildIdOption) {
+    const { latestBuild, deployedBuildId } = await fetchProject(
+      accountId,
+      projectName
+    );
+    if (!latestBuild || !latestBuild.buildId) {
+      logger.error(i18n(`${i18nKey}.errors.noBuilds`));
+      process.exit(EXIT_CODES.ERROR);
+    }
+    const buildIdPromptResponse = await buildIdPrompt(
+      latestBuild.buildId,
+      deployedBuildId,
+      projectName
+    );
+
+    buildIdToDeploy = buildIdPromptResponse.buildId;
+  }
+
+  if (!buildIdToDeploy) {
+    logger.error(i18n(`${i18nKey}.errors.noBuildId`));
+    process.exit(EXIT_CODES.ERROR);
   }
 
   let exitCode = EXIT_CODES.SUCCESS;
 
-  const getBuildId = async () => {
-    const { latestBuild } = await fetchProject(accountId, projectName);
-    if (latestBuild && latestBuild.buildId) {
-      return latestBuild.buildId;
-    }
-    logger.error(i18n(`${i18nKey}.errors.noBuildId`));
-    exitCode = EXIT_CODES.ERROR;
-    return;
-  };
-
   try {
-    const deployedBuildId = buildId || (await getBuildId());
-
     const deployResp = await deployProject(
       accountId,
       projectName,
-      deployedBuildId
+      buildIdToDeploy
     );
 
     if (deployResp.error) {
@@ -84,7 +98,7 @@ exports.handler = async options => {
       accountId,
       projectName,
       deployResp.id,
-      deployedBuildId
+      buildIdToDeploy
     );
   } catch (e) {
     if (e.statusCode === 400) {

--- a/packages/cli/lib/prompts/buildIdPrompt.js
+++ b/packages/cli/lib/prompts/buildIdPrompt.js
@@ -1,0 +1,35 @@
+const { promptUser } = require('./promptUtils');
+const { i18n } = require('@hubspot/cli-lib/lib/lang');
+
+const i18nKey = 'cli.lib.prompts.buildIdPrompt';
+
+const buildIdPrompt = (latestBuildId, deployedBuildId, projectName) => {
+  return promptUser({
+    name: 'buildId',
+    message: i18n(`${i18nKey}.enterBuildId`),
+    default: () => {
+      if (latestBuildId === deployedBuildId) {
+        return;
+      }
+      return latestBuildId;
+    },
+    validate: val => {
+      if (Number(val) > latestBuildId) {
+        return i18n(`${i18nKey}.errors.buildIdDoesNotExist`, {
+          buildId: val,
+          projectName,
+        });
+      }
+      if (Number(val) === deployedBuildId) {
+        return i18n(`${i18nKey}.errors.buildAlreadyDeployed`, {
+          buildId: val,
+        });
+      }
+      return true;
+    },
+  });
+};
+
+module.exports = {
+  buildIdPrompt,
+};


### PR DESCRIPTION
## Description and Context
See https://git.hubteam.com/HubSpot/hubspot-cli-issues/issues/389
This updates the `hs project deploy` command to prompt for a `buildId` when one is not specified, preventing users from accidentally deploying their latest build as was previously possible. The prompt defaults to the latest build unless its currently deployed, and includes validation that prevents users from entering the currently deployed build and builds that don't exist.

## Screenshots
Before
<img width="588" alt="Screenshot 2023-05-09 at 3 14 03 PM" src="https://github.com/HubSpot/hubspot-cli/assets/10413161/7de6fbaf-82d8-474c-b385-166f782ff743">

After
<img width="578" alt="Screenshot 2023-05-09 at 3 14 31 PM" src="https://github.com/HubSpot/hubspot-cli/assets/10413161/73a8a6a4-aac8-48a2-9965-9dee0cb1134f">

Error state
<img width="575" alt="Screenshot 2023-05-09 at 3 14 58 PM" src="https://github.com/HubSpot/hubspot-cli/assets/10413161/7bf7b681-b06a-4964-9eff-aa563e0a8432">
<img width="557" alt="Screenshot 2023-05-09 at 3 14 51 PM" src="https://github.com/HubSpot/hubspot-cli/assets/10413161/af24679d-a68c-4aa8-a2f6-20f807144292">
ates

## Who to Notify
@brandenrodgers @kemmerle @markhazlewood 
