### PR TITLE
`hs project dev` add polling to project fetch in case of 403

### DIFF
--- a/packages/cli/commands/project/dev.js
+++ b/packages/cli/commands/project/dev.js
@@ -155,6 +155,7 @@ exports.handler = async options => {
     {
       allowCreate: false,
       noLogs: true,
+      withPolling: true,
     }
   );
 

--- a/packages/cli/lib/projects.js
+++ b/packages/cli/lib/projects.js
@@ -39,6 +39,9 @@ const { EXIT_CODES } = require('./enums/exitCodes');
 const { uiLine, uiLink, uiAccountDescription } = require('../lib/ui');
 const { i18n } = require('@hubspot/cli-lib/lib/lang');
 const SpinniesManager = require('./SpinniesManager');
+const {
+  isSpecifiedError,
+} = require('@hubspot/cli-lib/errorHandlers/apiErrors');
 
 const i18nKey = 'cli.lib.projects';
 
@@ -170,14 +173,6 @@ const validateProjectConfig = (projectConfig, projectDir) => {
 
 const pollFetchProject = async (accountId, projectName) => {
   // Temporary solution for gating slowness. Retry on 403 statusCode
-  try {
-    const project = await fetchProject(accountId, projectName);
-    return project;
-  } catch (error) {
-    if (error.statusCode === 404) {
-      throw error;
-    }
-  }
   return new Promise((resolve, reject) => {
     let pollCount = 0;
     const spinnies = SpinniesManager.init();
@@ -193,13 +188,24 @@ const pollFetchProject = async (accountId, projectName) => {
           resolve(project);
         }
       } catch (err) {
-        // Poll up to max 30s
-        if (err.statusCode === 404 || pollCount >= 15) {
+        if (
+          isSpecifiedError(err, {
+            statusCode: 403,
+            category: 'GATED',
+            subCategory: 'BuildPipelineErrorType.PORTAL_GATED',
+          })
+        ) {
+          pollCount += 1;
+        } else if (pollCount >= 15) {
+          // Poll up to max 30s
+          spinnies.remove('pollFetchProject');
+          clearInterval(pollInterval);
+          reject(err);
+        } else {
           spinnies.remove('pollFetchProject');
           clearInterval(pollInterval);
           reject(err);
         }
-        pollCount += 1;
       }
     }, POLLING_DELAY);
   });
@@ -208,11 +214,18 @@ const pollFetchProject = async (accountId, projectName) => {
 const ensureProjectExists = async (
   accountId,
   projectName,
-  { forceCreate = false, allowCreate = true, noLogs = false } = {}
+  {
+    forceCreate = false,
+    allowCreate = true,
+    noLogs = false,
+    withPolling = false,
+  } = {}
 ) => {
   const accountIdentifier = uiAccountDescription(accountId);
   try {
-    const project = await pollFetchProject(accountId, projectName);
+    const project = withPolling
+      ? await pollFetchProject(accountId, projectName)
+      : await fetchProject(accountId, projectName);
     return !!project;
   } catch (err) {
     if (err.statusCode === 404) {


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->

This PR specifically deals with fetchProject behavior when creating a new sandbox with `hs project dev`. Due to gating slowness (sometimes) when creating a new sandbox in prod, we are receiving 403's on initial fetch with a forbidden request error. 

We are adding a pollingFetchProject util that keeps retrying (up to max 30s) until a 404 or a success is received. This also ensures that the portal is ungated if the user needs to create a new project in the next step. 

We can remove this polling piece once CRM dev tools are ungated to all. 

## Screenshots
<!-- Provide images of the before and after functionality -->
Adding a spinner to show progress
<img width="1113" alt="Screenshot 2023-05-09 at 15 20 23" src="https://github.com/HubSpot/hubspot-cli/assets/16788677/fd63d0f1-0b1c-462a-a9b9-483176f8df07">

Once we get a 404 or success, we remove the spinner
<img width="1108" alt="Screenshot 2023-05-09 at 15 20 39" src="https://github.com/HubSpot/hubspot-cli/assets/16788677/034d6175-254f-4b40-9678-e0abef3b09b1">


## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
