### PR TITLE
`hs project dev` add missing scope error handling

### DIFF
--- a/packages/cli/commands/project/dev.js
+++ b/packages/cli/commands/project/dev.js
@@ -40,6 +40,10 @@ const { getValidEnv } = require('@hubspot/cli-lib/lib/environment');
 const { logErrorInstance } = require('@hubspot/cli-lib/errorHandlers');
 const { buildSandbox } = require('../../lib/sandbox-create');
 const { syncSandbox } = require('../../lib/sandbox-sync');
+const { getHubSpotWebsiteOrigin } = require('@hubspot/cli-lib/lib/urls');
+const {
+  isMissingScopeError,
+} = require('@hubspot/cli-lib/errorHandlers/apiErrors');
 
 const i18nKey = 'cli.commands.project.subcommands.dev';
 
@@ -114,7 +118,23 @@ exports.handler = async options => {
     try {
       await validateSandboxUsageLimits(accountConfig, DEVELOPER_SANDBOX, env);
     } catch (err) {
-      logErrorInstance(err);
+      if (isMissingScopeError(err)) {
+        logger.error(
+          i18n('cli.lib.sandbox.create.failure.scopes.message', {
+            accountName: accountConfig.name || accountId,
+          })
+        );
+        const websiteOrigin = getHubSpotWebsiteOrigin(env);
+        const url = `${websiteOrigin}/personal-access-key/${accountId}`;
+        logger.info(
+          i18n('cli.lib.sandbox.create.failure.scopes.instructions', {
+            accountName: accountConfig.name || accountId,
+            url,
+          })
+        );
+      } else {
+        logErrorInstance(err);
+      }
       process.exit(EXIT_CODES.ERROR);
     }
     try {

--- a/packages/cli/commands/sandbox/create.js
+++ b/packages/cli/commands/sandbox/create.js
@@ -99,8 +99,8 @@ exports.handler = async options => {
       );
     } else {
       logErrorInstance(err);
-      trackCommandUsage('sandbox-create', { successful: false }, accountId);
     }
+    trackCommandUsage('sandbox-create', { successful: false }, accountId);
     process.exit(EXIT_CODES.ERROR);
   }
 

--- a/packages/cli/commands/sandbox/create.js
+++ b/packages/cli/commands/sandbox/create.js
@@ -30,6 +30,10 @@ const {
 const { promptUser } = require('../../lib/prompts/promptUtils');
 const { syncSandbox } = require('../../lib/sandbox-sync');
 const { logErrorInstance } = require('@hubspot/cli-lib/errorHandlers');
+const {
+  isMissingScopeError,
+} = require('@hubspot/cli-lib/errorHandlers/apiErrors');
+const { getHubSpotWebsiteOrigin } = require('@hubspot/cli-lib/lib/urls');
 
 const i18nKey = 'cli.commands.sandbox.subcommands.create';
 
@@ -79,8 +83,24 @@ exports.handler = async options => {
   try {
     await validateSandboxUsageLimits(accountConfig, sandboxType, env);
   } catch (err) {
-    logErrorInstance(err);
-    trackCommandUsage('sandbox-create', { successful: false }, accountId);
+    if (isMissingScopeError(err)) {
+      logger.error(
+        i18n('cli.lib.sandbox.create.failure.scopes.message', {
+          accountName: accountConfig.name || accountId,
+        })
+      );
+      const websiteOrigin = getHubSpotWebsiteOrigin(env);
+      const url = `${websiteOrigin}/personal-access-key/${accountId}`;
+      logger.info(
+        i18n('cli.lib.sandbox.create.failure.scopes.instructions', {
+          accountName: accountConfig.name || accountId,
+          url,
+        })
+      );
+    } else {
+      logErrorInstance(err);
+      trackCommandUsage('sandbox-create', { successful: false }, accountId);
+    }
     process.exit(EXIT_CODES.ERROR);
   }
 


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
When attempting to create a sandbox with `hs project dev`, we throw an error if the PAK does not have sandboxes scopes. 

This PR repurposes a sandboxes scoping error message we had for `hs sandbox create` to help guide the user to deactivate and regenerate a new PAK with new scopes. The two places that this error is thrown are both sandboxes specific so the error message applies perfectly. 

## Screenshots
<!-- Provide images of the before and after functionality -->
<img width="1211" alt="Screenshot 2023-05-10 at 15 37 31" src="https://github.com/HubSpot/hubspot-cli/assets/16788677/5043d7e8-e84b-4de3-a7b3-f6a811333522">

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
