### PR TITLE
Better error handling for locked projects in Dev Mode

### DIFF
--- a/packages/cli/commands/project/dev.js
+++ b/packages/cli/commands/project/dev.js
@@ -38,12 +38,14 @@ const {
   getAvailableSyncTypes,
 } = require('../../lib/sandboxes');
 const { getValidEnv } = require('@hubspot/cli-lib/lib/environment');
+const { ERROR_TYPES } = require('@hubspot/cli-lib/lib/constants');
 const { logErrorInstance } = require('@hubspot/cli-lib/errorHandlers');
 const { buildSandbox } = require('../../lib/sandbox-create');
 const { syncSandbox } = require('../../lib/sandbox-sync');
 const { getHubSpotWebsiteOrigin } = require('@hubspot/cli-lib/lib/urls');
 const {
   isMissingScopeError,
+  isSpecifiedError,
 } = require('@hubspot/cli-lib/errorHandlers/apiErrors');
 
 const i18nKey = 'cli.commands.project.subcommands.dev';
@@ -217,7 +219,7 @@ exports.handler = async options => {
           succeedColor: 'white',
         });
       } catch (err) {
-        logger.log(i18n(`${i18nKey}.logs.failedToCreateProject`));
+        logger.log(i18n(`${i18nKey}.status.failedToCreateProject`));
         process.exit(EXIT_CODES.ERROR);
       }
     } else {
@@ -251,6 +253,18 @@ exports.handler = async options => {
     spinnies.fail('devModeSetup', {
       text: i18n(`${i18nKey}.status.startupFailed`),
     });
+
+    if (
+      result.error &&
+      isSpecifiedError(result.error, {
+        subCategory: ERROR_TYPES.PROJECT_LOCKED,
+      })
+    ) {
+      logger.log();
+      logger.error(i18n(`${i18nKey}.errors.projectLockedError`));
+      logger.log();
+    }
+
     process.exit(EXIT_CODES.ERROR);
   } else {
     spinnies.remove('devModeSetup');

--- a/packages/cli/commands/project/upload.js
+++ b/packages/cli/commands/project/upload.js
@@ -59,13 +59,6 @@ exports.handler = async options => {
   );
 
   if (result.error) {
-    logApiErrorInstance(
-      result.error,
-      new ApiErrorContext({
-        accountId,
-        projectName: projectConfig.name,
-      })
-    );
     if (
       isSpecifiedError(result.error, {
         subCategory: ERROR_TYPES.PROJECT_LOCKED,
@@ -74,6 +67,14 @@ exports.handler = async options => {
       logger.log();
       logger.error(i18n(`${i18nKey}.errors.projectLockedError`));
       logger.log();
+    } else {
+      logApiErrorInstance(
+        result.error,
+        new ApiErrorContext({
+          accountId,
+          projectName: projectConfig.name,
+        })
+      );
     }
     process.exit(EXIT_CODES.ERROR);
   }

--- a/packages/cli/commands/project/upload.js
+++ b/packages/cli/commands/project/upload.js
@@ -19,6 +19,14 @@ const {
 } = require('../../lib/projects');
 const { i18n } = require('../../lib/lang');
 const { getAccountConfig } = require('@hubspot/cli-lib');
+const { ERROR_TYPES } = require('@hubspot/cli-lib/lib/constants');
+const {
+  isSpecifiedError,
+} = require('@hubspot/cli-lib/errorHandlers/apiErrors');
+const {
+  logApiErrorInstance,
+  ApiErrorContext,
+} = require('@hubspot/cli-lib/errorHandlers');
 const { EXIT_CODES } = require('../../lib/enums/exitCodes');
 
 const i18nKey = 'cli.commands.project.subcommands.upload';
@@ -50,6 +58,25 @@ exports.handler = async options => {
     message
   );
 
+  if (result.error) {
+    logApiErrorInstance(
+      result.error,
+      new ApiErrorContext({
+        accountId,
+        projectName: projectConfig.name,
+      })
+    );
+    if (
+      isSpecifiedError(result.error, {
+        subCategory: ERROR_TYPES.PROJECT_LOCKED,
+      })
+    ) {
+      logger.log();
+      logger.error(i18n(`${i18nKey}.errors.projectLockedError`));
+      logger.log();
+    }
+    process.exit(EXIT_CODES.ERROR);
+  }
   if (result.buildSucceeded && !result.autodeployEnabled) {
     uiLine();
     logger.log(

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -469,6 +469,7 @@ en:
                 describe: "The port that the running server will listen on"
             errors:
               noProjectConfig: "No project detected. Please run this command again from a project directory."
+              projectLockedError: "Your project is locked. This may mean that another user is running the {{#bold}}`hs project dev`{{/bold}} command for this project. If this is you, unlock the project in Projects UI."
             examples:
               default: "Start local dev for the current project"
           create:
@@ -560,20 +561,13 @@ en:
               buildSucceeded: "Build #{{ buildId }} succeeded\n"
               readyToGoLive: "🚀 Ready to take your project live?"
               runCommand: "Run `{{ command }}`"
+            errors:
+              projectLockedError: "Your project is locked. This may mean that another user is running the {{#bold}}`hs project dev`{{/bold}} command for this project. If this is you, unlock the project in Projects UI."
             options:
               forceCreate:
                 describe: "Automatically create project if it does not exist"
               message:
                 describe: "Add a message when you upload your project and create a build"
-            positionals:
-              path:
-                describe: "Path to a project folder"
-          unlock:
-            describe: "Unlock a locked project"
-            examples:
-              default: "Unlock a locked project in the myProjectsFolder folder"
-            logs:
-              unlockSucceeded: "Successfully unlocked the project"
             positionals:
               path:
                 describe: "Path to a project folder"
@@ -879,7 +873,6 @@ en:
           fail: "Failed to upload {{#bold}}{{ projectName }}{{/bold}} project files to {{ accountIdentifier }}"
           succeed: "Uploaded {{#bold}}{{ projectName }}{{/bold}} project files to {{ accountIdentifier }}"
           buildCreated: "Project \"{{ projectName }}\" uploaded and build #{{ buildId }} created"
-          projectLockedError: "\nYour project may be locked by an active `{{#yellow}}hs project watch{{/yellow}}`. Try stopping the `{{#yellow}}watch{{/yellow}}` process before uploading.\nIf that doesn't work, you may need to start and stop a new `{{#yellow}}watch{{/yellow}}` process to unlock the project."
         handleProjectUpload:
           emptySource: "Source directory \"{{ srcDir }}\" is empty. Add files to your project and rerun `{{#yellow}}hs project upload{{/yellow}}` to upload them to HubSpot."
           compressed: "Project files compressed: {{ byteCount }} bytes"

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -837,6 +837,8 @@ en:
           options:
             describe: "Options to pass to javascript fields files"
     lib:
+      DevServerManager:
+        portConflict: "The port {{ port }} is already in use."
       LocalDevManager:
         exitingStart: "Stopping local dev server ..."
         exitingSucceed: "Successfully exited"

--- a/packages/cli/lib/DevServerManager.js
+++ b/packages/cli/lib/DevServerManager.js
@@ -57,7 +57,9 @@ class DevServerManager {
     // Start server
     this.server = app.listen(port || DEFAULT_PORT);
 
-    return `http://localhost:${this.server.address().port}`;
+    return this.server.address()
+      ? `http://localhost:${this.server.address().port}`
+      : null;
   }
 
   async notify() {

--- a/packages/cli/lib/DevServerManager.js
+++ b/packages/cli/lib/DevServerManager.js
@@ -1,7 +1,12 @@
 const express = require('express');
 const bodyParser = require('body-parser');
 const cors = require('cors');
+const { i18n } = require('./lang');
 const { getProjectDetailUrl } = require('./projects');
+const { EXIT_CODES } = require('./enums/exitCodes');
+const { logger } = require('@hubspot/cli-lib/logger');
+
+const i18nKey = 'cli.lib.DevServerManager';
 
 const DEFAULT_PORT = 8080;
 
@@ -55,7 +60,15 @@ class DevServerManager {
     });
 
     // Start server
-    this.server = app.listen(port || DEFAULT_PORT);
+    this.server = app.listen(port || DEFAULT_PORT).on('error', err => {
+      if (err.code === 'EADDRINUSE') {
+        logger.error(
+          i18n(`${i18nKey}.portConflict`, { port: port || DEFAULT_PORT })
+        );
+        logger.log();
+        process.exit(EXIT_CODES.ERROR);
+      }
+    });
 
     return this.server.address()
       ? `http://localhost:${this.server.address().port}`

--- a/packages/cli/lib/LocalDevManager.js
+++ b/packages/cli/lib/LocalDevManager.js
@@ -29,7 +29,7 @@ const { uiAccountDescription, uiLink } = require('./ui');
 
 const i18nKey = 'cli.lib.LocalDevManager';
 
-const BUILD_DEBOUNCE_TIME = 2000;
+const BUILD_DEBOUNCE_TIME = 3500;
 
 const WATCH_EVENTS = {
   add: 'add',


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
This adds some better error handling for the situation where a user runs the `hs project dev` command against a project that is currently locked.

The current copy that I'm using is this:
> Your project is locked. This may mean that another user is running the {{#bold}}`hs project dev`{{/bold}} command for this project. If this is you, unlock the project in Projects UI.

cc/ @markhazlewood for thoughts

## Screenshots
<!-- Provide images of the before and after functionality -->
### BEFORE
<img width="846" alt="image" src="https://github.com/HubSpot/hubspot-cli/assets/6654014/27cfbd82-a7a6-4ad1-9317-76826da22b26">

### AFTER
<img width="854" alt="image" src="https://github.com/HubSpot/hubspot-cli/assets/6654014/7831742e-a080-4f4f-b647-adbf1b467fec">

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
