### PR TITLE
Console improvements to dev mode

### DIFF
--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -860,8 +860,9 @@ en:
             manualUpload: "{{#bold}}Status:{{/bold}} {{#green}}Manually uploading pending changes{{/green}}"
         upload:
           noUploadsAllowed: "The change to {{ filePath }} requires an upload, but the CLI cannot upload to a project that is using a github integration."
-          manualUploadSkipped: "Manual upload skipped. Some changes may not be visible."
-          manualUploadRequired: "Project files changed, manual upload and deploy is needed ..."
+          manualUploadSkipped: "Manually upload and deploy project: {{#green}}(n){{/green}}"
+          manualUploadConfirmed: "Manually upload and deploy project: {{#green}}(Y){{/green}}"
+          manualUploadRequired: "Project file changes require a manual upload and deploy ..."
           manualUploadExplanation1: "{{#yellow}}> Dev server is running on a {{#bold}}non-sandbox account{{/bold}}.{{/yellow}}"
           manualUploadExplanation2: "{{#yellow}}> Uploading changes may overwrite production data.{{/yellow}}"
           manualUploadPrompt: "? Manually upload and deploy project? {{#green}}Y/n{{/green}}"

--- a/packages/cli/lib/SpinniesManager.js
+++ b/packages/cli/lib/SpinniesManager.js
@@ -15,7 +15,6 @@ class SpinniesManager {
 
     return {
       add: this.add.bind(this),
-      addOrUpdate: this.addOrUpdate.bind(this),
       pick: this.spinnies.pick.bind(this.spinnies),
       remove: this.remove.bind(this),
       removeAll: this.removeAll.bind(this),
@@ -69,16 +68,6 @@ class SpinniesManager {
     }
 
     return uniqueKey;
-  }
-
-  addOrUpdate(key, options = {}) {
-    const spinner = this.spinnies.pick(key);
-
-    if (spinner) {
-      this.spinnies.update(key, options);
-    } else {
-      this.add(key, options);
-    }
   }
 
   remove(key) {

--- a/packages/cli/lib/SpinniesManager.js
+++ b/packages/cli/lib/SpinniesManager.js
@@ -15,6 +15,7 @@ class SpinniesManager {
 
     return {
       add: this.add.bind(this),
+      addOrUpdate: this.addOrUpdate.bind(this),
       pick: this.spinnies.pick.bind(this.spinnies),
       remove: this.remove.bind(this),
       removeAll: this.removeAll.bind(this),
@@ -51,17 +52,32 @@ class SpinniesManager {
     const { category, isParent, noIndent, ...rest } = options;
     const originalIndent = rest.indent || 0;
 
+    // Support adding generic spinnies lines without specifying a key
+    const uniqueKey = key || `${Date.now()}`;
+
     if (category) {
-      this.addKeyToCategory(key, category);
+      this.addKeyToCategory(uniqueKey, category);
     }
 
-    this.spinnies.add(key, {
+    this.spinnies.add(uniqueKey, {
       ...rest,
       indent: this.parentKey && !noIndent ? originalIndent + 1 : originalIndent,
     });
 
     if (isParent) {
-      this.parentKey = key;
+      this.parentKey = uniqueKey;
+    }
+
+    return uniqueKey;
+  }
+
+  addOrUpdate(key, options = {}) {
+    const spinner = this.spinnies.pick(key);
+
+    if (spinner) {
+      this.spinnies.update(key, options);
+    } else {
+      this.add(key, options);
     }
   }
 
@@ -79,10 +95,14 @@ class SpinniesManager {
    * Removes all spinnies instances
    * @param {string} preserveCategory - do not remove spinnies with a matching category
    */
-  removeAll({ preserveCategory = null } = {}) {
+  removeAll({ preserveCategory = null, targetCategory = null } = {}) {
     if (this.spinnies) {
       Object.keys(this.spinnies.spinners).forEach(key => {
-        if (
+        if (targetCategory) {
+          if (this.getCategoryForKey(key) === targetCategory) {
+            this.remove(key);
+          }
+        } else if (
           !preserveCategory ||
           this.getCategoryForKey(key) !== preserveCategory
         ) {

--- a/packages/cli/lib/projects.js
+++ b/packages/cli/lib/projects.js
@@ -550,6 +550,7 @@ const makePollTaskStatusFunc = ({
       succeedColor: 'white',
       failColor: 'white',
       failPrefix: chalk.bold('!'),
+      category: 'projectPollStatus',
     });
 
     const [
@@ -610,6 +611,7 @@ const makePollTaskStatusFunc = ({
           indent,
           succeedColor: 'white',
           failColor: 'white',
+          category: 'projectPollStatus',
         });
       };
 


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
This make some improvements to the persistence of the console messages in the running dev mode command. Previously this command would erase the console pretty frequently, but this makes it so that the logs persist. I had to add some new utils to the Spinnies lib to support the new functionality. I needed a way to add generic items to spinnies without passing in a key. 

In the screenshots below, I...
1. Targeted a prod account (so it shows me the "manual upload" option)
2. Made a change in a project file
3. Pressed "Y" to upload
4. Waited for the upload + build + deploy to finish

## Screenshots
<!-- Provide images of the before and after functionality -->
### BEFORE
<img width="639" alt="image" src="https://github.com/HubSpot/hubspot-cli/assets/6654014/5254f34b-0aec-43b1-a262-d3236d589e79">

### AFTER
<img width="648" alt="image" src="https://github.com/HubSpot/hubspot-cli/assets/6654014/298fe3a3-b4e7-4022-9fba-2bda53503fa4">

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
