### PR TITLE
Update 'whats next' section for `hs sandbox create`

### DIFF
--- a/packages/cli/commands/sandbox/create.js
+++ b/packages/cli/commands/sandbox/create.js
@@ -186,12 +186,14 @@ exports.handler = async options => {
       throw err;
     }
 
-    uiFeatureHighlight([
-      'accountsUseCommand',
-      sandboxType === DEVELOPER_SANDBOX
-        ? 'projectDevCommand'
-        : 'projectUploadCommand',
-    ]);
+    const highlightItems = ['accountsUseCommand', 'projectCreateCommand'];
+    if (sandboxType === DEVELOPER_SANDBOX) {
+      highlightItems.push('projectDevCommand');
+    } else {
+      highlightItems.push('projectUploadCommand');
+    }
+
+    uiFeatureHighlight(highlightItems);
     process.exit(EXIT_CODES.SUCCESS);
   } catch (error) {
     trackCommandUsage('sandbox-create', { successful: false }, accountId);

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -932,6 +932,9 @@ en:
             helpCommand:
               command: "hs help"
               message: "Run {{ command }} to see a list of available commands"
+            projectCreateCommand:
+              command: "hs project create"
+              message: "Run {{ command }} to create a new project"
             projectDeployCommand:
               command: "hs project deploy"
               message: "Ready to take your project live? Run {{ command }}"
@@ -943,13 +946,13 @@ en:
               message: "Run {{ command }} to upload your project to HubSpot and trigger builds"
             projectDevCommand:
               command: "hs project dev"
-              message: "Run {{ command }} to start testing your project locally."
+              message: "Run {{ command }} to start testing your project locally"
             sandboxSyncDevelopmentCommand:
               command: "hs sandbox sync"
-              message: "Run {{ command }} to to update CRM object definitions in your sandbox."
+              message: "Run {{ command }} to to update CRM object definitions in your sandbox"
             sandboxSyncStandardCommand:
               command: "hs sandbox sync"
-              message: "Run {{ command }} to to update all supported assets to your sandbox from production."
+              message: "Run {{ command }} to to update all supported assets to your sandbox from production"
       commonOpts:
         options:
           portal:


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->

For issue https://git.hubteam.com/HubSpot/hubspot-cli-issues/issues/401

For creating dev sandboxes: To reduce confusion about `hs project dev` as a follow up command when a user does not have a project, we're adding in another step to have them create a project. 

We also do the same for creating standard sandboxes, but rather than `hs project dev` as the last command, we let them know about `hs project upload`. 

## Screenshots
<!-- Provide images of the before and after functionality -->
<img width="803" alt="Screenshot 2023-05-26 at 13 26 33" src="https://github.com/HubSpot/hubspot-cli/assets/16788677/fe240c66-a71c-46cf-858f-4222be31fad5">


## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

n/a

## Who to Notify
<!-- /cc those you wish to know about the PR -->
