### PR TITLE
Change `repoPath` flag to `templateSource` in `hs project create`

### DIFF
--- a/packages/cli/commands/project/create.js
+++ b/packages/cli/commands/project/create.js
@@ -35,7 +35,7 @@ exports.handler = async options => {
     path.resolve(getCwd(), options.location || location),
     options.name || name,
     options.template || template,
-    options.repoPath
+    options.templateSource
   );
 
   logger.log('');
@@ -62,8 +62,8 @@ exports.builder = yargs => {
       describe: i18n(`${i18nKey}.options.template.describe`),
       type: 'string',
     },
-    repoPath: {
-      describe: i18n(`${i18nKey}.options.repoPath.describe`),
+    templateSource: {
+      describe: i18n(`${i18nKey}.options.templateSource.describe`),
       type: 'string',
     },
   });

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -484,7 +484,7 @@ en:
                 describe: "Project name (cannot be changed)"
               template:
                 describe: "The starting template"
-              repoPath:
+              templateSource:
                 describe: "Path to custom GitHub repository from which to create project template"
           add:
             describe: "Create a new component within a project"

--- a/packages/cli/lib/projects.js
+++ b/packages/cli/lib/projects.js
@@ -92,7 +92,7 @@ const createProjectConfig = async (
   projectPath,
   projectName,
   template,
-  repoPath
+  templateSource
 ) => {
   const { projectConfig, projectDir } = await getProjectConfig(projectPath);
 
@@ -137,7 +137,11 @@ const createProjectConfig = async (
       srcDir: 'src',
     });
   } else {
-    await downloadGitHubRepoContents(repoPath, template.path, projectPath);
+    await downloadGitHubRepoContents(
+      templateSource,
+      template.path,
+      projectPath
+    );
     const _config = JSON.parse(fs.readFileSync(projectConfigPath));
     writeProjectConfig(projectConfigPath, {
       ..._config,

--- a/packages/cli/lib/prompts/createProjectPrompt.js
+++ b/packages/cli/lib/prompts/createProjectPrompt.js
@@ -20,12 +20,12 @@ const hasAllProperties = projectList => {
   );
 };
 
-const createTemplateOptions = async repoPath => {
-  const isRepoPath = !!repoPath;
+const createTemplateOptions = async templateSource => {
+  const isTemplateSource = !!templateSource;
   const config = await fetchJsonFromRepository(
-    repoPath,
+    templateSource,
     'main/config.json',
-    isRepoPath
+    isTemplateSource
   );
 
   if (!config || !config[PROJECT_COMPONENT_TYPES.PROJECTS]) {
@@ -42,7 +42,9 @@ const createTemplateOptions = async repoPath => {
 };
 
 const createProjectPrompt = async (promptOptions = {}) => {
-  const projectTemplates = await createTemplateOptions(promptOptions.repoPath);
+  const projectTemplates = await createTemplateOptions(
+    promptOptions.templateSource
+  );
 
   return promptUser([
     {


### PR DESCRIPTION
## Description and Context
Based on discussions with @markhazlewood and @sejal27, we've decided to change the `--repoPath` flag in the `hs project create` command to `--templateSource`. 

## Screenshots
<!-- Provide images of the before and after functionality -->

Before (`repoPath`): 

<img width="1489" alt="Screenshot 2023-05-30 at 12 07 57 PM" src="https://github.com/HubSpot/hubspot-cli/assets/25392256/6fb84c62-06af-43b1-9050-eeec4eaff2d2">

After (`templateSource`):

<img width="1770" alt="Screenshot 2023-05-30 at 12 08 40 PM" src="https://github.com/HubSpot/hubspot-cli/assets/25392256/a41b2001-7694-43a3-9691-963198b51f96">

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

In a separate PR, we plan to streamline the command's pattern to make it more intuitive for users. Changing the flag name is most important before the UI Extension React Alpha's start date tomorrow. 

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@brandenrodgers @camden11 
