### PR TITLE
Sandboxes handle invalid users

### DIFF
--- a/packages/cli/commands/sandbox/delete.js
+++ b/packages/cli/commands/sandbox/delete.js
@@ -189,6 +189,21 @@ exports.handler = async options => {
       }
     } else if (
       isSpecifiedError(err, {
+        statusCode: 403,
+        category: 'BANNED',
+        subCategory: 'SandboxErrors.USER_ACCESS_NOT_ALLOWED',
+      })
+    ) {
+      logger.log('');
+      logger.error(
+        i18n(`${i18nKey}.failure.invalidUser`, {
+          accountName: getAccountName(accountConfig),
+          parentAccountName: getAccountName(parentAccount),
+        })
+      );
+      logger.log('');
+    } else if (
+      isSpecifiedError(err, {
         statusCode: 404,
         category: 'OBJECT_NOT_FOUND',
         subCategory: 'SandboxErrors.SANDBOX_NOT_FOUND',

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -641,7 +641,6 @@ en:
               type:
                 describe: "Type of sandbox to create (standard | development)"
             failure:
-              invalidUser: "Couldn't create {{ accountName }} because your account has been removed from {{ parentAccountName }} or your permission set doesn't allow you to create the sandbox. To update your permissions, contact a super admin in {{ parentAccountName }}."
               optionMissing:
                 type: "Invalid or missing sandbox --type option in command. Please try again."
                 name: "Invalid or missing sandbox --name option in command. Please try again."
@@ -693,7 +692,6 @@ en:
               developmentSandbox: "Sync CRM object definitions to {{#cyan}}{{#bold}}{{ sandboxName }}{{/bold}}{{/cyan}} from {{#bold}}{{ parentAccountName }}{{/bold}}?"
               standardSandbox: "Sync all supported assets to {{#cyan}}{{#bold}}{{ sandboxName }}{{/bold}}{{/cyan}} from {{#bold}}{{ parentAccountName }}{{/bold}}?"
             failure:
-              invalidUser: "Couldn't sync {{ accountName }} because your account has been removed from {{ parentAccountName }} or your permission set doesn't allow you to sync the sandbox. To update your permissions, contact a super admin in {{ parentAccountName }}."
               notSandbox: "Sync must be run in a sandbox account. Your default account is a production account. Run {{#bold}}hs auth{{/bold}} to connect your sandbox account to the CLI or {{#bold}}hs accounts use{{/bold}} to change your default account, then try again."
               missingParentPortal: "The production account associated to {{#bold}}{{ sandboxName }}{{/bold}} is not connected to your HubSpot CLI.
                 \n- Run {{#bold}}hs auth{{/bold}} to connect that account to your terminal, then try again.
@@ -975,7 +973,7 @@ en:
             describe: "Use environment variable config"
       prompts:
         projectDevTargetAccountPrompt:
-          createNewSandboxOption: "<Test on a new dev sandbox>"
+          createNewSandboxOption: "<Test on a new development sandbox>"
           chooseDefaultAccountOption: "<{{#bold}}!{{/bold}} Test on this production account {{#bold}}!{{/bold}}>"
           promptMessage: "[--account] Choose a sandbox under {{ accountIdentifier }} to test with:"
           sandboxLimit: "You’ve reached the limit of {{ limit }} development sandboxes"
@@ -1131,6 +1129,7 @@ en:
           success:
             configFileUpdated: "{{ configFilename }} updated with {{ authMethod }} for account {{ account }}."
           failure:
+            invalidUser: "Couldn't create {{#bold}}{{ accountName }}{{/bold}} because your account has been removed from {{#bold}}{{ parentAccountName }}{{/bold}} or your permission set doesn't allow you to create the sandbox. To update your permissions, contact a super admin in {{#bold}}{{ parentAccountName }}{{/bold}}."
             limit:
               developer:
                 one: "{{#bold}}{{ accountName }}{{/bold}} reached the limit of {{ limit }} development sandbox.
@@ -1188,6 +1187,7 @@ en:
             fail: "Failed to fetch sync updates. View the sync status at: {{ url }}"
             succeed: "Sandbox sync complete."
           failure:
+            invalidUser: "Couldn't sync {{ accountName }} because your account has been removed from {{ parentAccountName }} or your permission set doesn't allow you to sync the sandbox. To update your permissions, contact a super admin in {{ parentAccountName }}."
             missingScopes: "Couldn’t run the sync because there are scopes missing in your production account. To update scopes, deactivate your current personal access key for {{#bold}}{{ accountName }}{{/bold}}, and generate a new one. Then run `hs auth` to update the CLI with the new key."
             syncInProgress: "Couldn’t run the sync because there’s another sync in progress. Wait for the current sync to finish and then try again. To check the sync status, visit the sync activity log: {{ url }}."
             notSuperAdmin: "Couldn't run the sync because you are not a super admin in {{ account }}. Ask the account owner for super admin access to the sandbox."

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -641,6 +641,7 @@ en:
               type:
                 describe: "Type of sandbox to create (standard | development)"
             failure:
+              invalidUser: "Couldn't create {{ accountName }} because your account has been removed from {{ parentAccountName }} or your permission set doesn't allow you to create the sandbox. To update your permissions, contact a super admin in {{ parentAccountName }}."
               optionMissing:
                 type: "Invalid or missing sandbox --type option in command. Please try again."
                 name: "Invalid or missing sandbox --name option in command. Please try again."
@@ -662,10 +663,11 @@ en:
               deleteDefault: "Sandbox \"{{ account }}\" with portalId \"{{ sandboxHubId }}\" was deleted successfully and removed as the default account."
               configFileUpdated: "Removed account {{ account }} from {{ configFilename }}."
             failure:
+              invalidUser: "Couldn't delete {{ accountName }} because your account has been removed from {{ parentAccountName }} or your permission set doesn't allow you to delete the sandbox. To update your permissions, contact a super admin in {{ parentAccountName }}."
               noAccount: "No account specified. Specify an account by using the --account flag."
               noSandboxAccounts: "There are no sandboxes connected to the CLI. To add a sandbox, run {{#bold}}hs auth{{/bold}}."
               noParentAccount: "This sandbox can't be deleted from the CLI because you haven't given the CLI access to its parent account. To do this, run {{#bold}}hs auth{{/bold}} and add the parent account."
-              objectNotFound: "Sandbox {{#bold}}{{ account }}{{/bold}} may have been be deleted through the UI. The account has been removed from the config."
+              objectNotFound: "Sandbox {{#bold}}{{ account }}{{/bold}} may have been deleted through the UI. The account has been removed from the config."
               noParentPortalAvailable: "This sandbox can't be deleted from the CLI because you haven't given the CLI access to its parent account. To do this, run {{#bold}}{{ command }}{{/bold}}. You can also delete the sandbox from the HubSpot management tool: {{#bold}}{{ url }}{{/bold}}."
               invalidKey: "Your personal access key for account {{#bold}}{{ account }}{{/bold}} is inactive. To re-authenticate, please run {{#bold}}hs auth personalaccesskey{{/bold}}."
             options:
@@ -691,6 +693,7 @@ en:
               developmentSandbox: "Sync CRM object definitions to {{#cyan}}{{#bold}}{{ sandboxName }}{{/bold}}{{/cyan}} from {{#bold}}{{ parentAccountName }}{{/bold}}?"
               standardSandbox: "Sync all supported assets to {{#cyan}}{{#bold}}{{ sandboxName }}{{/bold}}{{/cyan}} from {{#bold}}{{ parentAccountName }}{{/bold}}?"
             failure:
+              invalidUser: "Couldn't sync {{ accountName }} because your account has been removed from {{ parentAccountName }} or your permission set doesn't allow you to sync the sandbox. To update your permissions, contact a super admin in {{ parentAccountName }}."
               notSandbox: "Sync must be run in a sandbox account. Your default account is a production account. Run {{#bold}}hs auth{{/bold}} to connect your sandbox account to the CLI or {{#bold}}hs accounts use{{/bold}} to change your default account, then try again."
               missingParentPortal: "The production account associated to {{#bold}}{{ sandboxName }}{{/bold}} is not connected to your HubSpot CLI.
                 \n- Run {{#bold}}hs auth{{/bold}} to connect that account to your terminal, then try again.
@@ -1188,7 +1191,7 @@ en:
             missingScopes: "Couldn’t run the sync because there are scopes missing in your production account. To update scopes, deactivate your current personal access key for {{#bold}}{{ accountName }}{{/bold}}, and generate a new one. Then run `hs auth` to update the CLI with the new key."
             syncInProgress: "Couldn’t run the sync because there’s another sync in progress. Wait for the current sync to finish and then try again. To check the sync status, visit the sync activity log: {{ url }}."
             notSuperAdmin: "Couldn't run the sync because you are not a super admin in {{ account }}. Ask the account owner for super admin access to the sandbox."
-            objectNotFound: "Couldn't sync the sandbox because {{#bold}}{{ account }}{{/bold}} may have been be deleted through the UI. Run {{#bold}}hs sandbox delete{{/bold}} to remove this account from the config. "
+            objectNotFound: "Couldn't sync the sandbox because {{#bold}}{{ account }}{{/bold}} may have been deleted through the UI. Run {{#bold}}hs sandbox delete{{/bold}} to remove this account from the config. "
           types:
             parcels:
               label: "Account tools and features"

--- a/packages/cli/lib/sandbox-create.js
+++ b/packages/cli/lib/sandbox-create.js
@@ -88,6 +88,21 @@ const buildSandbox = async ({
       );
     } else if (
       isSpecifiedError(err, {
+        statusCode: 403,
+        category: 'BANNED',
+        subCategory: 'SandboxErrors.USER_ACCESS_NOT_ALLOWED',
+      })
+    ) {
+      logger.log('');
+      logger.error(
+        i18n(`${i18nKey}.failure.invalidUser`, {
+          accountName: name,
+          parentAccountName: accountConfig.name || accountId,
+        })
+      );
+      logger.log('');
+    } else if (
+      isSpecifiedError(err, {
         statusCode: 400,
         category: 'VALIDATION_ERROR',
         subCategory:


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->

Adds appropriate error messaging for invalid users in a portal for all sandboxes commands. This also adds an error when creating a sandbox through `hs project dev`. 

Lastly, we updated a string from `dev` to `development` from the `hs project dev` prompt, and fixed a typo in a separate error. 

## Screenshots
<!-- Provide images of the before and after functionality -->
Create:
<img width="1263" alt="Screenshot 2023-05-31 at 10 02 38" src="https://github.com/HubSpot/hubspot-cli/assets/16788677/270c51b4-041b-4dc1-8235-8e8d48ffa7f8">

Sync:
<img width="1267" alt="Screenshot 2023-05-31 at 10 07 24" src="https://github.com/HubSpot/hubspot-cli/assets/16788677/882298c3-9797-4db7-9292-396c9db37337">

Delete:
<img width="1264" alt="Screenshot 2023-05-31 at 10 10 31" src="https://github.com/HubSpot/hubspot-cli/assets/16788677/eeff608e-89c8-46f1-b5a9-60b3e43a4652">


## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

n/a

## Who to Notify
<!-- /cc those you wish to know about the PR -->
