### PR TITLE
Update `hs ls` to include @hubspot folder, improve logging a little

### DIFF
--- a/packages/cli/commands/list.js
+++ b/packages/cli/commands/list.js
@@ -52,29 +52,37 @@ exports.handler = async options => {
     process.exit(EXIT_CODES.SUCCESS);
   }
 
-  if (contentsResp.children.length) {
-    const mappedContents = contentsResp.children.map(fileOrFolder => {
+  if (contentsResp.children) {
+    const contents =
+      directoryPath === '/'
+        ? ['@hubspot', ...contentsResp.children]
+        : contentsResp.children;
+    const mappedContents = contents.map(fileOrFolder => {
       if (!isPathFolder(fileOrFolder)) {
-        return fileOrFolder;
+        return chalk.reset.cyan(fileOrFolder);
       }
-
+      if (
+        fileOrFolder === HUBSPOT_FOLDER ||
+        fileOrFolder === MARKETPLACE_FOLDER
+      ) {
+        return chalk.reset.bold.blue(fileOrFolder);
+      }
       return chalk.reset.blue(fileOrFolder);
     });
-    const hubspotFolder = `/${HUBSPOT_FOLDER}`;
-    const marketplaceFolder = `/${MARKETPLACE_FOLDER}`;
+
     const folderContentsOutput = mappedContents
       .sort(function(a, b) {
         // Pin @hubspot folder to top
-        if (a === hubspotFolder) {
+        if (a === HUBSPOT_FOLDER) {
           return -1;
-        } else if (b === hubspotFolder) {
+        } else if (b === HUBSPOT_FOLDER) {
           return 1;
         }
 
         // Pin @marketplace folder to top
-        if (a === marketplaceFolder) {
+        if (a === MARKETPLACE_FOLDER) {
           return -1;
-        } else if (b === marketplaceFolder) {
+        } else if (b === MARKETPLACE_FOLDER) {
           return 1;
         }
 


### PR DESCRIPTION
## Description and Context
`getDirectoryContentsByPath` omits the `@hubspot` default asset folder. Recently it became possible to query the folder directly, leading to some strange behavior where `hs ls` didn't list `@hubspot`, but `hs ls @hubspot` would print the directory contents just fine. This update aims to bring this behavior more in line with the current DMUI and VSCE behavior and display this content for users.

The i18n key for the error was also wrong so fixed that. `In` -> `At`

Also went ahead and adjusted the logging a little bit, the `@hubspot` and `@marketplace` now display in bold, and files now display in cyan instead of black. We can change this color scheme a bit if anyone has Opinions 


## Screenshots
<!-- Provide images of the before and after functionality -->
<img width="323" alt="Screenshot 2023-06-02 at 2 22 44 PM" src="https://github.com/HubSpot/hubspot-cli/assets/25852903/fe427b65-e05f-4558-a545-69d985414add">

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@TheWebTech 