### PR TITLE
`hs sandbox create` duplicate name error handling

### DIFF
--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -998,7 +998,7 @@ en:
             invalidName: "You entered an invalid name. Please try again."
             nameRequired: "The name may not be blank. Please try again."
             spacesInName: "The name may not contain spaces. Please try again."
-            accountNameExists: "Account name \"{{ name }}\" already exists, please enter a different name."
+            accountNameExists: "Account with name \"{{ name }}\" already exists in the CLI config, please enter a different name."
         personalAccessKeyPrompt:
           enterAccountId: "Enter the account ID for your account (the number under the DOMAIN column at https://app.hubspot.com/myaccounts-beta ): "
           enterClientId: "Enter your OAuth2 client ID: "
@@ -1077,7 +1077,7 @@ en:
             errors:
               invalidName: "You entered an invalid name. Please try again."
               nameRequired: "The name may not be blank. Please try again."
-              accountNameExists: "Account name \"{{ name }}\" already exists, please enter a different name."
+              accountNameExists: "Account with name \"{{ name }}\" already exists in the CLI config, please enter a different name."
             selectAccountName: "Select the sandbox account you want to delete"
             selectParentAccountName: "Select the account that the sandbox belongs to"
           type:

--- a/packages/cli/lib/sandboxes.js
+++ b/packages/cli/lib/sandboxes.js
@@ -256,19 +256,20 @@ const saveSandboxToConfig = async (env, result, force = false) => {
     const invalidAccountName = accountNameExistsInConfig(nameForConfig);
     if (invalidAccountName) {
       if (!force) {
-        logger.log(
+        logger.log('');
+        logger.warn(
           i18n(
             `cli.lib.prompts.enterAccountNamePrompt.errors.accountNameExists`,
             { name: nameForConfig }
           )
         );
         const { name: promptName } = await enterAccountNamePrompt(
-          nameForConfig + `_${Date.now()}`
+          nameForConfig + `_${result.sandbox.sandboxHubId}`
         );
         validName = promptName;
       } else {
         // Basic invalid name handling when force flag is passed
-        validName = nameForConfig + `_${Date.now()}`;
+        validName = nameForConfig + `_${result.sandbox.sandboxHubId}`;
       }
     }
   }

--- a/packages/cli/lib/sandboxes.js
+++ b/packages/cli/lib/sandboxes.js
@@ -263,7 +263,7 @@ const saveSandboxToConfig = async (env, result, force = false) => {
           )
         );
         const { name: promptName } = await enterAccountNamePrompt(
-          nameForConfig
+          nameForConfig + `_${Date.now()}`
         );
         validName = promptName;
       } else {


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->

Issue to track: https://git.hubteam.com/HubSpot/hubspot-cli-issues/issues/405

Updates "error" message when a duplicate name is detected to be more clear about where the duplicate name was found. I've also used a logger.warn to make it clearer, and updated the default account name to append the newly created sandbox hub ID to avoid suggesting yet another duplicate name. 

## Screenshots
<!-- Provide images of the before and after functionality -->
Before:
![image](https://github.com/HubSpot/hubspot-cli/assets/16788677/cf3dbbd1-539c-43c9-a385-6614310b93c1)

After: 
<img width="787" alt="Screenshot 2023-06-12 at 15 27 13" src="https://github.com/HubSpot/hubspot-cli/assets/16788677/08d59b98-01fe-4505-8734-141c7befa3f0">

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
