### PR TITLE
Add error messaging on failed builds in project dev mode command

### DIFF
--- a/packages/cli/commands/project/upload.js
+++ b/packages/cli/commands/project/upload.js
@@ -59,7 +59,6 @@ exports.handler = async options => {
       message
     );
 
-    logger.log(result);
     if (result.uploadError) {
       if (
         isSpecifiedError(result.uploadError, {

--- a/packages/cli/commands/project/upload.js
+++ b/packages/cli/commands/project/upload.js
@@ -59,9 +59,10 @@ exports.handler = async options => {
       message
     );
 
-    if (result.error) {
+    logger.log(result);
+    if (result.uploadError) {
       if (
-        isSpecifiedError(result.error, {
+        isSpecifiedError(result.uploadError, {
           subCategory: ERROR_TYPES.PROJECT_LOCKED,
         })
       ) {
@@ -70,7 +71,7 @@ exports.handler = async options => {
         logger.log();
       } else {
         logApiErrorInstance(
-          result.error,
+          result.uploadError,
           new ApiErrorContext({
             accountId,
             projectName: projectConfig.name,
@@ -79,7 +80,7 @@ exports.handler = async options => {
       }
       process.exit(EXIT_CODES.ERROR);
     }
-    if (result.buildSucceeded && !result.autodeployEnabled) {
+    if (result.succeeded && !result.buildResult.isAutoDeployEnabled) {
       uiLine();
       logger.log(
         chalk.bold(

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -449,7 +449,6 @@ en:
             describe: "Start local dev for the current project"
             logs:
               betaMessage: "{{#yellow}}{{#bold}}[beta]{{/bold}}{{/yellow}} HubSpot projects local development"
-              learnMoreLink: "Learn more about the projects local dev server"
               nonSandboxWarning: "Testing in a sandbox is strongly recommended. To switch the target account, select an option below or run {{#bold}}`hs accounts use`{{/bold}} before running the command again."
               placeholderAccountSelection: "Using default account as target account (for now)"
               projectMustExistExplanation: "The project {{ projectName }} does not exist in the target account {{ accountIdentifier}}. This command requires the project to exist in the target account."
@@ -857,7 +856,6 @@ en:
         cancelledFromUI: "The dev process has been cancelled from the UI. Any changes made since cancelling have not been uploaded. To resume dev mode, rerun {{#yellow}}`hs project dev`{{/yellow}}."
         header:
           betaMessage: "{{#yellow}}{{#bold}}[beta]{{/bold}}{{/yellow}} HubSpot projects local development"
-          learnMoreLink: "Learn more about the projects local dev server"
           running: "Running {{ projectName}} locally on {{ accountIdentifier }}, waiting for changes ..."
           quitHelper: "Press {{#bold}}'q'{{/bold}} to stop the local dev server"
           viewInHubSpotLink: "View in HubSpot"

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -863,6 +863,8 @@ en:
           viewInHubSpotLink: "View in HubSpot"
           status:
             clean: "{{#bold}}Status:{{/bold}} {{#green}}Everything up to date{{/green}}"
+            buildError: "{{#bold}}Status:{{/bold}} {{#red}}Build failed{{/red}}"
+            deployError: "{{#bold}}Status:{{/bold}} {{#red}}Deploy failed{{/red}}"
             uploadPending: "{{#bold}}Status:{{/bold}} {{#yellow}}Upload is pending{{/yellow}}"
             noUploadsAllowed: "{{#bold}}Status:{{/bold}} {{#red}}Change requires upload, but uploads are not allowed{{/red}}"
             manualUploadRequired: "{{#bold}}Status:{{/bold}} {{#yellow}}Change requires manual upload{{/yellow}}"

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -876,6 +876,8 @@ en:
           manualUploadExplanation1: "{{#yellow}}> Dev server is running on a {{#bold}}non-sandbox account{{/bold}}.{{/yellow}}"
           manualUploadExplanation2: "{{#yellow}}> Uploading changes may overwrite production data.{{/yellow}}"
           manualUploadPrompt: "? Manually upload and deploy project? {{#green}}Y/n{{/green}}"
+          extensionNotAllowed: "Extension not allowed for {{ filePath }}"
+          fileIgnored: "File ignored: {{ filePath }}"
           uploadingAddChange: "[INFO] Uploading {{ filePath }}"
           uploadedAddChange: "[INFO] Uploaded {{ filePath }}"
           uploadingRemoveChange: "[INFO] Removing {{ filePath }}"

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -861,8 +861,8 @@ en:
           viewInHubSpotLink: "View in HubSpot"
           status:
             clean: "{{#bold}}Status:{{/bold}} {{#green}}Everything up to date{{/green}}"
-            buildError: "{{#bold}}Status:{{/bold}} {{#red}}Build failed{{/red}}"
-            deployError: "{{#bold}}Status:{{/bold}} {{#red}}Deploy failed{{/red}}"
+            buildError: "{{#bold}}Status:{{/bold}} {{#red}}Latest build failed{{/red}}"
+            deployError: "{{#bold}}Status:{{/bold}} {{#red}}Latest deploy failed{{/red}}"
             uploadPending: "{{#bold}}Status:{{/bold}} {{#yellow}}Upload is pending{{/yellow}}"
             noUploadsAllowed: "{{#bold}}Status:{{/bold}} {{#red}}Change requires upload, but uploads are not allowed{{/red}}"
             manualUploadRequired: "{{#bold}}Status:{{/bold}} {{#yellow}}Change requires manual upload{{/yellow}}"

--- a/packages/cli/lib/DevServerManager.js
+++ b/packages/cli/lib/DevServerManager.js
@@ -46,10 +46,6 @@ class DevServerManager {
     app.get('/hs/project', (req, res) => {
       res.redirect(getProjectDetailUrl(projectConfig.name, accountId));
     });
-    app.get('/hs/learnMore', (req, res) => {
-      //TODO link to docs
-      res.redirect(getProjectDetailUrl(projectConfig.name, accountId));
-    });
 
     // Initialize component servers
     await this.iterateDevServers(async (serverInterface, serverKey) => {

--- a/packages/cli/lib/LocalDevManager.js
+++ b/packages/cli/lib/LocalDevManager.js
@@ -364,18 +364,10 @@ class LocalDevManager {
       return;
     }
 
-    if (this.uploadQueue.isPaused) {
-      this.addChangeToStandbyQueue({ ...changeInfo, supported: false });
-    } else {
+    this.addChangeToStandbyQueue({ ...changeInfo, supported: false });
+
+    if (!this.uploadQueue.isPaused) {
       await this.flushStandbyChanges();
-
-      if (!this.uploadQueue.isPaused) {
-        this.debounceQueueBuild(changeInfo);
-      }
-
-      return this.uploadQueue.add(async () => {
-        await this.sendChanges(changeInfo);
-      });
     }
   }
 
@@ -427,12 +419,22 @@ class LocalDevManager {
 
     if (event === WATCH_EVENTS.add || event === WATCH_EVENTS.change) {
       if (!isAllowedExtension(filePath)) {
-        logger.debug(`Extension not allowed: ${filePath}`);
+        this.spinnies.add(null, {
+          text: i18n(`${i18nKey}.upload.extensionNotAllowed`, {
+            filePath,
+          }),
+          status: 'non-spinnable',
+        });
         return;
       }
     }
     if (shouldIgnoreFile(filePath, true)) {
-      logger.debug(`File ignored: ${filePath}`);
+      this.spinnies.add(null, {
+        text: i18n(`${i18nKey}.upload.fileIgnored`, {
+          filePath,
+        }),
+        status: 'non-spinnable',
+      });
       return;
     }
 

--- a/packages/cli/lib/LocalDevManager.js
+++ b/packages/cli/lib/LocalDevManager.js
@@ -259,7 +259,6 @@ class LocalDevManager {
     const subTasks = buildStatus[PROJECT_BUILD_TEXT.SUBTASK_KEY] || [];
     const failedSubTasks = subTasks.filter(task => task.status === 'FAILURE');
 
-    logger.log(failedSubTasks);
     if (failedSubTasks.length) {
       this.updateDevModeStatus('buildError');
 

--- a/packages/cli/lib/SpinniesManager.js
+++ b/packages/cli/lib/SpinniesManager.js
@@ -52,7 +52,7 @@ class SpinniesManager {
     const originalIndent = rest.indent || 0;
 
     // Support adding generic spinnies lines without specifying a key
-    const uniqueKey = key || `${Date.now()}`;
+    const uniqueKey = key || `${Date.now()}-${Math.random()}`;
 
     if (category) {
       this.addKeyToCategory(uniqueKey, category);


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->

The Dev Mode command was previously failing silently whenever the initial build failed. It This updates it to show the user that something went wrong in their build. It also adds logging for the specific build errors (rather than just saying "something went wrong").


## Screenshots
<!-- Provide images of the before and after functionality -->
Screenshot shows the initial state of the dev mode command when the initial upload + build fails. In the before screenshot, we're telling the user that everything went fine. In the after screenshot, we're doing a better job of letting the user know what the status of their project is.
### Before
<img width="716" alt="image" src="https://github.com/HubSpot/hubspot-cli/assets/6654014/5767b63f-1d0e-43be-a199-c8aeb067720c">

### After
<img width="838" alt="image" src="https://github.com/HubSpot/hubspot-cli/assets/6654014/c20acb2d-c19e-4193-9bed-6d8fc3ad8bec">

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->
- [x] Verify the UX of the output for the status when builds fail
- [x] Verify the UX of the output of the build errors
- [x] Verify that the error handling for failed deploys also works

## Who to Notify
<!-- /cc those you wish to know about the PR -->
