### PR TITLE
Disable printing logs in project logs command

### DIFF
--- a/packages/cli/commands/project/logs.js
+++ b/packages/cli/commands/project/logs.js
@@ -9,7 +9,7 @@ const {
 } = require('../../lib/commonOpts');
 const { trackCommandUsage } = require('../../lib/usageTracking');
 const { logger } = require('@hubspot/cli-lib/logger');
-const { outputLogs } = require('@hubspot/cli-lib/lib/logs');
+// const { outputLogs } = require('@hubspot/cli-lib/lib/logs');
 const {
   fetchProject,
   fetchDeployComponentsMetadata,
@@ -18,25 +18,25 @@ const {
   getTableContents,
   getTableHeader,
 } = require('@hubspot/cli-lib/lib/table');
-const {
-  getProjectAppFunctionLogs,
-  getLatestProjectAppFunctionLog,
-} = require('@hubspot/cli-lib/api/functions');
-const {
-  logApiErrorInstance,
-  ApiErrorContext,
-} = require('@hubspot/cli-lib/errorHandlers');
-const {
-  getFunctionLogs,
-  getLatestFunctionLog,
-} = require('@hubspot/cli-lib/api/results');
+// const {
+//   getProjectAppFunctionLogs,
+//   getLatestProjectAppFunctionLog,
+// } = require('@hubspot/cli-lib/api/functions');
+// const {
+//   logApiErrorInstance,
+//   ApiErrorContext,
+// } = require('@hubspot/cli-lib/errorHandlers');
+// const {
+//   getFunctionLogs,
+//   getLatestFunctionLog,
+// } = require('@hubspot/cli-lib/api/results');
 const { ensureProjectExists } = require('../../lib/projects');
 const { loadAndValidateOptions } = require('../../lib/validation');
 const { uiLine, uiLink } = require('../../lib/ui');
 const { projectLogsPrompt } = require('../../lib/prompts/projectsLogsPrompt');
-const { tailLogs } = require('../../lib/serverlessLogs');
+// const { tailLogs } = require('../../lib/serverlessLogs');
 const { i18n } = require('../../lib/lang');
-const { EXIT_CODES } = require('../../lib/enums/exitCodes');
+// const { EXIT_CODES } = require('../../lib/enums/exitCodes');
 
 const i18nKey = 'cli.commands.project.subcommands.logs';
 
@@ -48,90 +48,92 @@ const getPrivateAppsUrl = accountId => {
   return `${baseUrl}/private-apps/${accountId}`;
 };
 
-const handleLogsError = (e, name, projectName) => {
-  if (e.statusCode === 404) {
-    logger.debug(`Log fetch error: ${e.message}`);
-    logger.log(i18n(`${i18nKey}.logs.noLogsFound`, { name }));
-  } else {
-    logApiErrorInstance(
-      e,
-      new ApiErrorContext({ accountId: getAccountId(), projectName })
-    );
-    process.exit(EXIT_CODES.ERROR);
-  }
-};
+// We currently cannot fetch logs directly to the CLI. See internal CLI issue #413 for more information.
 
-const handleFunctionLog = async (accountId, options) => {
-  const {
-    latest,
-    follow,
-    compact,
-    appPath,
-    functionName,
-    projectName,
-  } = options;
+// const handleLogsError = (e, name, projectName) => {
+//   if (e.statusCode === 404) {
+//     logger.debug(`Log fetch error: ${e.message}`);
+//     logger.log(i18n(`${i18nKey}.logs.noLogsFound`, { name }));
+//   } else {
+//     logApiErrorInstance(
+//       e,
+//       new ApiErrorContext({ accountId: getAccountId(), projectName })
+//     );
+//     process.exit(EXIT_CODES.ERROR);
+//   }
+// };
 
-  let logsResp;
+// const handleFunctionLog = async (accountId, options) => {
+//   const {
+//     latest,
+//     follow,
+//     compact,
+//     appPath,
+//     functionName,
+//     projectName,
+//   } = options;
 
-  const tailCall = async after => {
-    try {
-      return appPath
-        ? getProjectAppFunctionLogs(
-            accountId,
-            functionName,
-            projectName,
-            appPath,
-            {
-              after,
-            }
-          )
-        : getFunctionLogs(accountId, functionName, { after });
-    } catch (e) {
-      handleLogsError(e, functionName, projectName);
-    }
-  };
+//   let logsResp;
 
-  const fetchLatest = async () => {
-    return appPath
-      ? getLatestProjectAppFunctionLog(
-          accountId,
-          functionName,
-          projectName,
-          appPath
-        )
-      : getLatestFunctionLog(accountId, functionName, projectName);
-  };
+//   const tailCall = async after => {
+//     try {
+//       return appPath
+//         ? getProjectAppFunctionLogs(
+//             accountId,
+//             functionName,
+//             projectName,
+//             appPath,
+//             {
+//               after,
+//             }
+//           )
+//         : getFunctionLogs(accountId, functionName, { after });
+//     } catch (e) {
+//       handleLogsError(e, functionName, projectName);
+//     }
+//   };
 
-  if (follow) {
-    await tailLogs({
-      accountId,
-      compact,
-      tailCall,
-      fetchLatest,
-      name: functionName,
-    });
-  } else if (latest) {
-    try {
-      logsResp = await fetchLatest();
-    } catch (e) {
-      handleLogsError(e, functionName, projectName);
-      return true;
-    }
-  } else {
-    try {
-      logsResp = await tailCall();
-    } catch (e) {
-      handleLogsError(e, functionName, projectName);
-      return true;
-    }
-  }
+//   const fetchLatest = async () => {
+//     return appPath
+//       ? getLatestProjectAppFunctionLog(
+//           accountId,
+//           functionName,
+//           projectName,
+//           appPath
+//         )
+//       : getLatestFunctionLog(accountId, functionName, projectName);
+//   };
 
-  if (logsResp) {
-    outputLogs(logsResp, options);
-    return true;
-  }
-  return false;
-};
+//   if (follow) {
+//     await tailLogs({
+//       accountId,
+//       compact,
+//       tailCall,
+//       fetchLatest,
+//       name: functionName,
+//     });
+//   } else if (latest) {
+//     try {
+//       logsResp = await fetchLatest();
+//     } catch (e) {
+//       handleLogsError(e, functionName, projectName);
+//       return true;
+//     }
+//   } else {
+//     try {
+//       logsResp = await tailCall();
+//     } catch (e) {
+//       handleLogsError(e, functionName, projectName);
+//       return true;
+//     }
+//   }
+
+//   if (logsResp) {
+//     outputLogs(logsResp, options);
+//     return true;
+//   }
+//   return false;
+// };
 
 exports.command = 'logs [--project] [--app] [--function] [--endpoint]';
 exports.describe = i18n(`${i18nKey}.describe`);
@@ -154,7 +156,7 @@ exports.handler = async options => {
     options.function || promptFunctionName || options.endpoint;
   const endpointName = options.endpoint || promptEndpointName;
 
-  let relativeAppPath;
+  // let relativeAppPath;
   let appId;
 
   if (appName && !endpointName) {
@@ -162,10 +164,11 @@ exports.handler = async options => {
       allowCreate: false,
     });
 
-    const { deployedBuild, id: projectId } = await fetchProject(
-      accountId,
-      projectName
-    );
+    // const { deployedBuild, id: projectId } = await fetchProject(
+    //   accountId,
+    //   projectName
+    // );
+    const { id: projectId } = await fetchProject(accountId, projectName);
 
     const { results: deployComponents } = await fetchDeployComponentsMetadata(
       accountId,
@@ -180,22 +183,22 @@ exports.handler = async options => {
       appId = appComponent.componentIdentifier;
     }
 
-    if (deployedBuild && deployedBuild.subbuildStatuses) {
-      const appSubbuild = deployedBuild.subbuildStatuses.find(
-        subbuild => subbuild.buildName === appName
-      );
-      if (appSubbuild) {
-        relativeAppPath = appSubbuild.rootPath;
-      } else {
-        logger.error(
-          i18n(`${i18nKey}.errors.invalidAppName`, {
-            appName: options.app,
-            projectName,
-          })
-        );
-        process.exit(EXIT_CODES.ERROR);
-      }
-    }
+    // if (deployedBuild && deployedBuild.subbuildStatuses) {
+    //   const appSubbuild = deployedBuild.subbuildStatuses.find(
+    //     subbuild => subbuild.buildName === appName
+    //   );
+    //   if (appSubbuild) {
+    //     relativeAppPath = appSubbuild.rootPath;
+    //   } else {
+    //     logger.error(
+    //       i18n(`${i18nKey}.errors.invalidAppName`, {
+    //         appName: options.app,
+    //         projectName,
+    //       })
+    //     );
+    //     process.exit(EXIT_CODES.ERROR);
+    //   }
+    // }
   }
 
   trackCommandUsage('project-logs', null, accountId);
@@ -240,16 +243,16 @@ exports.handler = async options => {
   logger.log();
   uiLine();
 
-  const showFinalMessage = await handleFunctionLog(accountId, {
-    ...options,
-    projectName,
-    appPath: relativeAppPath,
-    functionName: functionName || endpointName,
-  });
+  //   const showFinalMessage = await handleFunctionLog(accountId, {
+  //     ...options,
+  //     projectName,
+  //     appPath: relativeAppPath,
+  //     functionName: functionName || endpointName,
+  //   });
 
-  if (showFinalMessage) {
-    uiLine();
-  }
+  //   if (showFinalMessage) {
+  //     uiLine();
+  //   }
 };
 
 exports.builder = yargs => {


### PR DESCRIPTION
## Description and Context
Because of a change in the logging endpoint, we are currently always returning a 404 status code error when attempting to fetch logs in the `hs project logs` command. 

It will take some time for the logging team to address this issue, and so in the meantime, I've disabled the `Logs not found` comment and simply provide the customer to a link to the Logs UI, which is correct and up-to-date. 

One question for @camden11 or @brandenrodgers: I've simply commented out the code that generates the logs for now, assuming that we will re-enable this feature once the API endpoint is fixed. Would it be better simply to delete this code for now? 

## Screenshots
<!-- Provide images of the before and after functionality -->

Currently, we always tell the customer that logs cannot be found:

<img width="873" alt="Screenshot 2023-06-28 at 12 33 36 PM" src="https://github.com/HubSpot/hubspot-cli/assets/25392256/107a84b8-d269-415f-b511-877129730235">

With these changes, we simply link to the logs:

<img width="956" alt="Screenshot 2023-06-28 at 12 34 03 PM" src="https://github.com/HubSpot/hubspot-cli/assets/25392256/96b69605-4194-47ca-a42c-8a7a2425176a">

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@brandenrodgers @camden11 