### PR TITLE
Fix bugs in bulk adds/deletes in dev mode

### DIFF
--- a/packages/cli/lib/LocalDevManager.js
+++ b/packages/cli/lib/LocalDevManager.js
@@ -40,6 +40,7 @@ const WATCH_EVENTS = {
   add: 'add',
   change: 'change',
   unlink: 'unlink',
+  unlinkDir: 'unlinkDir',
 };
 
 const UPLOAD_PERMISSIONS = {
@@ -335,6 +336,9 @@ class LocalDevManager {
     this.watcher.on('unlink', async filePath => {
       this.handleWatchEvent(filePath, WATCH_EVENTS.unlink);
     });
+    this.watcher.on('unlinkDir', async filePath => {
+      this.handleWatchEvent(filePath, WATCH_EVENTS.unlinkDir);
+    });
   }
 
   async handleWatchEvent(filePath, event) {
@@ -468,7 +472,10 @@ class LocalDevManager {
           }),
           status: 'non-spinnable',
         });
-      } else if (event === WATCH_EVENTS.unlink) {
+      } else if (
+        event === WATCH_EVENTS.unlink ||
+        event === WATCH_EVENTS.unlinkDir
+      ) {
         const { name: spinnerName } = SpinniesManager.add(null, {
           text: i18n(`${i18nKey}.upload.uploadingRemoveChange`, {
             filePath: remotePath,


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
This fixes an issue that pops up when you try to add or remove many files simultaneously from a project. You can test it out by creating a folder of several files and then alternate dragging it into and out of the project while the Dev Mode command is running.

The main issue was happening because we were using `await` on the call to [this.uploadQueue.addAll](https://github.com/HubSpot/hubspot-cli/compare/br-fix-dev-mode-bulk-actions?expand=1#diff-0391b654b5bab2f8d2b05906b406db63c1c591cc6b937dfba92d6a7d475cf878L638). This was causing the process to wait until that finished before setting `this.standbyChanges = [];` (happens right afterwards). This opened us up to the race condition where:
1. User drags a folder that contains two files (`file1.js` and `file2.js`) into the project
2. The watcher picks up the addition of file1. It adds it to the queue and flushes the changes, which triggers an upload
3. The watcher picks up the addition of file2 (before the flushing of the file1 changes as finished) and it flushes the changes
4. The standbyChanges list hasn't been cleared out yet, so file1 changes and file2 changes get uploaded

Also, I need to test this out, but I don't think we need `unlinkDir` because our BE doesn't care about empty folders anyways. 
## Screenshots
<!-- Provide images of the before and after functionality -->

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
