### PR TITLE
Better handling for ignored extensions when upload permission is manual

### DIFF
--- a/packages/cli/lib/LocalDevManager.js
+++ b/packages/cli/lib/LocalDevManager.js
@@ -387,29 +387,34 @@ class LocalDevManager {
     } else {
       this.updateDevModeStatus('manualUploadRequired');
 
-      this.addChangeToStandbyQueue({ ...changeInfo, supported: false });
+      const addedToQueue = this.addChangeToStandbyQueue({
+        ...changeInfo,
+        supported: false,
+      });
 
-      SpinniesManager.add('manualUploadRequired', {
-        text: i18n(`${i18nKey}.upload.manualUploadRequired`),
-        status: 'fail',
-        failColor: 'white',
-        noIndent: true,
-      });
-      SpinniesManager.add('manualUploadExplanation1', {
-        text: i18n(`${i18nKey}.upload.manualUploadExplanation1`),
-        status: 'non-spinnable',
-        indent: 1,
-      });
-      SpinniesManager.add('manualUploadExplanation2', {
-        text: i18n(`${i18nKey}.upload.manualUploadExplanation2`),
-        status: 'non-spinnable',
-        indent: 1,
-      });
-      SpinniesManager.add('manualUploadPrompt', {
-        text: i18n(`${i18nKey}.upload.manualUploadPrompt`),
-        status: 'non-spinnable',
-        indent: 1,
-      });
+      if (addedToQueue) {
+        SpinniesManager.add('manualUploadRequired', {
+          text: i18n(`${i18nKey}.upload.manualUploadRequired`),
+          status: 'fail',
+          failColor: 'white',
+          noIndent: true,
+        });
+        SpinniesManager.add('manualUploadExplanation1', {
+          text: i18n(`${i18nKey}.upload.manualUploadExplanation1`),
+          status: 'non-spinnable',
+          indent: 1,
+        });
+        SpinniesManager.add('manualUploadExplanation2', {
+          text: i18n(`${i18nKey}.upload.manualUploadExplanation2`),
+          status: 'non-spinnable',
+          indent: 1,
+        });
+        SpinniesManager.add('manualUploadPrompt', {
+          text: i18n(`${i18nKey}.upload.manualUploadPrompt`),
+          status: 'non-spinnable',
+          indent: 1,
+        });
+      }
     }
   }
 
@@ -417,14 +422,14 @@ class LocalDevManager {
     const { event, filePath } = changeInfo;
 
     if (event === WATCH_EVENTS.add || event === WATCH_EVENTS.change) {
-      if (!isAllowedExtension(filePath)) {
+      if (!isAllowedExtension(filePath, ['jsx'])) {
         SpinniesManager.add(null, {
           text: i18n(`${i18nKey}.upload.extensionNotAllowed`, {
             filePath,
           }),
           status: 'non-spinnable',
         });
-        return;
+        return false;
       }
     }
     if (shouldIgnoreFile(filePath, true)) {
@@ -434,7 +439,7 @@ class LocalDevManager {
         }),
         status: 'non-spinnable',
       });
-      return;
+      return false;
     }
 
     const existingIndex = this.standbyChanges.findIndex(
@@ -447,6 +452,7 @@ class LocalDevManager {
     } else {
       this.standbyChanges.push(changeInfo);
     }
+    return true;
   }
 
   async sendChanges(changeInfo) {


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
There were two issues happening:
- We weren't allowing jsx files to be uploaded because we were filtering out files with that extension type
- We weren't handling ignored files well when the upload permission was set to manual. We were asking the user to upload the changes when in reality there was nothing to upload. Now we will only prompt the user to upload something if there is something to upload.

## Screenshots
<!-- Provide images of the before and after functionality -->

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
