### PR TITLE
Allow for folder deletion in project dev/watch mode

### DIFF
--- a/packages/cli/lib/LocalDevManager.js
+++ b/packages/cli/lib/LocalDevManager.js
@@ -21,7 +21,7 @@ const { shouldIgnoreFile } = require('@hubspot/cli-lib/ignoreRules');
 const {
   cancelStagedBuild,
   uploadFileToBuild,
-  deleteFileFromBuild,
+  deleteAssetFromBuild,
   provisionBuild,
   queueBuild,
 } = require('@hubspot/cli-lib/api/dfs');
@@ -485,10 +485,12 @@ class LocalDevManager {
           }),
           status: 'non-spinnable',
         });
-        await deleteFileFromBuild(
+        const path =
+          event === WATCH_EVENTS.unlinkDir ? `${remotePath}/` : remotePath;
+        await deleteAssetFromBuild(
           this.targetAccountId,
           this.projectConfig.name,
-          remotePath
+          path
         );
         SpinniesManager.update(spinnerName, {
           text: i18n(`${i18nKey}.upload.uploadedRemoveChange`, {

--- a/packages/cli/lib/LocalDevManager.js
+++ b/packages/cli/lib/LocalDevManager.js
@@ -21,7 +21,7 @@ const { shouldIgnoreFile } = require('@hubspot/cli-lib/ignoreRules');
 const {
   cancelStagedBuild,
   uploadFileToBuild,
-  deleteAssetFromBuild,
+  deleteFileFromBuild,
   provisionBuild,
   queueBuild,
 } = require('@hubspot/cli-lib/api/dfs');
@@ -487,7 +487,7 @@ class LocalDevManager {
         });
         const path =
           event === WATCH_EVENTS.unlinkDir ? `${remotePath}/` : remotePath;
-        await deleteAssetFromBuild(
+        await deleteFileFromBuild(
           this.targetAccountId,
           this.projectConfig.name,
           path


### PR DESCRIPTION
## Description and Context
Currently, when running the `hs project dev` or `hs project watch` commands, we're unable to delete folders. The folder will still appear on the build detail page after it's supposed to be deleted. In this PR, I've added a trailing `/` to folder paths, so that the BE can successfully delete them. 

## Loom
The before/after functionality is a bit complicated in this case, so I recorded [a loom](https://www.loom.com/share/a620af3c3e6943a9a766387b3f328a2e). 

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

@brandenrodgers, I could only find references to the `unlinkDir` watch event in the `LocalDevManager` file, but I'm wondering whether I've missed any references. Would love some extra 👀 on this. 

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@brandenrodgers 
