### PR TITLE
`hs sandbox delete` remove regex check for auth errors

### DIFF
--- a/packages/cli/commands/accounts/list.js
+++ b/packages/cli/commands/accounts/list.js
@@ -71,7 +71,7 @@ const getPortalData = mappedPortalData => {
 };
 
 exports.handler = async options => {
-  await loadAndValidateOptions(options);
+  await loadAndValidateOptions(options, false);
 
   const accountId = getAccountId(options);
 

--- a/packages/cli/commands/sandbox/delete.js
+++ b/packages/cli/commands/sandbox/delete.js
@@ -168,19 +168,15 @@ exports.handler = async options => {
   } catch (err) {
     debugErrorAndContext(err);
 
-    if (err instanceof HubSpotAuthError) {
+    if (err instanceof HubSpotAuthError && err.statusCode === 401) {
       // Intercept invalid key error
       // This command uses the parent portal PAK to delete a sandbox, so we must specify which account needs a new key
-      const regex = /\bYour personal access key is invalid\b/;
-      const match = err.message.match(regex);
-      if (match && match[0]) {
-        logger.log('');
-        logger.error(
-          i18n(`${i18nKey}.failure.invalidKey`, {
-            account: getAccountName(parentAccount),
-          })
-        );
-      }
+      logger.log('');
+      logger.error(
+        i18n(`${i18nKey}.failure.invalidKey`, {
+          account: getAccountName(parentAccount),
+        })
+      );
     } else if (
       isSpecifiedError(err, {
         statusCode: 403,


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->

Related `cli-lib` PR that will need to go out for this to work: https://github.com/HubSpot/cli-lib/pull/16

With the updated `HubSpotAuthError` and the removal of an extra message line from the refresh token flow, `hs sandbox delete` needs to be updated to remove the regex check and use `statusCode` in its place. 

I also found that `hs accounts list` does not work if you have an invalid access token which doesn't seem helpful, I disabled the validation check for that command since its not really an action needing a valid key. 

## Screenshots
<!-- Provide images of the before and after functionality -->
n/a

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
