### PR TITLE
Sandboxes: tracking intermediate actions with new action

### DIFF
--- a/packages/cli/commands/project/dev.js
+++ b/packages/cli/commands/project/dev.js
@@ -5,7 +5,10 @@ const {
   addUseEnvironmentOptions,
   addTestingOptions,
 } = require('../../lib/commonOpts');
-const { trackCommandUsage } = require('../../lib/usageTracking');
+const {
+  trackCommandUsage,
+  trackCommandMetadataUsage,
+} = require('../../lib/usageTracking');
 const { loadAndValidateOptions } = require('../../lib/validation');
 const { i18n } = require('../../lib/lang');
 const { logger } = require('@hubspot/cli-lib/logger');
@@ -129,6 +132,13 @@ exports.handler = async options => {
     }
     try {
       const { name } = await sandboxNamePrompt(DEVELOPER_SANDBOX);
+
+      trackCommandMetadataUsage(
+        'sandbox-create',
+        { step: 'project-dev' },
+        accountId
+      );
+
       const { result } = await buildSandbox({
         name,
         type: DEVELOPER_SANDBOX,

--- a/packages/cli/commands/sandbox/create.js
+++ b/packages/cli/commands/sandbox/create.js
@@ -22,7 +22,10 @@ const {
 } = require('../../lib/sandboxes');
 const { getValidEnv } = require('@hubspot/cli-lib/lib/environment');
 const { logger } = require('@hubspot/cli-lib/logger');
-const { trackCommandUsage } = require('../../lib/usageTracking');
+const {
+  trackCommandUsage,
+  trackCommandMetadataUsage,
+} = require('../../lib/usageTracking');
 const {
   sandboxTypePrompt,
   sandboxNamePrompt,
@@ -153,6 +156,12 @@ exports.handler = async options => {
     // Prompt user to sync assets after sandbox creation
     const sandboxAccountConfig = getAccountConfig(result.sandbox.sandboxHubId);
     const handleSyncSandbox = async syncTasks => {
+      // Send tracking event for secondary action, in this case a sandbox sync within the sandbox create flow
+      trackCommandMetadataUsage(
+        'sandbox-sync',
+        { step: 'sandbox-create' },
+        result.sandbox.sandboxHubId
+      );
       await syncSandbox({
         accountConfig: sandboxAccountConfig,
         parentAccountConfig: accountConfig,

--- a/packages/cli/lib/usageTracking.js
+++ b/packages/cli/lib/usageTracking.js
@@ -7,6 +7,30 @@ const { version } = require('../package.json');
 const { getPlatform } = require('./environment');
 const { setLogLevel } = require('./commonOpts');
 
+/* **
+Available tracking meta properties
+
+  ImmutableMap
+    .<EventProperty, String>builder()
+    .put(EventProperty.ACTION, "The specific action taken in the CLI")
+    .put(EventProperty.OS, "The user's OS")
+    .put(EventProperty.NODE_VERSION, "The user's version of node.js")
+    .put(EventProperty.NODE_MAJOR_VERSION, "The user's major version of node.js")
+    .put(EventProperty.VERSION, "The user's version of the CLI")
+    .put(
+      EventProperty.COMMAND,
+      "The specific command that the user ran in this interaction"
+    )
+    .put(EventProperty.AUTH_TYPE, "The configured auth type the user has for the CLI")
+    .put(EventProperty.STEP, "The specific step in the auth process")
+    .put(EventProperty.ASSET_TYPE, "The CMS asset type")
+    .put(EventProperty.MODE, "The CLI mode (draft or publish")
+    .put(EventProperty.TYPE, "The upload type (file or folder)")
+    .put(EventProperty.FILE, "Whether or not the 'file' flag was used")
+    .put(EventProperty.SUCCESSFUL, "Whether or not the CLI interaction was successful")
+
+*/
+
 const EventClass = {
   USAGE: 'USAGE',
   INTERACTION: 'INTERACTION',
@@ -132,10 +156,48 @@ const trackAuthAction = async (command, authType, step, accountId) => {
   }
 };
 
+function trackCommandMetadataUsage(command, meta = {}, accountId) {
+  if (!isTrackingAllowed()) {
+    return;
+  }
+  logger.debug('Attempting to track metadata usage of "%s" command', command);
+  let authType = 'unknown';
+  if (accountId) {
+    const accountConfig = getAccountConfig(accountId);
+    authType =
+      accountConfig && accountConfig.authType
+        ? accountConfig.authType
+        : API_KEY_AUTH_METHOD.value;
+  }
+  setImmediate(async () => {
+    const usageTrackingEvent = {
+      action: 'cli-command-metadata',
+      os: getPlatform(),
+      ...getNodeVersionData(),
+      version,
+      command,
+      authType,
+      ...meta,
+    };
+    try {
+      await trackUsage(
+        'cli-interaction',
+        EventClass.INTERACTION,
+        usageTrackingEvent,
+        accountId
+      );
+      logger.debug('Sent usage tracking command event: %o', usageTrackingEvent);
+    } catch (e) {
+      logger.debug('Metadata usage tracking failed: %s', e.message);
+    }
+  });
+}
+
 module.exports = {
   trackCommandUsage,
   trackHelpUsage,
   addHelpUsageTracking,
   trackConvertFieldsUsage,
   trackAuthAction,
+  trackCommandMetadataUsage,
 };

--- a/packages/cli/lib/usageTracking.js
+++ b/packages/cli/lib/usageTracking.js
@@ -10,24 +10,19 @@ const { setLogLevel } = require('./commonOpts');
 /* **
 Available tracking meta properties
 
-  ImmutableMap
-    .<EventProperty, String>builder()
-    .put(EventProperty.ACTION, "The specific action taken in the CLI")
-    .put(EventProperty.OS, "The user's OS")
-    .put(EventProperty.NODE_VERSION, "The user's version of node.js")
-    .put(EventProperty.NODE_MAJOR_VERSION, "The user's major version of node.js")
-    .put(EventProperty.VERSION, "The user's version of the CLI")
-    .put(
-      EventProperty.COMMAND,
-      "The specific command that the user ran in this interaction"
-    )
-    .put(EventProperty.AUTH_TYPE, "The configured auth type the user has for the CLI")
-    .put(EventProperty.STEP, "The specific step in the auth process")
-    .put(EventProperty.ASSET_TYPE, "The CMS asset type")
-    .put(EventProperty.MODE, "The CLI mode (draft or publish")
-    .put(EventProperty.TYPE, "The upload type (file or folder)")
-    .put(EventProperty.FILE, "Whether or not the 'file' flag was used")
-    .put(EventProperty.SUCCESSFUL, "Whether or not the CLI interaction was successful")
+  - action: "The specific action taken in the CLI"
+  - os: "The user's OS"
+  - nodeVersion: "The user's version of node.js"
+  - nodeMajorVersion: "The user's major version of node.js"
+  - version: "The user's version of the CLI"
+  - command: "The specific command that the user ran in this interaction"
+  - authType: "The configured auth type the user has for the CLI"
+  - step: "The specific step in the auth process"
+  - assetType: "The CMS asset type"
+  - mode: "The CLI mode (draft or publish"
+  - type: "The upload type (file or folder)"
+  - file: "Whether or not the 'file' flag was used"
+  - successful: "Whether or not the CLI interaction was successful"
 
 */
 


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->

For actions that happen during a command, eg: syncing a sandbox in the sandbox create flow, we now track them using a new action name `cli-command-metadata`. 

Usages in this PR:
- User responds `yes` to a prompt for syncing a newly created sandbox within the `hs sandbox create` flow
- User creates a new sandbox within the `hs project dev` flow

I re-used the `step` metadata prop, but open to changing it to use another. 

Related sandboxes issue: https://git.hubteam.com/HubSpot/sandboxes-ui/issues/1930

## Screenshots
<!-- Provide images of the before and after functionality -->
Sandbox sync in sandbox create:
<img width="1261" alt="Screenshot 2023-07-20 at 15 07 33" src="https://github.com/HubSpot/hubspot-cli/assets/16788677/e9b7964a-7baa-404e-b725-089bb3b938d6">

Sandbox create in project dev:
<img width="1210" alt="Screenshot 2023-07-20 at 15 08 23" src="https://github.com/HubSpot/hubspot-cli/assets/16788677/fb643258-c6f1-4072-bcca-d2563f97a168">


## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->


## Who to Notify
<!-- /cc those you wish to know about the PR -->
