### PR TITLE
Dev Mode - support setup step

### DIFF
--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -461,10 +461,11 @@ en:
               startupMessage: "Starting local dev server for {{#bold}}{{ projectName }}{{/bold}} ..."
             prompt:
               createProject: "Create new project {{ projectName}} in {{#bold}}[{{ accountIdentifier }}]{{/bold}}?"
-              targetNonSandbox: "Continue testing in a non-sandbox account?"
             options:
-              extension:
-                describe: "The extension that you would like to run locally"
+              local:
+                describe: "Run the alpha version of this command with some local dev server functionality"
+              localAll:
+                describe: "Run the alpha version of this command with all local dev server functionality"
             errors:
               noProjectConfig: "No project detected. Please run this command again from a project directory."
               projectLockedError: "Your project is locked. This may mean that another user is running the {{#bold}}`hs project dev`{{/bold}} command for this project. If this is you, unlock the project in Projects UI."
@@ -848,8 +849,12 @@ en:
     lib:
       DevServerManager:
         portConflict: "The port {{ port }} is already in use."
+        notInitialized: "The Dev Server Manager must be initialized before it is started."
+        noCompatibleComponents: "Skipping call to {{ serverKey }} because there are no compatible components in the project."
       LocalDevManagerV2:
         failedToInitialize: "Missing required arguments to initialize Local Dev"
+        noComponents: "There are no components in this project."
+        noRunnableComponents: "There are no components in this project that support local development."
         betaMessage: "HubSpot projects local development"
         running: "Running {{#bold}}{{ projectName }}{{/bold}} locally on {{ accountIdentifier }}, waiting for changes ..."
         quitHelper: "Press {{#bold}}'q'{{/bold}} to stop the local dev server"
@@ -859,6 +864,7 @@ en:
         exitingFail: "Failed to cleanup before exiting"
         devServer:
           cleanupError: "Failed to cleanup local dev server: {{ message }}"
+          setupError: "Failed to setup local dev server: {{ message }}"
           startError: "Failed to start local dev server: {{ message }}"
       LocalDevManager:
         failedToInitialize: "Missing required arguments to initialize Local Dev Manager"

--- a/packages/cli/lib/DevServerManager.js
+++ b/packages/cli/lib/DevServerManager.js
@@ -1,28 +1,35 @@
 const express = require('express');
 const bodyParser = require('body-parser');
 const cors = require('cors');
-const { walk } = require('@hubspot/cli-lib/lib/walk');
+const httpClient = require('@hubspot/cli-lib/http');
+const { logger } = require('@hubspot/cli-lib/logger');
 const { getProjectDetailUrl } = require('./projects');
+const { COMPONENT_TYPES } = require('./projectStructure');
 const { i18n } = require('./lang');
 const { EXIT_CODES } = require('./enums/exitCodes');
-const { logger } = require('@hubspot/cli-lib/logger');
+const { promptUser } = require('./prompts/promptUtils');
 
 const i18nKey = 'cli.lib.DevServerManager';
 
 const DEFAULT_PORT = 8080;
-
 class DevServerManager {
   constructor() {
     this.initialized = false;
+    this.started = false;
+    this.componentsByType = {};
     this.server = null;
     this.path = null;
     this.devServers = {};
+    this.debug = false;
   }
 
   safeLoadServer() {
     try {
       const { DevModeInterface } = require('@hubspot/ui-extensions-dev-server');
-      this.devServers['uie'] = DevModeInterface;
+      this.devServers['uie'] = {
+        componentType: COMPONENT_TYPES.app,
+        serverInterface: DevModeInterface,
+      };
     } catch (e) {
       logger.debug('Failed to load dev server interface: ', e);
     }
@@ -33,8 +40,16 @@ class DevServerManager {
 
     for (let i = 0; i < serverKeys.length; i++) {
       const serverKey = serverKeys[i];
-      const serverInterface = this.devServers[serverKey];
-      await callback(serverInterface, serverKey);
+      const devServer = this.devServers[serverKey];
+
+      const compatibleComponents =
+        this.componentsByType[devServer.componentType] || {};
+
+      if (Object.keys(compatibleComponents).length) {
+        await callback(devServer.serverInterface, compatibleComponents);
+      } else {
+        logger.debug(i18n(`${i18nKey}.noCompatibleComponents`, { serverKey }));
+      }
     }
   }
 
@@ -42,66 +57,82 @@ class DevServerManager {
     return this.path ? `${this.path}/${path}` : null;
   }
 
-  async start({
-    accountId,
-    debug,
-    extension,
-    projectConfig,
-    projectSourceDir,
-  }) {
-    const app = express();
+  async setup({ alpha, componentsByType, debug }) {
+    this.debug = debug;
+    this.componentsByType = componentsByType;
 
-    // Install Middleware
-    app.use(bodyParser.json({ limit: '50mb' }));
-    app.use(bodyParser.urlencoded({ limit: '50mb', extended: true }));
-    app.use(cors());
+    this.safeLoadServer();
 
-    // Configure
-    app.set('trust proxy', true);
-
-    // Initialize a base route
-    app.get('/', (req, res) => {
-      res.send('HubSpot local dev server');
-    });
-
-    // Initialize URL redirects
-    app.get('/hs/project', (req, res) => {
-      res.redirect(getProjectDetailUrl(projectConfig.name, accountId));
-    });
-
-    // Start server
-    this.server = await app.listen(DEFAULT_PORT).on('error', err => {
-      if (err.code === 'EADDRINUSE') {
-        logger.error(i18n(`${i18nKey}.portConflict`, { port: DEFAULT_PORT }));
-        logger.log();
-        process.exit(EXIT_CODES.ERROR);
-      }
-    });
-
-    const projectFiles = await walk(projectSourceDir);
-
-    // Initialize component servers
-    await this.iterateDevServers(async serverInterface => {
-      if (serverInterface.start) {
-        await serverInterface.start({
-          accountId,
+    await this.iterateDevServers(async (serverInterface, components) => {
+      if (serverInterface.setup) {
+        await serverInterface.setup({
+          alpha,
+          components,
           debug,
-          extension,
-          projectConfig,
-          projectFiles,
+          promptUser,
         });
       }
     });
 
-    this.path = this.server.address()
-      ? `http://localhost:${this.server.address().port}`
-      : null;
-
     this.initialized = true;
   }
 
-  async cleanup() {
+  async start({ alpha, accountId, projectConfig }) {
     if (this.initialized) {
+      const app = express();
+
+      // Install Middleware
+      app.use(bodyParser.json({ limit: '50mb' }));
+      app.use(bodyParser.urlencoded({ limit: '50mb', extended: true }));
+      app.use(cors());
+
+      // Configure
+      app.set('trust proxy', true);
+
+      // Initialize a base route
+      app.get('/', (req, res) => {
+        res.send('HubSpot local dev server');
+      });
+
+      // Initialize URL redirects
+      app.get('/hs/project', (req, res) => {
+        res.redirect(getProjectDetailUrl(projectConfig.name, accountId));
+      });
+
+      // Start server
+      this.server = await app.listen(DEFAULT_PORT).on('error', err => {
+        if (err.code === 'EADDRINUSE') {
+          logger.error(i18n(`${i18nKey}.portConflict`, { port: DEFAULT_PORT }));
+          logger.log();
+          process.exit(EXIT_CODES.ERROR);
+        }
+      });
+
+      // Initialize component servers
+      await this.iterateDevServers(async serverInterface => {
+        if (serverInterface.start) {
+          await serverInterface.start({
+            alpha,
+            accountId,
+            debug: this.debug,
+            httpClient,
+            projectConfig,
+          });
+        }
+      });
+
+      this.path = this.server.address()
+        ? `http://localhost:${this.server.address().port}`
+        : null;
+    } else {
+      throw new Error(i18n(`${i18nKey}.notInitialized`));
+    }
+
+    this.started = true;
+  }
+
+  async cleanup() {
+    if (this.started) {
       await this.iterateDevServers(async serverInterface => {
         if (serverInterface.cleanup) {
           await serverInterface.cleanup();

--- a/packages/cli/lib/DevServerManager.js
+++ b/packages/cli/lib/DevServerManager.js
@@ -12,6 +12,10 @@ const { promptUser } = require('./prompts/promptUtils');
 const i18nKey = 'cli.lib.DevServerManager';
 
 const DEFAULT_PORT = 8080;
+const SERVER_KEYS = {
+  app: 'app',
+};
+
 class DevServerManager {
   constructor() {
     this.initialized = false;
@@ -26,7 +30,7 @@ class DevServerManager {
   safeLoadServer() {
     try {
       const { DevModeInterface } = require('@hubspot/ui-extensions-dev-server');
-      this.devServers['uie'] = {
+      this.devServers[SERVER_KEYS.app] = {
         componentType: COMPONENT_TYPES.app,
         serverInterface: DevModeInterface,
       };

--- a/packages/cli/lib/LocalDevManager.js
+++ b/packages/cli/lib/LocalDevManager.js
@@ -663,6 +663,9 @@ class LocalDevManager {
 
   async devServerStart() {
     try {
+      // Set this to true manually for now
+      DevServerManager.initialized = true;
+
       await DevServerManager.start({
         accountId: this.targetAccountId,
         debug: this.debug,

--- a/packages/cli/lib/LocalDevManagerV2.js
+++ b/packages/cli/lib/LocalDevManagerV2.js
@@ -73,9 +73,9 @@ class LocalDevManagerV2 {
     }
 
     logger.log();
-    await this.devServerSetup(runnableComponentsByType);
+    const setupSucceeded = await this.devServerSetup(runnableComponentsByType);
 
-    if (!this.debug) {
+    if (setupSucceeded || !this.debug) {
       console.clear();
     }
 
@@ -140,6 +140,7 @@ class LocalDevManagerV2 {
         componentsByType,
         debug: this.debug,
       });
+      return true;
     } catch (e) {
       if (this.debug) {
         logger.error(e);
@@ -147,6 +148,7 @@ class LocalDevManagerV2 {
       logger.error(
         i18n(`${i18nKey}.devServer.setupError`, { message: e.message })
       );
+      return false;
     }
   }
 

--- a/packages/cli/lib/projectStructure.js
+++ b/packages/cli/lib/projectStructure.js
@@ -1,0 +1,92 @@
+const fs = require('fs');
+const path = require('path');
+const { walk } = require('@hubspot/cli-lib/lib/walk');
+const { logger } = require('@hubspot/cli-lib/logger');
+
+const COMPONENT_TYPES = Object.freeze({
+  app: 'app',
+});
+
+const APP_COMPONENT_CONFIG = 'app.json';
+
+function safeLoadConfigFile(configPath) {
+  if (configPath) {
+    try {
+      const source = fs.readFileSync(configPath);
+      const parsedConfig = JSON.parse(source);
+      return parsedConfig;
+    } catch (e) {
+      logger.debug(e);
+    }
+  }
+  return null;
+}
+
+function getIsLegacyApp(appConfig, appPath) {
+  let cards;
+
+  if (appConfig && appConfig.extensions && appConfig.extensions.crm) {
+    cards = appConfig.extensions.crm.cards;
+  }
+
+  if (cards) {
+    let hasAnyReactExtensions = false;
+
+    cards.forEach(({ file }) => {
+      if (!hasAnyReactExtensions) {
+        const cardConfigPath = path.join(appPath, file);
+        const cardConfig = safeLoadConfigFile(cardConfigPath);
+
+        const isReactExtension =
+          cardConfig &&
+          !!cardConfig.data &&
+          !!cardConfig.data.module &&
+          !!cardConfig.data.module.file;
+
+        hasAnyReactExtensions = isReactExtension;
+      }
+    });
+
+    return !hasAnyReactExtensions;
+  }
+
+  // Assume any app that does not have any cards is not legacy
+  return false;
+}
+
+async function findProjectComponents(projectSourceDir) {
+  let componentsByType = {};
+
+  const projectFiles = await walk(projectSourceDir);
+
+  projectFiles.forEach(projectFile => {
+    if (projectFile.endsWith(APP_COMPONENT_CONFIG)) {
+      const parsedAppConfig = safeLoadConfigFile(projectFile);
+
+      if (parsedAppConfig && parsedAppConfig.name) {
+        const appPath = projectFile.substring(
+          0,
+          projectFile.indexOf(APP_COMPONENT_CONFIG)
+        );
+        const isLegacy = getIsLegacyApp(parsedAppConfig, appPath);
+
+        if (!componentsByType[COMPONENT_TYPES.app]) {
+          componentsByType[COMPONENT_TYPES.app] = {};
+        }
+
+        componentsByType[COMPONENT_TYPES.app][parsedAppConfig.name] = {
+          config: parsedAppConfig,
+          runnable: !isLegacy,
+          path: appPath,
+        };
+      }
+    }
+  });
+
+  return componentsByType;
+}
+
+module.exports = {
+  COMPONENT_TYPES,
+  findProjectComponents,
+};

--- a/packages/cli/lib/ui.js
+++ b/packages/cli/lib/ui.js
@@ -6,6 +6,10 @@ const { getAccountConfig } = require('@hubspot/cli-lib/lib/config');
 const { i18n } = require('./lang');
 const { logger } = require('@hubspot/cli-lib/logger');
 
+const UI_COLORS = {
+  orange: '#FF8F59',
+};
+
 /**
  * Outputs horizontal line
  *
@@ -108,7 +112,7 @@ const uiFeatureHighlight = (commands, title) => {
 const uiBetaMessage = message => {
   const i18nKey = 'cli.lib.ui';
 
-  logger.log(chalk.hex('#bda9ea')(i18n(`${i18nKey}.betaTag`)), message);
+  logger.log(chalk.hex(UI_COLORS.orange)(i18n(`${i18nKey}.betaTag`)), message);
 };
 
 const uiBetaWarning = logMessage => {
@@ -120,6 +124,7 @@ const uiBetaWarning = logMessage => {
 };
 
 module.exports = {
+  UI_COLORS,
   uiAccountDescription,
   uiBetaMessage,
   uiBetaWarning,


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
This PR is replacing #889 . This one is backwards compatible with the existing dev mode command behavior.

There are two new hidden options:
- `--local` - runs the local dev server for ui extensions
- `--local-all` - runs the local dev server for ui extensions and app functions

When `--local-all` is specified, we pass `alpha: true` to the `setup` and `start` lifecycle methods for the DevServerManager.

This also adds a new `setup` lifecycle method that the dev servers can use as a opportunity to prompt for any information that they might need to run. It passes down an object that contains useful project structure information. It looks like this:
```js
{
  <app_name>: {
    config: <parsed app config>,
    path: <path to app dir>
  }
}
```

It passes down the [promptUser](https://github.com/HubSpot/hubspot-cli/blob/master/packages/cli/lib/prompts/promptUtils.js#L3) util function that we use in the CLI to prompt the user for input.

As part of this, I also simplified the amount of information that gets passed down to the servers on `start` because they should already have all of that information via the `setup` step.
## Screenshots
<!-- Provide images of the before and after functionality -->

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
