### PR TITLE
Unhide project commands and account for different errors (other half in cli-lib)

### DIFF
--- a/packages/cli/bin/cli.js
+++ b/packages/cli/bin/cli.js
@@ -115,7 +115,7 @@ const argv = yargs
   .option('debug', {
     alias: 'd',
     default: false,
-    describe: 'set log level to debug',
+    describe: 'Set log level to debug',
     type: 'boolean',
   })
   .option('noHyperlinks', {

--- a/packages/cli/commands/project.js
+++ b/packages/cli/commands/project.js
@@ -21,16 +21,16 @@ exports.builder = yargs => {
   addAccountOptions(yargs, true);
 
   // TODO: deploy must be updated
-  yargs.command(deploy).demandCommand(1, '');
   yargs.command(create).demandCommand(0, '');
-  yargs.command(upload).demandCommand(0, '');
+  yargs.command(add).demandCommand(0, '');
   yargs.command(watch).demandCommand(0, '');
-  yargs.command(listBuilds).demandCommand(0, '');
+  yargs.command(dev).demandCommand(0, '');
+  yargs.command(upload).demandCommand(0, '');
+  yargs.command(deploy).demandCommand(1, '');
   yargs.command(logs).demandCommand(1, '');
+  yargs.command(listBuilds).demandCommand(0, '');
   yargs.command(download).demandCommand(0, '');
   yargs.command(open).demandCommand(0, '');
-  yargs.command(dev).demandCommand(0, '');
-  yargs.command(add).demandCommand(0, '');
 
   return yargs;
 };

--- a/packages/cli/commands/project.js
+++ b/packages/cli/commands/project.js
@@ -1,4 +1,5 @@
 const { addConfigOptions, addAccountOptions } = require('../lib/commonOpts');
+const { i18n } = require('../lib/lang');
 const deploy = require('./project/deploy');
 const create = require('./project/create');
 const upload = require('./project/upload');
@@ -10,8 +11,10 @@ const open = require('./project/open');
 const dev = require('./project/dev');
 const add = require('./project/add');
 
+const i18nKey = 'cli.commands.project';
+
 exports.command = 'project';
-exports.describe = false; //'Commands for working with projects';
+exports.describe = i18n(`${i18nKey}.describe`);
 
 exports.builder = yargs => {
   addConfigOptions(yargs, true);

--- a/packages/cli/commands/project/add.js
+++ b/packages/cli/commands/project/add.js
@@ -11,7 +11,7 @@ const { loadAndValidateOptions } = require('../../lib/validation');
 const i18nKey = 'cli.commands.project.subcommands.add';
 
 exports.command = 'add';
-exports.describe = null; //i18n(`${i18nKey}.describe`);
+exports.describe = i18n(`${i18nKey}.describe`);
 
 exports.handler = async options => {
   await loadAndValidateOptions(options);

--- a/packages/cli/commands/project/dev.js
+++ b/packages/cli/commands/project/dev.js
@@ -60,7 +60,7 @@ const {
 const i18nKey = 'cli.commands.project.subcommands.dev';
 
 exports.command = 'dev [--account]';
-exports.describe = null; //i18n(`${i18nKey}.describe`);
+exports.describe = i18n(`${i18nKey}.describe`);
 
 exports.handler = async options => {
   await loadAndValidateOptions(options);

--- a/packages/cli/commands/project/listBuilds.js
+++ b/packages/cli/commands/project/listBuilds.js
@@ -7,6 +7,7 @@ const {
   addUseEnvironmentOptions,
 } = require('../../lib/commonOpts');
 const { trackCommandUsage } = require('../../lib/usageTracking');
+const { i18n } = require('../../lib/lang');
 const {
   logApiErrorInstance,
   ApiErrorContext,
@@ -31,8 +32,10 @@ const {
 const moment = require('moment');
 const { promptUser } = require('../../lib/prompts/promptUtils');
 
+const i18nKey = 'cli.commands.project.subcommands.listBuilds';
+
 exports.command = 'list-builds [path]';
-exports.describe = false;
+exports.describe = i18n(`${i18nKey}.describe`);
 
 exports.handler = async options => {
   await loadAndValidateOptions(options);

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -602,7 +602,7 @@ en:
               dest:
                 describe: "Destination folder for the project"
           open:
-            describe: "Open available projects for the specified account"
+            describe: "Open the specified project's details page in the browser"
             options:
               project:
                 describe: "Name of project to open"

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -444,7 +444,7 @@ en:
             describe: "Shortcut of the link you'd like to open"
         selectLink: "Select a link to open"
       project:
-        describe: "Commands for working with projects"
+        describe: "Commands for working with projects. For more information, visit our documentation: https://developers.hubspot.com/docs/platform/build-and-deploy-using-hubspot-projects"
         subcommands:
           dev:
             describe: "Start local dev for the current project"

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -444,10 +444,10 @@ en:
             describe: "Shortcut of the link you'd like to open"
         selectLink: "Select a link to open"
       project:
-        describe: "Commands for working with projects. For more information, visit our documentation: https://developers.hubspot.com/docs/platform/build-and-deploy-using-hubspot-projects"
+        describe: "{{#bold}}[beta]{{/bold}} Commands for working with projects. For more information, visit our documentation: https://developers.hubspot.com/docs/platform/build-and-deploy-using-hubspot-projects"
         subcommands:
           dev:
-            describe: "Start local dev for the current project"
+            describe: "{{#bold}}[beta]{{/bold}} Start local dev for the current project"
             logs:
               betaMessage: "HubSpot projects local development"
               nonSandboxWarning: "Testing in a sandbox is strongly recommended. To switch the target account, select an option below or run {{#bold}}`hs accounts use`{{/bold}} before running the command again."
@@ -472,7 +472,7 @@ en:
             examples:
               default: "Start local dev for the current project"
           create:
-            describe: "Create a new project"
+            describe: "{{#bold}}[beta]{{/bold}} Create a new project"
             logs:
               welcomeMessage: "Welcome to HubSpot Developer Projects!"
             examples:
@@ -487,7 +487,7 @@ en:
               templateSource:
                 describe: "Path to custom GitHub repository from which to create project template"
           add:
-            describe: "Create a new component within a project"
+            describe: "{{#bold}}[beta]{{/bold}} Create a new component within a project"
             options:
               name:
                 describe: "Component name"
@@ -502,7 +502,7 @@ en:
             examples:
               default: "Create a component within your project"
           deploy:
-            describe: "Deploy a project build"
+            describe: "{{#bold}}[beta]{{/bold}} Deploy a project build"
             debug:
               deploying: "Deploying project at path: {{ path }}"
             errors:
@@ -518,9 +518,9 @@ en:
               project:
                 describe: "Project name"
           listBuilds:
-            describe: "List the project's builds"
+            describe: "{{#bold}}[beta]{{/bold}} List the project's builds"
           logs:
-            describe: "Get execution logs for a serverless function within a project"
+            describe: "{{#bold}}[beta]{{/bold}} Get execution logs for a serverless function within a project"
             errors:
               invalidAppName: "Could not find app with name \"{{ appName }}\" in project \"{{ projectName }}\""
             logs:
@@ -555,7 +555,7 @@ en:
               endpoint:
                 describe: "Public endpoint path"
           upload:
-            describe: "Upload your project files and create a new build"
+            describe: "{{#bold}}[beta]{{/bold}} Upload your project files and create a new build"
             examples:
               default: "Upload a project"
             logs:
@@ -573,7 +573,7 @@ en:
               path:
                 describe: "Path to a project folder"
           watch:
-            describe: "Watch your local project for changes and automatically upload changed files to a new build in HubSpot"
+            describe: "{{#bold}}[beta]{{/bold}} Watch your local project for changes and automatically upload changed files to a new build in HubSpot"
             examples:
               default: "Watch a project within the myProjectFolder folder"
             logs:
@@ -585,7 +585,7 @@ en:
               initialUpload:
                 describe: "Upload directory before watching for updates"
           download:
-            describe: "Download your project files from HubSpot and write to a path on your computer"
+            describe: "{{#bold}}[beta]{{/bold}} Download your project files from HubSpot and write to a path on your computer"
             examples:
               default: "Download the project myProject into myProjectFolder folder"
             logs:
@@ -602,7 +602,7 @@ en:
               dest:
                 describe: "Destination folder for the project"
           open:
-            describe: "Open the specified project's details page in the browser"
+            describe: "{{#bold}}[beta]{{/bold}} Open the specified project's details page in the browser"
             options:
               project:
                 describe: "Name of project to open"

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -444,6 +444,7 @@ en:
             describe: "Shortcut of the link you'd like to open"
         selectLink: "Select a link to open"
       project:
+        describe: "Commands for working with projects"
         subcommands:
           dev:
             describe: "Start local dev for the current project"
@@ -516,6 +517,8 @@ en:
                 describe: "Project build ID to be deployed"
               project:
                 describe: "Project name"
+          listBuilds:
+            describe: "List the project's builds"
           logs:
             describe: "Get execution logs for a serverless function within a project"
             errors:

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/HubSpot/hubspot-cms-tools"
   },
   "dependencies": {
-    "@hubspot/cli-lib": "^4.1.14",
+    "@hubspot/cli-lib": "^4.2.1",
     "@hubspot/serverless-dev-runtime": "4.1.8-beta.6",
     "@hubspot/ui-extensions-dev-server": "^0.4.0",
     "archiver": "^5.3.0",

--- a/packages/serverless-dev-runtime/package.json
+++ b/packages/serverless-dev-runtime/package.json
@@ -6,7 +6,7 @@
   "repository": "https://github.com/HubSpot/hubspot-cli",
   "license": "Apache-2.0",
   "dependencies": {
-    "@hubspot/cli-lib": "^4.1.14",
+    "@hubspot/cli-lib": "^4.2.1",
     "body-parser": "^1.19.0",
     "chalk": "^4.1.0",
     "chokidar": "^3.4.3",

--- a/packages/webpack-cms-plugins/package.json
+++ b/packages/webpack-cms-plugins/package.json
@@ -17,7 +17,7 @@
     "test": "echo \"Error: run tests from root\" && exit 1"
   },
   "dependencies": {
-    "@hubspot/cli-lib": "^4.1.14"
+    "@hubspot/cli-lib": "^4.2.1"
   },
   "gitHead": "0659fd19cabc3645af431b177c11d0c1b089e0f8"
 }


### PR DESCRIPTION
## Description and Context
Since Developer Projects is now in public beta, we can unhide project commands, give them descriptions, and link to our documentation. 

In this PR, I've unhidden and added descriptions for certain project commands. I've also added some better handling for gating errors, and I'm seeking feedback about downgrading errors. 

In order to fully test out the error handling for gating, you will need to check out [the appropriate branch](https://github.com/HubSpot/cli-lib/pull/17) in the cli-lib repo and then use the yarn link @hubspot/cli-lib command to use the symlinked local package. [Docs](https://github.com/HubSpot/hubspot-cli/blob/master/CONTRIBUTING.md#local-development-with-cli-lib) for more details.

## Screenshots
<!-- Provide images of the before and after functionality -->

New project commands help menu (revised and with beta tags):

<img width="2405" alt="Screenshot 2023-07-25 at 2 01 47 PM" src="https://github.com/HubSpot/hubspot-cli/assets/25392256/fd38a915-d6fb-49c6-b4aa-4d08f627be20">

New error message when there's a gating error (revised):

<img width="2557" alt="Screenshot 2023-07-24 at 6 07 26 PM" src="https://github.com/HubSpot/hubspot-cli/assets/25392256/010a91db-3c8f-4f77-9a81-4b71808c8a18">

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

- [x] Address any feedback from Mark. 
- [x] Add handling for downgrading errors if necessary (not necessary at the moment).

@markhazlewood, thanks for your feedback! 

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@markhazlewood @brandenrodgers @camden11 
