### PR TITLE
Invalid portal error handling for `hs project dev`

### DIFF
--- a/packages/cli/commands/sandbox/delete.js
+++ b/packages/cli/commands/sandbox/delete.js
@@ -28,8 +28,8 @@ const { promptUser } = require('../../lib/prompts/promptUtils');
 const { getHubSpotWebsiteOrigin } = require('@hubspot/cli-lib/lib/urls');
 const {
   isSpecifiedError,
+  isSpecifiedHubSpotAuthError,
 } = require('@hubspot/cli-lib/errorHandlers/apiErrors');
-const { HubSpotAuthError } = require('@hubspot/cli-lib/lib/models/Errors');
 const { getAccountName } = require('../../lib/sandboxes');
 const { getValidEnv } = require('@hubspot/cli-lib/lib/environment');
 
@@ -168,7 +168,7 @@ exports.handler = async options => {
   } catch (err) {
     debugErrorAndContext(err);
 
-    if (err instanceof HubSpotAuthError && err.statusCode === 401) {
+    if (isSpecifiedHubSpotAuthError(err, { statusCode: 401 })) {
       // Intercept invalid key error
       // This command uses the parent portal PAK to delete a sandbox, so we must specify which account needs a new key
       logger.log('');

--- a/packages/cli/lib/projects.js
+++ b/packages/cli/lib/projects.js
@@ -44,6 +44,7 @@ const SpinniesManager = require('./SpinniesManager');
 const {
   isSpecifiedError,
 } = require('@hubspot/cli-lib/errorHandlers/apiErrors');
+const { HubSpotAuthError } = require('@hubspot/cli-lib/lib/models/Errors');
 
 const i18nKey = 'cli.lib.projects';
 
@@ -279,6 +280,10 @@ const ensureProjectExists = async (
         }
         return false;
       }
+    }
+    if (err.statusCode === 401 && err instanceof HubSpotAuthError) {
+      logger.error(err.message);
+      process.exit(EXIT_CODES.ERROR);
     }
     logApiErrorInstance(err, new ApiErrorContext({ accountId, projectName }));
     process.exit(EXIT_CODES.ERROR);

--- a/packages/cli/lib/projects.js
+++ b/packages/cli/lib/projects.js
@@ -43,8 +43,8 @@ const { i18n } = require('./lang');
 const SpinniesManager = require('./SpinniesManager');
 const {
   isSpecifiedError,
+  isSpecifiedHubSpotAuthError,
 } = require('@hubspot/cli-lib/errorHandlers/apiErrors');
-const { HubSpotAuthError } = require('@hubspot/cli-lib/lib/models/Errors');
 
 const i18nKey = 'cli.lib.projects';
 
@@ -281,7 +281,11 @@ const ensureProjectExists = async (
         return false;
       }
     }
-    if (err.statusCode === 401 && err instanceof HubSpotAuthError) {
+    if (
+      isSpecifiedHubSpotAuthError(err, {
+        statusCode: 401,
+      })
+    ) {
       logger.error(err.message);
       process.exit(EXIT_CODES.ERROR);
     }


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->

With new errors being thrown for invalid portals and unauthorized users (https://git.hubteam.com/HubSpotProtected/LocalDevAuth/pull/138), this PR serves to update error handling for the `ensureProjectExists` function and display more detailed messaging. 

Note: if your default account is set to a sandbox, the error will get caught and thrown in the `loadAndValidateOptions` check at the top of the command. If the default account is not a sandbox, it will show a list of sandboxes but it will not perform the same validation on selection which could result in selecting a deleted portal or one that the user is unauthorized for. 

## Screenshots
<!-- Provide images of the before and after functionality -->
Before: 
<img width="1220" alt="Screenshot 2023-07-27 at 14 39 49" src="https://github.com/HubSpot/hubspot-cli/assets/16788677/139d3383-46d8-4dfd-a501-4e2e8c1eb0f5">

After:

Inactive account:
<img width="1202" alt="Screenshot 2023-07-27 at 14 33 01" src="https://github.com/HubSpot/hubspot-cli/assets/16788677/e0edd194-6f49-48bd-8b06-64d79b64f26f">

Unauthorized user/invalid PAK:
<img width="1259" alt="Screenshot 2023-07-27 at 14 33 06" src="https://github.com/HubSpot/hubspot-cli/assets/16788677/c53faca9-fef6-4830-9a0f-8614d1af1e5d">


## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

n/a

## Who to Notify
<!-- /cc those you wish to know about the PR -->
