### PR TITLE
Add build + deploy IDs while polling in dev mode

### DIFF
--- a/packages/cli/lib/projects.js
+++ b/packages/cli/lib/projects.js
@@ -610,7 +610,7 @@ const makePollTaskStatusFunc = ({
     SpinniesManager.update(overallTaskSpinniesKey, {
       text: `${statusStrings.INITIALIZE(
         taskName,
-        taskId
+        displayId
       )}\n${componentCountText}`,
     });
 
@@ -691,11 +691,11 @@ const makePollTaskStatusFunc = ({
           if (isTaskComplete(taskStatus)) {
             if (status === statusText.STATES.SUCCESS) {
               SpinniesManager.succeed(overallTaskSpinniesKey, {
-                text: statusStrings.SUCCESS(taskName, taskId),
+                text: statusStrings.SUCCESS(taskName, displayId),
               });
             } else if (status === statusText.STATES.FAILURE) {
               SpinniesManager.fail(overallTaskSpinniesKey, {
-                text: statusStrings.FAIL(taskName, taskId),
+                text: statusStrings.FAIL(taskName, displayId),
               });
 
               if (!silenceLogs) {
@@ -752,12 +752,9 @@ const pollBuildStatus = makePollTaskStatusFunc({
   structureFn: getBuildStructure,
   statusText: PROJECT_BUILD_TEXT,
   statusStrings: {
-    INITIALIZE: (name, buildId) =>
-      `Building build #${buildId} in ${chalk.bold(name)}`,
-    SUCCESS: (name, buildId) =>
-      `Built build #${buildId} in ${chalk.bold(name)}`,
-    FAIL: (name, buildId) =>
-      `Failed to build #${buildId} in ${chalk.bold(name)}`,
+    INITIALIZE: (name, buildId) => `Building ${chalk.bold(name)} #${buildId}`,
+    SUCCESS: (name, buildId) => `Built ${chalk.bold(name)} #${buildId}`,
+    FAIL: (name, buildId) => `Failed to build ${chalk.bold(name)} #${buildId}`,
     SUBTASK_FAIL: (buildId, name) =>
       `Build #${buildId} failed because there was a problem\nbuilding ${chalk.bold(
         name

--- a/packages/cli/lib/projects.js
+++ b/packages/cli/lib/projects.js
@@ -608,7 +608,10 @@ const makePollTaskStatusFunc = ({
         ) + '\n';
 
     SpinniesManager.update(overallTaskSpinniesKey, {
-      text: `${statusStrings.INITIALIZE(taskName)}\n${componentCountText}`,
+      text: `${statusStrings.INITIALIZE(
+        taskName,
+        taskId
+      )}\n${componentCountText}`,
     });
 
     if (!silenceLogs) {
@@ -688,11 +691,11 @@ const makePollTaskStatusFunc = ({
           if (isTaskComplete(taskStatus)) {
             if (status === statusText.STATES.SUCCESS) {
               SpinniesManager.succeed(overallTaskSpinniesKey, {
-                text: statusStrings.SUCCESS(taskName),
+                text: statusStrings.SUCCESS(taskName, taskId),
               });
             } else if (status === statusText.STATES.FAILURE) {
               SpinniesManager.fail(overallTaskSpinniesKey, {
-                text: statusStrings.FAIL(taskName),
+                text: statusStrings.FAIL(taskName, taskId),
               });
 
               if (!silenceLogs) {
@@ -749,9 +752,12 @@ const pollBuildStatus = makePollTaskStatusFunc({
   structureFn: getBuildStructure,
   statusText: PROJECT_BUILD_TEXT,
   statusStrings: {
-    INITIALIZE: name => `Building ${chalk.bold(name)}`,
-    SUCCESS: name => `Built ${chalk.bold(name)}`,
-    FAIL: name => `Failed to build ${chalk.bold(name)}`,
+    INITIALIZE: (name, buildId) =>
+      `Building build #${buildId} in ${chalk.bold(name)}`,
+    SUCCESS: (name, buildId) =>
+      `Built build #${buildId} in ${chalk.bold(name)}`,
+    FAIL: (name, buildId) =>
+      `Failed to build #${buildId} in ${chalk.bold(name)}`,
     SUBTASK_FAIL: (buildId, name) =>
       `Build #${buildId} failed because there was a problem\nbuilding ${chalk.bold(
         name
@@ -769,9 +775,12 @@ const pollDeployStatus = makePollTaskStatusFunc({
   structureFn: getDeployStructure,
   statusText: PROJECT_DEPLOY_TEXT,
   statusStrings: {
-    INITIALIZE: name => `Deploying ${chalk.bold(name)}`,
-    SUCCESS: name => `Deployed ${chalk.bold(name)}`,
-    FAIL: name => `Failed to deploy ${chalk.bold(name)}`,
+    INITIALIZE: (name, buildId) =>
+      `Deploying build #${buildId} in ${chalk.bold(name)}`,
+    SUCCESS: (name, buildId) =>
+      `Deployed build #${buildId} in ${chalk.bold(name)}`,
+    FAIL: (name, buildId) =>
+      `Failed to deploy build #${buildId} in ${chalk.bold(name)}`,
     SUBTASK_FAIL: (deployedBuildId, name) =>
       `Deploy for build #${deployedBuildId} failed because there was a\nproblem deploying ${chalk.bold(
         name


### PR DESCRIPTION
## Description and Context
In Dev mode, we currently show `Building <project name>` and `Deploying <project name>` (see screenshot), but we do not include the build and deploy numbers. This PR adds the build numbers while polling. @brandenrodgers, our general pattern has been to write `Deploy build #` rather than giving a deploy number. I've followed that pattern, but let me know if that's not correct. 

## Screenshots
<!-- Provide images of the before and after functionality -->
Before

![8e02e94b-3f8a-4792-99ea-64a6ce4284fb](https://github.com/HubSpot/hubspot-cli/assets/25392256/f6b56273-9afe-46fc-9f2b-f489fb9f1816)

After

<img width="1959" alt="Screenshot 2023-07-31 at 10 43 07 AM" src="https://github.com/HubSpot/hubspot-cli/assets/25392256/b0dac8a6-e00d-4a28-b907-9a831e869dac">

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

- [x] Get feedback on copy from @markhazlewood 
- [x] Clarify with @brandenrodgers about deploy vs build IDs (see question above). 

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@brandenrodgers @camden11 @markhazlewood 
