### PR TITLE
Replace ! with emoji in local dev prod warning message

### DIFF
--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -1011,7 +1011,7 @@ en:
       prompts:
         projectDevTargetAccountPrompt:
           createNewSandboxOption: "<Test on a new development sandbox>"
-          chooseDefaultAccountOption: "<{{#bold}}!{{/bold}} Test on this production account {{#bold}}!{{/bold}}>"
+          chooseDefaultAccountOption: "<{{#bold}}\U00002757{{/bold}} Test on this production account {{#bold}}\U00002757{{/bold}}>"
           promptMessage: "[--account] Choose a sandbox under {{ accountIdentifier }} to test with:"
           sandboxLimit: "You’ve reached the limit of {{ limit }} development sandboxes"
         projectLogsPrompt:


### PR DESCRIPTION
## Description and Context
See https://git.hubteam.com/HubSpot/hubspot-cli-issues/issues/432
This replaces the `!` in the local dev prod warning message with the❗ emoji. 

Did a little research into whether its safe to use emojis on the CLI without a fallback. It seems like actually checking emoji support is non-trivial but they should be supported in the vast majority of cases so this should be fine

## Screenshots
<img width="741" alt="Screenshot 2023-07-31 at 11 58 41 AM" src="https://github.com/HubSpot/hubspot-cli/assets/10413161/c92e23ac-eff1-4765-943b-f22f754505eb">

## Who to Notify
@brandenrodgers @kemmerle @markhazlewood 
