### PR TITLE
default sandbox confirmation prompt

### DIFF
--- a/packages/cli/commands/project/dev.js
+++ b/packages/cli/commands/project/dev.js
@@ -27,6 +27,7 @@ const { uiAccountDescription, uiBetaMessage, uiLine } = require('../../lib/ui');
 const { confirmPrompt } = require('../../lib/prompts/promptUtils');
 const {
   selectTargetAccountPrompt,
+  confirmDefaultSandboxAccountPrompt,
 } = require('../../lib/prompts/projectDevTargetAccountPrompt');
 const SpinniesManager = require('../../lib/SpinniesManager');
 const LocalDevManager = require('../../lib/LocalDevManager');
@@ -88,7 +89,14 @@ exports.handler = async options => {
   const defaultAccountIsSandbox = isSandbox(accountConfig);
 
   if (!targetAccountId && defaultAccountIsSandbox) {
-    targetAccountId = accountId;
+    const useDefaultSandboxAccount = await confirmDefaultSandboxAccountPrompt(
+      accountConfig.name,
+      accountConfig.sandboxAccountType
+    );
+
+    if (useDefaultSandboxAccount) {
+      targetAccountId = accountId;
+    }
   }
 
   if (!targetAccountId) {

--- a/packages/cli/commands/project/dev.js
+++ b/packages/cli/commands/project/dev.js
@@ -96,6 +96,9 @@ exports.handler = async options => {
 
     if (useDefaultSandboxAccount) {
       targetAccountId = accountId;
+    } else {
+      logger.log(i18n(`${i18nKey}.logs.declineDefaultSandboxExplanation`));
+      process.exit(EXIT_CODES.SUCCESS);
     }
   }
 

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -455,6 +455,7 @@ en:
               projectMustExistExplanation: "The project {{ projectName }} does not exist in the target account {{ accountIdentifier}}. This command requires the project to exist in the target account."
               choseNotToCreateProject: "Exiting because this command requires the project to exist in the target account."
               initialUploadMessage: "HubSpot Local Dev Server Startup"
+              declineDefaultSandboxExplanation: "To develop on a different account, run {{#bold}}`hs accounts use`{{/bold}} to change your default account, then re-run {{#bold}}`hs project dev`{{/bold}}."
             status:
               creatingProject: "Creating project {{ projectName }} in {{ accountIdentifier }}"
               createdProject: "Created project {{ projectName }} in {{ accountIdentifier }}"

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -971,6 +971,7 @@ en:
           chooseDefaultAccountOption: "<{{#bold}}\U00002757{{/bold}} Test on this production account {{#bold}}\U00002757{{/bold}}>"
           promptMessage: "[--account] Choose a sandbox under {{ accountIdentifier }} to test with:"
           sandboxLimit: "You’ve reached the limit of {{ limit }} development sandboxes"
+          confirmDefaultSandboxAccount: "Continue testing on {{#bold}}{{ accountName }} ({{ accountType }}){{/bold}}? (Y/n)"
         projectLogsPrompt:
           projectName:
             message: "[--project] Enter the project name:"

--- a/packages/cli/lib/prompts/projectDevTargetAccountPrompt.js
+++ b/packages/cli/lib/prompts/projectDevTargetAccountPrompt.js
@@ -74,6 +74,21 @@ const selectTargetAccountPrompt = async (accounts, defaultAccountConfig) => {
   return targetAccountInfo;
 };
 
+const confirmDefaultSandboxAccountPrompt = async (accountName, accountType) => {
+  const { useDefaultAccount } = await promptUser([
+    {
+      name: 'useDefaultAccount',
+      type: 'confirm',
+      message: i18n(`${i18nKey}.confirmDefaultSandboxAccount`, {
+        accountName,
+        accountType,
+      }),
+    },
+  ]);
+  return useDefaultAccount;
+};
+
 module.exports = {
   selectTargetAccountPrompt,
+  confirmDefaultSandboxAccountPrompt,
 };


### PR DESCRIPTION
## Description and Context
See https://git.hubteam.com/HubSpot/hubspot-cli-issues/issues/431

This adds a prompt for users to confirm using their default account for local dev when their default account is a sandbox. Previously, having a sandbox as your default account would skip the account prompt entirely.

## Screenshots
<img width="741" alt="Screenshot 2023-07-31 at 4 17 10 PM" src="https://github.com/HubSpot/hubspot-cli/assets/10413161/7eb86a1b-5821-4121-b86e-949e51675607">

## Who to Notify
@brandenrodgers @kemmerle @markhazlewood 
