### PR TITLE
Filter out skipping errors when build upload fails

### DIFF
--- a/packages/cli/lib/projects.js
+++ b/packages/cli/lib/projects.js
@@ -712,7 +712,13 @@ const makePollTaskStatusFunc = ({
                 logger.log('See below for a summary of errors.');
                 uiLine();
 
-                failedSubtasks.forEach(subTask => {
+                const displayErrors = failedSubtasks.filter(
+                  subtask =>
+                    subtask.standardError.subCategory !==
+                    'BuildPipelineErrorType.DEPENDENT_SUBBUILD_FAILED'
+                );
+
+                displayErrors.forEach(subTask => {
                   logger.log(
                     `\n--- ${chalk.bold(
                       subTask[statusText.SUBTASK_NAME_KEY]


### PR DESCRIPTION
## Description and Context
We've been testing out error messaging for projects to ensure that all our errors are user friendly. In the scenario where the customer downgrades (ie. a portal that's ungated to the beta but doesn't have the correct product tiers), we receive the following error:

<img width="2557" alt="Screenshot 2023-07-21 at 2 23 39 PM" src="https://github.com/HubSpot/hubspot-cli/assets/25392256/d8171973-f05c-4ca2-b4d7-732490ce69dd">

The truly pertinent error--that the customer does not have access to serverless functions--is buried underneath multiple other errors.

In this PR, I've filtered out errors where we've skipped over building components. Their subcategory is `BuildPipelineErrorType.DEPENDENT_SUBBUILD_FAILED`. 

## Screenshots
<!-- Provide images of the before and after functionality -->

With these changes:

<img width="1728" alt="Screenshot 2023-08-01 at 2 03 30 PM" src="https://github.com/HubSpot/hubspot-cli/assets/25392256/b7a07dcf-77fe-4dc4-8b9f-57dcc0c6cbe0">

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

- [x] Get feedback on whether we'd like to filter out skipping errors entirely or perhaps sort them to the bottom of the list. @brandenrodgers @markhazlewood 

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@brandenrodgers @camden11 @markhazlewood 
