### PR TITLE
Refactor `hs project download` (Other half in cli-lib)

### DIFF
--- a/packages/cli/commands/project/download.js
+++ b/packages/cli/commands/project/download.js
@@ -17,10 +17,7 @@ const {
   downloadProject,
   fetchProjectBuilds,
 } = require('@hubspot/cli-lib/api/dfs');
-const {
-  createProjectConfig,
-  ensureProjectExists,
-} = require('../../lib/projects');
+const { ensureProjectExists } = require('../../lib/projects');
 const { loadAndValidateOptions } = require('../../lib/validation');
 const {
   downloadProjectPrompt,
@@ -63,17 +60,6 @@ exports.handler = async options => {
 
     const absoluteDestPath = dest ? path.resolve(getCwd(), dest) : getCwd();
 
-    const projectConfigCreated = await createProjectConfig(
-      absoluteDestPath,
-      projectName,
-      { name: 'no-template' }
-    );
-
-    if (!projectConfigCreated) {
-      logger.log(i18n(`${i18nKey}.logs.downloadCancelled`));
-      process.exit(EXIT_CODES.SUCCESS);
-    }
-
     let buildNumberToDownload = buildNumber;
 
     if (!buildNumberToDownload) {
@@ -98,10 +84,8 @@ exports.handler = async options => {
     await extractZipArchive(
       zippedProject,
       projectName,
-      path.resolve(absoluteDestPath, 'src'),
-      {
-        includesRootDir: false,
-      }
+      path.resolve(absoluteDestPath),
+      { includesRootDir: false }
     );
 
     logger.log(

--- a/packages/cli/commands/project/download.js
+++ b/packages/cli/commands/project/download.js
@@ -36,8 +36,8 @@ exports.handler = async options => {
   const { projectConfig } = await getProjectConfig();
 
   if (projectConfig) {
-    logger.warn(i18n(`${i18nKey}.warnings.cannotDownloadWithinProject`));
-    process.exit(EXIT_CODES.WARNING);
+    logger.error(i18n(`${i18nKey}.warnings.cannotDownloadWithinProject`));
+    process.exit(EXIT_CODES.ERROR);
   }
 
   const { project, dest, buildNumber } = options;

--- a/packages/cli/commands/project/download.js
+++ b/packages/cli/commands/project/download.js
@@ -34,10 +34,11 @@ exports.handler = async options => {
   await loadAndValidateOptions(options);
 
   const { projectConfig } = await getProjectConfig();
-  const platformVersion =
-    projectConfig && projectConfig.platformVersion
-      ? projectConfig.platformVersion
-      : '';
+
+  if (projectConfig) {
+    logger.warn(i18n(`${i18nKey}.warnings.cannotDownloadWithinProject`));
+    process.exit(EXIT_CODES.WARNING);
+  }
 
   const { project, dest, buildNumber } = options;
   let { project: promptedProjectName } = await downloadProjectPrompt(options);
@@ -84,8 +85,7 @@ exports.handler = async options => {
     const zippedProject = await downloadProject(
       accountId,
       projectName,
-      buildNumberToDownload,
-      platformVersion
+      buildNumberToDownload
     );
 
     await extractZipArchive(

--- a/packages/cli/commands/project/download.js
+++ b/packages/cli/commands/project/download.js
@@ -17,7 +17,7 @@ const {
   downloadProject,
   fetchProjectBuilds,
 } = require('@hubspot/cli-lib/api/dfs');
-const { ensureProjectExists } = require('../../lib/projects');
+const { ensureProjectExists, getProjectConfig } = require('../../lib/projects');
 const { loadAndValidateOptions } = require('../../lib/validation');
 const {
   downloadProjectPrompt,
@@ -32,6 +32,12 @@ exports.describe = i18n(`${i18nKey}.describe`);
 
 exports.handler = async options => {
   await loadAndValidateOptions(options);
+
+  const { projectConfig } = await getProjectConfig();
+  const platformVersion =
+    projectConfig && projectConfig.platformVersion
+      ? projectConfig.platformVersion
+      : '';
 
   const { project, dest, buildNumber } = options;
   let { project: promptedProjectName } = await downloadProjectPrompt(options);
@@ -78,7 +84,8 @@ exports.handler = async options => {
     const zippedProject = await downloadProject(
       accountId,
       projectName,
-      buildNumberToDownload
+      buildNumberToDownload,
+      platformVersion
     );
 
     await extractZipArchive(

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -589,6 +589,8 @@ en:
             errors:
               downloadFailed: "Something went wrong downloading the project"
               projectNotFound: "Your project {{ projectName }} could not be found in {{ accountId }}"
+            warnings:
+              cannotDownloadWithinProject: "Cancelling project download. Please run the command again outside the context of an existing project."
             options:
               buildNumber:
                 describe: "The build number to download"

--- a/packages/cli/lib/prompts/downloadProjectPrompt.js
+++ b/packages/cli/lib/prompts/downloadProjectPrompt.js
@@ -5,7 +5,6 @@ const {
   logApiErrorInstance,
   ApiErrorContext,
 } = require('@hubspot/cli-lib/errorHandlers');
-const { getProjectConfig } = require('../projects');
 const { EXIT_CODES } = require('../enums/exitCodes');
 const { i18n } = require('../lang');
 
@@ -13,14 +12,12 @@ const i18nKey = 'cli.lib.prompts.downloadProjectPrompt';
 
 const createProjectsList = async () => {
   const accountId = getAccountId();
-  const { projectConfig } = await getProjectConfig();
-  const projectName = projectConfig.name;
 
   try {
     const projects = await fetchProjects(accountId);
     return projects.results;
   } catch (e) {
-    logApiErrorInstance(e, new ApiErrorContext({ accountId, projectName }));
+    logApiErrorInstance(e, new ApiErrorContext({ accountId }));
     process.exit(EXIT_CODES.ERROR);
   }
 };

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/HubSpot/hubspot-cms-tools"
   },
   "dependencies": {
-    "@hubspot/cli-lib": "^4.2.1",
+    "@hubspot/cli-lib": "^4.2.2",
     "@hubspot/serverless-dev-runtime": "4.2.1-beta.2",
     "@hubspot/ui-extensions-dev-server": "^0.5.0",
     "archiver": "^5.3.0",

--- a/packages/serverless-dev-runtime/package.json
+++ b/packages/serverless-dev-runtime/package.json
@@ -6,7 +6,7 @@
   "repository": "https://github.com/HubSpot/hubspot-cli",
   "license": "Apache-2.0",
   "dependencies": {
-    "@hubspot/cli-lib": "^4.2.1",
+    "@hubspot/cli-lib": "^4.2.2",
     "body-parser": "^1.19.0",
     "chalk": "^4.1.0",
     "chokidar": "^3.4.3",

--- a/packages/webpack-cms-plugins/package.json
+++ b/packages/webpack-cms-plugins/package.json
@@ -17,7 +17,7 @@
     "test": "echo \"Error: run tests from root\" && exit 1"
   },
   "dependencies": {
-    "@hubspot/cli-lib": "^4.2.1"
+    "@hubspot/cli-lib": "^4.2.2"
   },
   "gitHead": "0659fd19cabc3645af431b177c11d0c1b089e0f8"
 }


### PR DESCRIPTION
## Description and Context
1) Currently, there is a bug in the `hs project download` command, in which the command will not run outside a project directory. I was able to fix this issue by eliminating an unnecessary call to get a project config. 

2) I also refactored the download command to use a different download endpoint (`/archive-full`) that downloads the `src` of the project folder and the `hsproject.json`  (see the other part of this work in the [cli-lib PR](https://github.com/HubSpot/cli-lib/pull/23)).

To test out this PR, you will need to check out the [above branch](https://github.com/HubSpot/cli-lib/pull/23) in the cli-lib repo and then use the yarn link @hubspot/cli-lib command to use the symlinked local package. [Docs](https://github.com/HubSpot/hubspot-cli/blob/master/CONTRIBUTING.md#local-development-with-cli-lib) for more details.

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@brandenrodgers @camden11 
