### PR TITLE
Fix polling hang when gated

### DIFF
--- a/packages/cli/commands/project/dev.js
+++ b/packages/cli/commands/project/dev.js
@@ -176,7 +176,7 @@ exports.handler = async options => {
     {
       allowCreate: false,
       noLogs: true,
-      withPolling: true,
+      withPolling: createNewSandbox,
     }
   );
 

--- a/packages/cli/lib/projects.js
+++ b/packages/cli/lib/projects.js
@@ -202,14 +202,10 @@ const pollFetchProject = async (accountId, projectName) => {
             statusCode: 403,
             category: 'GATED',
             subCategory: 'BuildPipelineErrorType.PORTAL_GATED',
-          })
+          }) &&
+          pollCount < 15
         ) {
           pollCount += 1;
-        } else if (pollCount >= 15) {
-          // Poll up to max 30s
-          SpinniesManager.remove('pollFetchProject');
-          clearInterval(pollInterval);
-          reject(err);
         } else {
           SpinniesManager.remove('pollFetchProject');
           clearInterval(pollInterval);


### PR DESCRIPTION
## Description and Context
See https://git.hubteam.com/HubSpot/hubspot-cli-issues/issues/434
When users who haven't been ungated for projects run `hs project dev`, they'll get stuck as `ensureProjectExists` polls indefinitely. This was due to a bug in `pollFetchProject`. For good measure, I also made it only poll when it needs to, i.e. when you've created a new sandbox.

## Who to Notify
@brandenrodgers @kemmerle 
