### PR TITLE
Fix bug in template option for project create

### DIFF
--- a/packages/cli/commands/project/create.js
+++ b/packages/cli/commands/project/create.js
@@ -38,7 +38,7 @@ exports.handler = async options => {
   await createProjectConfig(
     path.resolve(getCwd(), options.location || location),
     options.name || name,
-    options.template || template,
+    template || { path: options.template },
     options.templateSource
   );
 


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
The `createProjectConfig` method expects the template argument to be an object that contains `path`

## Screenshots
<!-- Provide images of the before and after functionality -->

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
