### PR TITLE
exit if setup fails

### DIFF
--- a/packages/cli/lib/LocalDevManager.js
+++ b/packages/cli/lib/LocalDevManager.js
@@ -96,7 +96,9 @@ class LocalDevManager {
     logger.log();
     const setupSucceeded = await this.devServerSetup(runnableComponents);
 
-    if (setupSucceeded || !this.debug) {
+    if (!setupSucceeded) {
+      process.exit(EXIT_CODES.ERROR);
+    } else if (!this.debug) {
       console.clear();
     }
 


### PR DESCRIPTION
## Description and Context
Noticed a bug where referring to card json files that don't exist triggered the following error message, which wasn't very helpful. This is because the actual errors were being caught, logged, and immediately cleared from the console. Since `DevServerManager.start()` will always fail if setup didn't succeed, I _think_ we'll always want to just terminate the command if setup fails. This makes that change + skips the console clear so the real errors are visible

## Screenshots
Before
<img width="568" alt="Screenshot 2023-08-08 at 1 57 04 PM" src="https://github.com/HubSpot/hubspot-cli/assets/10413161/94d88a73-aa8a-4951-ad74-0b075f8756ad">

After
<img width="564" alt="Screenshot 2023-08-08 at 1 57 32 PM" src="https://github.com/HubSpot/hubspot-cli/assets/10413161/4c4e03e9-a003-4be4-9b9d-2686d00add12">

## Who to Notify
@brandenrodgers @kemmerle 
