### PR TITLE
`hs project dev` account picker only shows sandboxes for default account

### DIFF
--- a/packages/cli/lib/prompts/projectDevTargetAccountPrompt.js
+++ b/packages/cli/lib/prompts/projectDevTargetAccountPrompt.js
@@ -26,7 +26,11 @@ const selectTargetAccountPrompt = async (accounts, defaultAccountConfig) => {
     logger.debug('Unable to fetch sandbox usage limits: ', err);
   }
 
-  const sandboxAccounts = accounts.reverse().filter(isSandbox);
+  const sandboxAccounts = accounts
+    .reverse()
+    .filter(
+      config => isSandbox(config) && config.parentAccountId === defaultAccountId
+    );
   let disabledMessage = false;
 
   if (sandboxUsage['DEVELOPER'] && sandboxUsage['DEVELOPER'].available === 0) {


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
`hs project dev` prompt was updated to say "choose a sandbox **under** xyz account" but the prompt choices show all available sandboxes in your config. 

This PR filters down the list to sandboxes belonging to the default account only. This list will only show if the default account is a prod account, if a sandbox is the default it will automatically skip the prompt. 


## Screenshots
<!-- Provide images of the before and after functionality -->
Before:
<img width="1217" alt="Screenshot 2023-08-08 at 14 52 50" src="https://github.com/HubSpot/hubspot-cli/assets/16788677/d312350d-b823-45c0-8d29-12bb34b91c86">


After:
<img width="1207" alt="Screenshot 2023-08-08 at 14 52 31" src="https://github.com/HubSpot/hubspot-cli/assets/16788677/54cb43be-6357-49e0-b9ca-14390bae1f9c">


## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->
n/a

## Who to Notify
<!-- /cc those you wish to know about the PR -->
