### PR TITLE
Remove console clears from dev mode init flow

### DIFF
--- a/packages/cli/commands/project/dev.js
+++ b/packages/cli/commands/project/dev.js
@@ -234,13 +234,14 @@ exports.handler = async options => {
     if (shouldCreateProject) {
       await showPlatformVersionWarning(accountId, projectConfig);
 
+      SpinniesManager.add('createProject', {
+        text: i18n(`${i18nKey}.status.creatingProject`, {
+          accountIdentifier: uiAccountDescription(targetAccountId),
+          projectName: projectConfig.name,
+        }),
+      });
+
       try {
-        SpinniesManager.add('createProject', {
-          text: i18n(`${i18nKey}.status.creatingProject`, {
-            accountIdentifier: uiAccountDescription(targetAccountId),
-            projectName: projectConfig.name,
-          }),
-        });
         await createProject(targetAccountId, projectConfig.name);
         SpinniesManager.succeed('createProject', {
           text: i18n(`${i18nKey}.status.createdProject`, {
@@ -250,6 +251,7 @@ exports.handler = async options => {
           succeedColor: 'white',
         });
       } catch (err) {
+        SpinniesManager.fail('createProject');
         logger.log(i18n(`${i18nKey}.status.failedToCreateProject`));
         process.exit(EXIT_CODES.ERROR);
       }

--- a/packages/cli/commands/project/dev.js
+++ b/packages/cli/commands/project/dev.js
@@ -78,9 +78,6 @@ exports.handler = async options => {
 
   const { projectConfig, projectDir } = await getProjectConfig();
 
-  if (!options.debug) {
-    console.clear();
-  }
   uiBetaMessage(i18n(`${i18nKey}.logs.betaMessage`));
 
   if (!projectConfig) {
@@ -211,11 +208,6 @@ exports.handler = async options => {
 
   SpinniesManager.init();
 
-  if (!options.debug) {
-    console.clear();
-  }
-  uiBetaMessage(i18n(`${i18nKey}.logs.betaMessage`));
-
   if (!projectExists) {
     // Create the project without prompting if this is a newly created sandbox
     let shouldCreateProject = createNewSandbox;
@@ -317,7 +309,7 @@ exports.handler = async options => {
 
       logger.log();
       failedSubTasks.forEach(failedSubTask => {
-        console.log(failedSubTask.errorMessage);
+        console.error(failedSubTask.errorMessage);
       });
       logger.log();
 

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -865,8 +865,8 @@ en:
         noCompatibleComponents: "Skipping call to {{ serverKey }} because there are no compatible components in the project."
       LocalDevManager:
         failedToInitialize: "Missing required arguments to initialize Local Dev"
+        noDeployedBuild: "There is no deployed build for this project in {{ accountIdentifier }}. Run {{ uploadCommand }} to upload and deploy your project."
         noComponents: "There are no components in this project."
-        noDeployedBuild: "There is no deployed build for this project in {{ accountIdentifier }}."
         noRunnableComponents: "There are no components in this project that support local development."
         betaMessage: "HubSpot projects local development"
         running: "Running {{#bold}}{{ projectName }}{{/bold}} locally on {{ accountIdentifier }}, waiting for changes ..."
@@ -883,7 +883,6 @@ en:
           header: "{{ reason }} To reflect these changes:"
           stopDev: "  * Stop {{ command }}"
           runUpload: "  * Run {{ command }}"
-          runUploadWithAccount: "  * Run {{ command }}"
           restartDev: "  * Re-run {{ command }}"
         devServer:
           cleanupError: "Failed to cleanup local dev server: {{ message }}"


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
We decided that we don't want to be so aggressive with the console clears in the init flow for the dev command

Edit: I updated this PR to do a few more things. It now also includes some changes to the errors and logging that we do during the init flow.
- We weren't failing the spinnies for project create failures
- Adding a suggestion to run `hs project upload` whenever we detect that the project has no deployed build.

## Screenshots
<!-- Provide images of the before and after functionality -->

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
