### PR TITLE
Fetch empty template from github

### DIFF
--- a/packages/cli/lib/projects.js
+++ b/packages/cli/lib/projects.js
@@ -133,24 +133,15 @@ const createProjectConfig = async (
     }`
   );
 
+  await downloadGitHubRepoContents(templateSource, template.path, projectPath);
+  const _config = JSON.parse(fs.readFileSync(projectConfigPath));
+  writeProjectConfig(projectConfigPath, {
+    ..._config,
+    name: projectName,
+  });
+
   if (template.name === 'no-template') {
     fs.ensureDirSync(path.join(projectPath, 'src'));
-
-    writeProjectConfig(projectConfigPath, {
-      name: projectName,
-      srcDir: 'src',
-    });
-  } else {
-    await downloadGitHubRepoContents(
-      templateSource,
-      template.path,
-      projectPath
-    );
-    const _config = JSON.parse(fs.readFileSync(projectConfigPath));
-    writeProjectConfig(projectConfigPath, {
-      ..._config,
-      name: projectName,
-    });
   }
 
   return true;


### PR DESCRIPTION
## Description and Context
This modifies the create command to fetch the empty template from `hubspot-project-components` rather than creating it from scratch so that we can make sure new projects have the correct platform version.

See https://github.com/HubSpot/hubspot-project-components/pull/11

## Who to Notify
@brandenrodgers @kemmerle 
