### PR TITLE
Improve error message in deploy command when project doesn't exist

### DIFF
--- a/packages/cli/commands/project/deploy.js
+++ b/packages/cli/commands/project/deploy.js
@@ -25,6 +25,7 @@ const { getAccountConfig } = require('@hubspot/cli-lib');
 
 const i18nKey = 'cli.commands.project.subcommands.deploy';
 const { EXIT_CODES } = require('../../lib/enums/exitCodes');
+const { uiCommandReference, uiAccountDescription } = require('../../lib/ui');
 
 exports.command = 'deploy [--project] [--buildId]';
 exports.describe = i18n(`${i18nKey}.describe`);
@@ -56,10 +57,11 @@ exports.handler = async options => {
     logger.error(
       i18n(`${i18nKey}.errors.projectNotFound`, {
         projectName: chalk.bold(projectName),
-        accountId: chalk.bold(accountId),
+        accountIdentifier: uiAccountDescription(accountId),
+        command: uiCommandReference('hs project upload'),
       })
     );
-    return;
+    process.exit(EXIT_CODES.ERROR);
   }
 
   const namePromptResponse = await projectNamePrompt(accountId, {

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -517,6 +517,7 @@ en:
               deploy: "Deploy error: {{ details }}"
               noBuilds: "Deploy error: no builds for this project were found."
               noBuildId: "You must specify a build to deploy"
+              projectNotFound: "{{ projectName }} does not exists in account {{ accountId }}. Run `{{#yellow}}hs project upload{{/yellow}}` to upload your project files to HubSpot."
             examples:
               default: "Deploy the latest build of the current project"
               withOptions: "Deploy build 5 of the project my-project"

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -517,7 +517,7 @@ en:
               deploy: "Deploy error: {{ details }}"
               noBuilds: "Deploy error: no builds for this project were found."
               noBuildId: "You must specify a build to deploy"
-              projectNotFound: "{{ projectName }} does not exist in account {{ accountId }}. Run `{{#yellow}}hs project upload{{/yellow}}` to upload your project files to HubSpot."
+              projectNotFound: "{{ projectName }} does not exist in account {{ accountIdentifier }}. Run {{ command }} to upload your project files to HubSpot."
             examples:
               default: "Deploy the latest build of the current project"
               withOptions: "Deploy build 5 of the project my-project"

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -517,7 +517,7 @@ en:
               deploy: "Deploy error: {{ details }}"
               noBuilds: "Deploy error: no builds for this project were found."
               noBuildId: "You must specify a build to deploy"
-              projectNotFound: "{{ projectName }} does not exists in account {{ accountId }}. Run `{{#yellow}}hs project upload{{/yellow}}` to upload your project files to HubSpot."
+              projectNotFound: "{{ projectName }} does not exist in account {{ accountId }}. Run `{{#yellow}}hs project upload{{/yellow}}` to upload your project files to HubSpot."
             examples:
               default: "Deploy the latest build of the current project"
               withOptions: "Deploy build 5 of the project my-project"


### PR DESCRIPTION
## Description and Context
Currently, when anyone runs the `hs project deploy` and the project doesn't exist in the target account, they receive a very vague error message:

<img width="965" alt="Screenshot 2023-08-14 at 5 55 42 PM" src="https://github.com/HubSpot/hubspot-cli/assets/25392256/bb4e9e43-45b6-40a2-9cde-feab27139953">

With this PR, I've added a more detailed error message that gives the customer clear instructions to proceed:

<img width="1697" alt="Screenshot 2023-08-14 at 5 58 31 PM" src="https://github.com/HubSpot/hubspot-cli/assets/25392256/8e4c54a7-a3b0-453b-b372-2a92926450aa">

NOTE: I originally took a different approach and wanted to give the customer the option to create and build/deploy the project directly within the `hs project deploy` command. However, the deploy and upload commands work differently, in that uploading requires a project path. That would require making significant changes to the `deploy` command, which I don't think we want to do right now. 

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@brandenrodgers @camden11 
