### PR TITLE
Handle error when project does not exist in target account

### DIFF
--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -1109,7 +1109,7 @@ en:
           enterName: "[--project] Enter project name:"
           errors:
             invalidName: "You entered an invalid name. Please try again."
-            projectDoesNotExist: "Project \"{{ projectName }}\" could not be found in \"{{ accountId }}\""
+            projectDoesNotExist: "Project {{#bold}}{{ projectName }}{{/bold}} could not be found in \"{{ accountIdentifier }}\""
         feedbackPrompt:
           feedbackType:
             message: "What type of feedback would you like to leave?"

--- a/packages/cli/lib/prompts/projectNamePrompt.js
+++ b/packages/cli/lib/prompts/projectNamePrompt.js
@@ -1,6 +1,7 @@
 const { promptUser } = require('./promptUtils');
 const { i18n } = require('../lang');
 const { ensureProjectExists } = require('../projects');
+const { uiAccountDescription } = require('../ui');
 
 const i18nKey = 'cli.lib.prompts.projectNamePrompt';
 
@@ -20,7 +21,7 @@ const projectNamePrompt = (accountId, options = {}) => {
       if (!projectExists) {
         return i18n(`${i18nKey}.errors.projectDoesNotExist`, {
           projectName: val,
-          accountId,
+          accountIdentifier: uiAccountDescription(accountId),
         });
       }
       return true;


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
Fast follow for https://github.com/HubSpot/hubspot-cli/pull/920

My fault for not testing it more thoroughly before merging. The initial PR was attempting to add error handling for the scenario when the user runs `hs project dev` against an account that does not contain the current project. The issue is that the code in the initial PR was preventing us from ever getting to the `projectNamePrompt` util that asks the user to specify a project to deploy whenever the command is run from outside of a project folder.

Now we listen for a 404 response from the fetch or deploy endpoints to log out the "project not found" error. The way to reproduce this error is to cd in a local project that has never been uploaded into your target hubspot account. Then run the `hs project deploy` command. The CLI will attempt to deploy the latest build for your project, but it will fail because the project does not exist in your target account yet.

## Screenshots
<!-- Provide images of the before and after functionality -->

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
