### PR TITLE
Clearer disabled messages at sandbox limit

### DIFF
--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -988,8 +988,8 @@ en:
           createNewSandboxOption: "<Test on a new development sandbox>"
           chooseDefaultAccountOption: "<{{#bold}}\U00002757{{/bold}} Test on this production account {{#bold}}\U00002757{{/bold}}>"
           promptMessage: "[--account] Choose a sandbox under {{ accountIdentifier }} to test with:"
-          sandboxLimit: "Your portal reached the limit of {{ limit }} development sandboxes"
-          sandboxLimitWithSuggestion: "Your portal reached the limit of {{ limit }} development sandboxes. Run {{ authCommand }} to add an existing one to the config."
+          sandboxLimit: "Your account reached the limit of {{ limit }} development sandboxes"
+          sandboxLimitWithSuggestion: "Your account reached the limit of {{ limit }} development sandboxes. Run {{ authCommand }} to add an existing one to the config."
           confirmDefaultSandboxAccount: "Continue testing on {{#bold}}{{ accountName }} ({{ accountType }}){{/bold}}? (Y/n)"
         projectLogsPrompt:
           projectName:

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -989,7 +989,7 @@ en:
           chooseDefaultAccountOption: "<{{#bold}}\U00002757{{/bold}} Test on this production account {{#bold}}\U00002757{{/bold}}>"
           promptMessage: "[--account] Choose a sandbox under {{ accountIdentifier }} to test with:"
           sandboxLimit: "Your portal reached the limit of {{ limit }} development sandboxes"
-          sandboxLimitWithSuggestion: "Your portal reached the limit of {{ limit }} development sandboxes. Run {{#bold}}hs auth{{/bold}} to add an existing one to the config."
+          sandboxLimitWithSuggestion: "Your portal reached the limit of {{ limit }} development sandboxes. Run {{ authCommand }} to add an existing one to the config."
           confirmDefaultSandboxAccount: "Continue testing on {{#bold}}{{ accountName }} ({{ accountType }}){{/bold}}? (Y/n)"
         projectLogsPrompt:
           projectName:

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -988,7 +988,8 @@ en:
           createNewSandboxOption: "<Test on a new development sandbox>"
           chooseDefaultAccountOption: "<{{#bold}}\U00002757{{/bold}} Test on this production account {{#bold}}\U00002757{{/bold}}>"
           promptMessage: "[--account] Choose a sandbox under {{ accountIdentifier }} to test with:"
-          sandboxLimit: "You’ve reached the limit of {{ limit }} development sandboxes"
+          sandboxLimit: "Your portal reached the limit of {{ limit }} development sandboxes"
+          sandboxLimitWithSuggestion: "Your portal reached the limit of {{ limit }} development sandboxes. Run {{#bold}}hs auth{{/bold}} to add an existing one to the config."
           confirmDefaultSandboxAccount: "Continue testing on {{#bold}}{{ accountName }} ({{ accountType }}){{/bold}}? (Y/n)"
         projectLogsPrompt:
           projectName:

--- a/packages/cli/lib/prompts/projectDevTargetAccountPrompt.js
+++ b/packages/cli/lib/prompts/projectDevTargetAccountPrompt.js
@@ -1,6 +1,6 @@
 const { promptUser } = require('./promptUtils');
 const { i18n } = require('../lang');
-const { uiAccountDescription } = require('../ui');
+const { uiAccountDescription, uiCommandReference } = require('../ui');
 const { isSandbox, getAccountName } = require('../sandboxes');
 const { getAccountId } = require('@hubspot/cli-lib');
 const { getSandboxUsageLimits } = require('@hubspot/cli-lib/sandboxes');
@@ -36,6 +36,7 @@ const selectTargetAccountPrompt = async (accounts, defaultAccountConfig) => {
   if (sandboxUsage['DEVELOPER'] && sandboxUsage['DEVELOPER'].available === 0) {
     if (sandboxAccounts.length < sandboxUsage['DEVELOPER'].limit) {
       disabledMessage = i18n(`${i18nKey}.sandboxLimitWithSuggestion`, {
+        authCommand: uiCommandReference('hs auth'),
         limit: sandboxUsage['DEVELOPER'].limit,
       });
     } else {

--- a/packages/cli/lib/prompts/projectDevTargetAccountPrompt.js
+++ b/packages/cli/lib/prompts/projectDevTargetAccountPrompt.js
@@ -34,9 +34,15 @@ const selectTargetAccountPrompt = async (accounts, defaultAccountConfig) => {
   let disabledMessage = false;
 
   if (sandboxUsage['DEVELOPER'] && sandboxUsage['DEVELOPER'].available === 0) {
-    disabledMessage = i18n(`${i18nKey}.sandboxLimit`, {
-      limit: sandboxUsage['DEVELOPER'].limit,
-    });
+    if (sandboxAccounts.length < sandboxUsage['DEVELOPER'].limit) {
+      disabledMessage = i18n(`${i18nKey}.sandboxLimitWithSuggestion`, {
+        limit: sandboxUsage['DEVELOPER'].limit,
+      });
+    } else {
+      disabledMessage = i18n(`${i18nKey}.sandboxLimit`, {
+        limit: sandboxUsage['DEVELOPER'].limit,
+      });
+    }
   }
 
   // Order choices by Developer Sandbox -> Standard Sandbox


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->

To reduce confusion around available development sandbox accounts while running `hs project dev`, we've updated the disabled messaging to suggest running `hs auth` if the target portal is at the limit of sandboxes, but the CLI config only has one or none of the accounts listed. 

We've also updated the messaging to state the **portal** limit has been reached. 

## Screenshots
<!-- Provide images of the before and after functionality -->
<img width="1199" alt="Screenshot 2023-08-16 at 12 19 57" src="https://github.com/HubSpot/hubspot-cli/assets/16788677/e4d0902b-8221-4360-ab54-8227180fcee3">
<img width="1195" alt="Screenshot 2023-08-16 at 12 21 49" src="https://github.com/HubSpot/hubspot-cli/assets/16788677/b954024d-86d1-4d29-acd1-c19a57f89bd7">

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->
n/a

## Who to Notify
<!-- /cc those you wish to know about the PR -->
