### PR TITLE
Update upload warning copy for GH linked projects

### DIFF
--- a/packages/cli/commands/project/dev.js
+++ b/packages/cli/commands/project/dev.js
@@ -200,10 +200,14 @@ exports.handler = async options => {
   );
 
   let deployedBuild;
+  let isGithubLinked;
 
   if (projectExists) {
     const project = await fetchProject(targetAccountId, projectConfig.name);
     deployedBuild = project.deployedBuild;
+    isGithubLinked =
+      project.sourceIntegration &&
+      project.sourceIntegration.source === 'GITHUB';
   }
 
   SpinniesManager.init();
@@ -327,6 +331,7 @@ exports.handler = async options => {
     projectConfig,
     projectDir,
     targetAccountId,
+    isGithubLinked,
   });
 
   await LocalDev.start();

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -891,6 +891,7 @@ en:
           stopDev: "  * Stop {{ command }}"
           runUpload: "  * Run {{ command }}"
           restartDev: "  * Re-run {{ command }}"
+          pushToGithub: "  * Commit and push your changes to GitHub"
         devServer:
           cleanupError: "Failed to cleanup local dev server: {{ message }}"
           setupError: "Failed to setup local dev server: {{ message }}"

--- a/packages/cli/lib/LocalDevManager.js
+++ b/packages/cli/lib/LocalDevManager.js
@@ -44,6 +44,7 @@ class LocalDevManager {
     this.projectDir = options.projectDir;
     this.debug = options.debug || false;
     this.deployedBuild = options.deployedBuild;
+    this.isGithubLinked = options.isGithubLinked;
     this.watcher = null;
     this.uploadWarnings = {};
 
@@ -188,11 +189,15 @@ class LocalDevManager {
           command: uiCommandReference('hs project dev'),
         })
       );
-      logger.log(
-        i18n(`${i18nKey}.uploadWarning.runUpload`, {
-          command: this.getUploadCommand(),
-        })
-      );
+      if (this.isGithubLinked) {
+        logger.log(i18n(`${i18nKey}.uploadWarning.pushToGithub`));
+      } else {
+        logger.log(
+          i18n(`${i18nKey}.uploadWarning.runUpload`, {
+            command: this.getUploadCommand(),
+          })
+        );
+      }
       logger.log(
         i18n(`${i18nKey}.uploadWarning.restartDev`, {
           command: uiCommandReference('hs project dev'),


### PR DESCRIPTION
## Description and Context
Previously, changing `app.json` would prompt users to run `hs project upload`, even on GitHub linked projects where `upload` doesn't work. This adds copy for that scenario that prompts users to push their changes to GH.

See https://git.hubteam.com/HubSpot/hubspot-cli-issues/issues/446

## Screenshots
Before:
<img width="861" alt="Screenshot 2023-08-16 at 1 21 18 PM" src="https://github.com/HubSpot/hubspot-cli/assets/10413161/dd170e72-4df7-4ccb-afb4-08b466bc530f">

After:
<img width="867" alt="Screenshot 2023-08-16 at 1 20 35 PM" src="https://github.com/HubSpot/hubspot-cli/assets/10413161/b68a5603-546e-4b61-85e2-0fbd259ad00c">


## TODO
Confirm that copy looks good

## Who to Notify
@brandenrodgers 
