### PR TITLE
Change project create prompt

### DIFF
--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -1071,7 +1071,7 @@ en:
         createProjectPrompt:
           enterName: "[--name] Give your project a name: "
           enterLocation: "[--location] Where should the project be created?"
-          selectTemplate: "[--template] Start from a template?"
+          selectTemplate: "[--template] Choose a project template: "
           errors:
             nameRequired: "A project name is required"
             locationRequired: "A project location is required"


### PR DESCRIPTION
## Description and Context
In line with @markhazlewood's designs, we're changing the `hs project create` prompt to read **Choose a project template:** instead of **Start from a template?**. In another [PR](https://github.com/HubSpot/hubspot-project-components/pull/18) in the `hubspot-project-components` repo, I've also changed the way we label project templates. 

NOTE: https://github.com/HubSpot/hubspot-project-components/pull/18 should be released before this change (or simultaneously). 

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@brandenrodgers @camden11 @markhazlewood 
