### PR TITLE
Validate paths before generating card config paths

### DIFF
--- a/packages/cli/lib/projectStructure.js
+++ b/packages/cli/lib/projectStructure.js
@@ -32,11 +32,13 @@ function getAppCardConfigs(appConfig, appPath) {
 
   if (cards) {
     cards.forEach(({ file }) => {
-      const cardConfigPath = path.join(appPath, file);
-      const cardConfig = loadConfigFile(cardConfigPath);
+      if (typeof file === 'string') {
+        const cardConfigPath = path.join(appPath, file);
+        const cardConfig = loadConfigFile(cardConfigPath);
 
-      if (cardConfig) {
-        cardConfigs.push(cardConfig);
+        if (cardConfig) {
+          cardConfigs.push(cardConfig);
+        }
       }
     });
   }
@@ -84,14 +86,16 @@ async function findProjectComponents(projectSourceDir) {
           0,
           projectFile.indexOf(APP_COMPONENT_CONFIG)
         );
-        const isLegacy = getIsLegacyApp(parsedAppConfig, appPath);
+        if (typeof appPath === 'string') {
+          const isLegacy = getIsLegacyApp(parsedAppConfig, appPath);
 
-        components.push({
-          type: COMPONENT_TYPES.app,
-          config: parsedAppConfig,
-          runnable: !isLegacy,
-          path: appPath,
-        });
+          components.push({
+            type: COMPONENT_TYPES.app,
+            config: parsedAppConfig,
+            runnable: !isLegacy,
+            path: appPath,
+          });
+        }
       }
     }
   });


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
Quick PR to fix a JS error that gets thrown when you attempt to run `hs project dev` on a project that contains an app with a config like this:
```json
{
  // nothing above this matters
  "extensions": {
    "crm": {
      "cards": [
        {
          "file": "extensions/scoreboard-card.json"
        },
        {
          "file": null
        }
      ]
    }
  }
}
```

## Screenshots
<!-- Provide images of the before and after functionality -->

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
