### PR TITLE
Setting up foundation for lint command

### DIFF
--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -406,7 +406,8 @@ en:
         errors:
           configFileExists: "The config file {{ configPath }} already exists."
       lint:
-        issuesFound: "{{ count }} issues found."
+        issuesFound: "{{ errorCount }} issues found."
+        noIssuesFound: "No issues found."
         groupName: "Linting {{ path }}"
         positionals:
           path:


### PR DESCRIPTION
## Description and Context
Finalizing the `hs lint` command in order to return HubL validation errors and warnings. This is currently a standalone command that would need to be run manually on a file in order to get its validation results returned. The expectation in the future would be that we could integrate this into the watch/upload command so that developers can utilize it in order to catch these results before the file is uploaded to the DM (currently the only place that you can see them).

- Related lib PR here: https://github.com/HubSpot/cli-lib/pull/27

## Screenshots
#### Linting command run and return:
![Screenshot 2023-09-21 at 3 53 11 PM](https://github.com/HubSpot/hubspot-cli/assets/4976331/f0c0ee96-de19-411d-8e95-5e46f1013a50)

## TODO
- [ ] Testing: Run lint on a variety of file types to ensure that proper errors are thrown if linting command fails
- [ ] Testing: Run lint on templates with a variety of `template_errors` to make sure `SYNTAX_ERROR` and `DEPRECATED_MODULE` errors/warnings only come back
- [ ] Run command on folder - refactor to surface warnings and highlight while file those came from
- [ ] Determine if there are other errors/warnings that come from the `cos-rendering/v1/internal/validate` endpoint that should be surfaced in this command
- [ ] Add linting command as an optional flag onto the `upload` and `watch` commands
    - As the lint command is run on each file individually -- it might be nice to think about how this would work when uploading a large amount of files via watch/upload -- the validation warnings could get overwhelming if it is reporting back each of them
- [ ] Should determine if there is a flag to only show errors vs warnings -- in case developers don't want to be warned about the deprecated modules and whatnot
- [ ] Move linting logic from `cli-lib` to `hubspot-local-dev-lib`
- [ ] Determine why the line count for warnings is off -- in the example, these warnings are for different lines of the code and definitely no line `19` -- but this is what is being returned from the endpoint -- investigate.


## Who to Notify
<!-- /cc those you wish to know about the PR -->
