### PR TITLE
Fix i18n branch interpolation

### DIFF
--- a/packages/cli/lib/interpolation.js
+++ b/packages/cli/lib/interpolation.js
@@ -19,8 +19,11 @@ const isHelperIdentifier = identifier => {
 
 const generateReplaceFn = (matchedText, startIndex, replacementString) => {
   return currentStringValue =>
-    `${currentStringValue.slice(0, startIndex)}${replacementString ||
-      ''}${currentStringValue.slice(startIndex + matchedText.length)}`;
+    `${currentStringValue.slice(0, startIndex)}${
+      replacementString !== null && replacementString !== undefined
+        ? replacementString
+        : ''
+    }${currentStringValue.slice(startIndex + matchedText.length)}`;
 };
 
 /**


### PR DESCRIPTION
Fixes logic in i18n interpolation to not break for falsey values - previously any time an argument of "0" was passed into the string it would be replaced with an empty string!