### PR TITLE
Add debug logs for files filtered by ignore rules during project uploads

### DIFF
--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -907,6 +907,7 @@ en:
           emptySource: "Source directory \"{{ srcDir }}\" is empty. Add files to your project and rerun `{{#yellow}}hs project upload{{/yellow}}` to upload them to HubSpot."
           compressed: "Project files compressed: {{ byteCount }} bytes"
           compressing: "Compressing build files to \"{{ path }}\""
+          fileFiltered: "Ignoring \"{{ filename }}\""
         ensureProjectExists:
           createPrompt: "The project {{ projectName }} does not exist in {{ accountIdentifier }}. Would you like to create it?"
           createSuccess: "New project {{#bold}}{{ projectName }}{{/bold}} successfully created in {{#bold}}{{ accountIdentifier }}{{/bold}}."

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -907,7 +907,7 @@ en:
           emptySource: "Source directory \"{{ srcDir }}\" is empty. Add files to your project and rerun `{{#yellow}}hs project upload{{/yellow}}` to upload them to HubSpot."
           compressed: "Project files compressed: {{ byteCount }} bytes"
           compressing: "Compressing build files to \"{{ path }}\""
-          fileFiltered: "Ignoring \"{{ filename }}\""
+          fileFiltered: "Ignore rule triggered for \"{{ filename }}\""
         ensureProjectExists:
           createPrompt: "The project {{ projectName }} does not exist in {{ accountIdentifier }}. Would you like to create it?"
           createSuccess: "New project {{#bold}}{{ projectName }}{{/bold}} successfully created in {{#bold}}{{ accountIdentifier }}{{/bold}}."

--- a/packages/cli/lib/projects.js
+++ b/packages/cli/lib/projects.js
@@ -522,9 +522,15 @@ const handleProjectUpload = async (
 
   archive.pipe(output);
 
-  archive.directory(srcDir, false, file =>
-    shouldIgnoreFile(file.name, true) ? false : file
-  );
+  archive.directory(srcDir, false, file => {
+    const ignored = shouldIgnoreFile(file.name, true);
+    if (ignored) {
+      logger.debug(`${i18nKey}.handleProjectUpload.fileFiltered`, {
+        filename: file.name,
+      });
+    }
+    return ignored ? false : file;
+  });
 
   archive.finalize();
 

--- a/packages/cli/lib/projects.js
+++ b/packages/cli/lib/projects.js
@@ -522,12 +522,24 @@ const handleProjectUpload = async (
 
   archive.pipe(output);
 
+  let loggedIgnoredNodeModule = false;
+
   archive.directory(srcDir, false, file => {
     const ignored = shouldIgnoreFile(file.name, true);
     if (ignored) {
-      logger.debug(`${i18nKey}.handleProjectUpload.fileFiltered`, {
-        filename: file.name,
-      });
+      const isNodeModule = file.name.includes('node_modules');
+
+      if (!isNodeModule || !loggedIgnoredNodeModule) {
+        logger.debug(
+          i18n(`${i18nKey}.handleProjectUpload.fileFiltered`, {
+            filename: file.name,
+          })
+        );
+      }
+
+      if (isNodeModule && !loggedIgnoredNodeModule) {
+        loggedIgnoredNodeModule = true;
+      }
     }
     return ignored ? false : file;
   });


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
The CLI has a set of [default ignore rules](https://github.com/HubSpot/cli-lib/blob/main/ignoreRules.js#L6-L30) that it uses on upload which can be confusing to users when their content gets unexpectedly filtered. This PR adds the filtered content to some debug logs so it's easier for us to catch this when it happens. Ultimately it would be a little better if we could differentiate between a default HubSpot ignore rule and a user-defined one, but this is a good place to start.

I added some special casing to catch nodule_modules. It prevents us from logging tons of lines of debug logs for everything in the node modules folder.
## Screenshots
<!-- Provide images of the before and after functionality -->

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
