### PR TITLE
Bumping version of the ui extensions dev server package

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@hubspot/cli-lib": "^5.0.1",
     "@hubspot/serverless-dev-runtime": "4.2.1-beta.3",
-    "@hubspot/ui-extensions-dev-server": "^0.7.2",
+    "@hubspot/ui-extensions-dev-server": "^0.8.0",
     "archiver": "^5.3.0",
     "chalk": "^4.1.2",
     "chokidar": "^3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -441,10 +441,10 @@
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
   integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
 
-"@hubspot/app-functions-dev-server@^0.7.3":
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/@hubspot/app-functions-dev-server/-/app-functions-dev-server-0.7.3.tgz#fa4f4fa9ec52b11b6655551717314d4895f85780"
-  integrity sha512-NX/IGvHyO4WbwlmV73LPkQ46Lpfnead6JNT2Aoe7Ih5HBjxhjpxOeJK9DHcovGCVwRXEp/NBGLjnMd9pdsXejw==
+"@hubspot/app-functions-dev-server@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@hubspot/app-functions-dev-server/-/app-functions-dev-server-0.8.0.tgz#ed8697685bec2d1df7a1f799ae3f363f8786f2b6"
+  integrity sha512-TpIBoDRdJcA42enZMbBxE31zhIt8J4vxl9V9OngKHNOBmbjZxGVHDZ2VmGtzITkIa7a9KhE9Mbdnpe3Ows3t1w==
   dependencies:
     "@hubspot/cli-lib" "^4.1.6"
     body-parser "1.20.2"
@@ -500,20 +500,21 @@
     table "^6.6.0"
     unixify "1.0.0"
 
-"@hubspot/ui-extensions-dev-server@^0.7.2":
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/@hubspot/ui-extensions-dev-server/-/ui-extensions-dev-server-0.7.3.tgz#f8c41c2480279ac428ff5cacfc22a1512794acf2"
-  integrity sha512-sLaE93IZgA/rT0BP7lDn7R0++NtxLxKm+9BMfnfl5LORYsWFTnHh+a+gUbHQlIU9jqg/mtZXaR8L5aEM64JF9A==
+"@hubspot/ui-extensions-dev-server@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@hubspot/ui-extensions-dev-server/-/ui-extensions-dev-server-0.8.0.tgz#153c94563d5fdf8938f06522809531d252976c35"
+  integrity sha512-zP/fmc41RAWl+z2qByBfnLg7i3CMWsL+/AiICe7lHnvwBF1vr0hOj+MlTvU2b9Asgea88xDxa2sGrSka2ttuEQ==
   dependencies:
-    "@hubspot/app-functions-dev-server" "^0.7.3"
+    "@hubspot/app-functions-dev-server" "^0.8.0"
     "@hubspot/cli-lib" "^4.1.6"
     command-line-args "^5.2.1"
     command-line-usage "^7.0.1"
     console-log-colors "^0.4.0"
     cors "^2.8.5"
+    detect-port "1.5.1"
     express "^4.18.2"
     inquirer "8.2.0"
-    vite "^4.0.4"
+    vite "^4.4.9"
 
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"
@@ -1589,6 +1590,11 @@ add-stream@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/add-stream/-/add-stream-1.0.0.tgz#6a7990437ca736d5e1288db92bd3266d5f5cb2aa"
   integrity sha512-qQLMr+8o0WC4FZGQTcJiKBVC59JylcPSrTtk6usvmIDFUOCKegapy1VHQwRbFMOFyb/inzUVqHs+eMYKDM1YeQ==
+
+address@^1.0.1:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/address/-/address-1.2.2.tgz#2b5248dac5485a6390532c6a517fda2e3faac89e"
+  integrity sha512-4B/qKCfeE/ODUaAUpSwfzazo5x29WD4r3vXiWsB7I2mSDAihwEqKO+g8GELZUQSSAo5e1XTYh3ZVfLyxBc12nA==
 
 agent-base@6, agent-base@^6.0.2:
   version "6.0.2"
@@ -3194,6 +3200,14 @@ detect-newline@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
+
+detect-port@1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/detect-port/-/detect-port-1.5.1.tgz#451ca9b6eaf20451acb0799b8ab40dff7718727b"
+  integrity sha512-aBzdj76lueB6uUst5iAs7+0H/oOjqI5D16XUWxlWMIMROhcM0rfsNVk93zTngq1dDNpoXRr++Sus7ETAExppAQ==
+  dependencies:
+    address "^1.0.1"
+    debug "4"
 
 detective-amd@^3.0.1, detective-amd@^3.1.0:
   version "3.1.2"
@@ -9686,10 +9700,10 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-vite@^4.0.4:
-  version "4.4.9"
-  resolved "https://registry.yarnpkg.com/vite/-/vite-4.4.9.tgz#1402423f1a2f8d66fd8d15e351127c7236d29d3d"
-  integrity sha512-2mbUn2LlUmNASWwSCNSJ/EG2HuSRTnVNaydp6vMCm5VIqJsjMfbIWtbH2kDuwUVW5mMUKKZvGPX/rqeqVvv1XA==
+vite@^4.4.9:
+  version "4.4.11"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-4.4.11.tgz#babdb055b08c69cfc4c468072a2e6c9ca62102b0"
+  integrity sha512-ksNZJlkcU9b0lBwAGZGGaZHCMqHsc8OpgtoYhsQ4/I2v5cnpmmmqe5pM4nv/4Hn6G/2GhTdj0DhZh2e+Er1q5A==
   dependencies:
     esbuild "^0.18.10"
     postcss "^8.4.27"


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
There is a new release of the UI Extensibility dev server package that contains some bug fixes and better error handling. this bumps the CLI to use the new version `0.8.0` of it.

## Screenshots
<!-- Provide images of the before and after functionality -->

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
