### PR TITLE
Port error handlers to CLI

### DIFF
--- a/packages/cli/bin/cli.js
+++ b/packages/cli/bin/cli.js
@@ -5,7 +5,7 @@ const updateNotifier = require('update-notifier');
 const chalk = require('chalk');
 
 const { logger } = require('@hubspot/cli-lib/logger');
-const { logErrorInstance } = require('@hubspot/cli-lib/errorHandlers');
+const { logErrorInstance } = require('../lib/errorHandlers/standardErrors');
 const { setLogLevel, getCommandName } = require('../lib/commonOpts');
 const {
   trackHelpUsage,

--- a/packages/cli/commands/accounts/clean.js
+++ b/packages/cli/commands/accounts/clean.js
@@ -21,7 +21,7 @@ const SpinniesManager = require('../../lib/SpinniesManager');
 const { deleteAccount } = require('@hubspot/cli-lib/lib/config');
 const {
   isSpecifiedHubSpotAuthError,
-} = require('@hubspot/cli-lib/errorHandlers/apiErrors');
+} = require('../../lib/errorHandlers/apiErrors');
 
 const i18nKey = 'cli.commands.accounts.subcommands.clean';
 

--- a/packages/cli/commands/create.js
+++ b/packages/cli/commands/create.js
@@ -24,7 +24,7 @@
 const fs = require('fs-extra');
 const {
   logFileSystemErrorInstance,
-} = require('@hubspot/cli-lib/errorHandlers');
+} = require('../lib/errorHandlers/fileSystemErrors');
 const { logger } = require('@hubspot/cli-lib/logger');
 const { setLogLevel, getAccountId } = require('../lib/commonOpts');
 const { logDebugInfo } = require('../lib/debugInfo');

--- a/packages/cli/commands/customObject/create.js
+++ b/packages/cli/commands/customObject/create.js
@@ -1,5 +1,5 @@
 const { logger } = require('@hubspot/cli-lib/logger');
-const { logErrorInstance } = require('@hubspot/cli-lib/errorHandlers');
+const { logErrorInstance } = require('../../lib/errorHandlers/standardErrors');
 const { getAbsoluteFilePath } = require('@hubspot/cli-lib/path');
 const {
   isFileValidJSON,

--- a/packages/cli/commands/customObject/schema/create.js
+++ b/packages/cli/commands/customObject/schema/create.js
@@ -1,5 +1,7 @@
 const { logger } = require('@hubspot/cli-lib/logger');
-const { logErrorInstance } = require('@hubspot/cli-lib/errorHandlers');
+const {
+  logErrorInstance,
+} = require('../../../lib/errorHandlers/standardErrors');
 const { getAbsoluteFilePath } = require('@hubspot/cli-lib/path');
 const {
   isFileValidJSON,

--- a/packages/cli/commands/customObject/schema/delete.js
+++ b/packages/cli/commands/customObject/schema/delete.js
@@ -1,5 +1,7 @@
 const { logger } = require('@hubspot/cli-lib/logger');
-const { logErrorInstance } = require('@hubspot/cli-lib/errorHandlers');
+const {
+  logErrorInstance,
+} = require('../../../lib/errorHandlers/standardErrors');
 
 const { loadAndValidateOptions } = require('../../../lib/validation');
 const { trackCommandUsage } = require('../../../lib/usageTracking');

--- a/packages/cli/commands/customObject/schema/fetch-all.js
+++ b/packages/cli/commands/customObject/schema/fetch-all.js
@@ -1,5 +1,7 @@
 const { logger } = require('@hubspot/cli-lib/logger');
-const { logErrorInstance } = require('@hubspot/cli-lib/errorHandlers');
+const {
+  logErrorInstance,
+} = require('../../../lib/errorHandlers/standardErrors');
 
 const { loadAndValidateOptions } = require('../../../lib/validation');
 const { trackCommandUsage } = require('../../../lib/usageTracking');

--- a/packages/cli/commands/customObject/schema/fetch.js
+++ b/packages/cli/commands/customObject/schema/fetch.js
@@ -1,7 +1,9 @@
 const path = require('path');
 const { isConfigFlagEnabled } = require('@hubspot/cli-lib');
 const { logger } = require('@hubspot/cli-lib/logger');
-const { logErrorInstance } = require('@hubspot/cli-lib/errorHandlers');
+const {
+  logErrorInstance,
+} = require('../../../lib/errorHandlers/standardErrors');
 const { ConfigFlags } = require('@hubspot/cli-lib/lib/constants');
 const { downloadSchema, getResolvedPath } = require('@hubspot/cli-lib/schema');
 const { fetchSchema } = require('@hubspot/cli-lib/api/fileTransport');

--- a/packages/cli/commands/customObject/schema/list.js
+++ b/packages/cli/commands/customObject/schema/list.js
@@ -1,5 +1,7 @@
 const { logger } = require('@hubspot/cli-lib/logger');
-const { logErrorInstance } = require('@hubspot/cli-lib/errorHandlers');
+const {
+  logErrorInstance,
+} = require('../../../lib/errorHandlers/standardErrors');
 
 const { loadAndValidateOptions } = require('../../../lib/validation');
 const { trackCommandUsage } = require('../../../lib/usageTracking');

--- a/packages/cli/commands/customObject/schema/update.js
+++ b/packages/cli/commands/customObject/schema/update.js
@@ -1,5 +1,7 @@
 const { logger } = require('@hubspot/cli-lib/logger');
-const { logErrorInstance } = require('@hubspot/cli-lib/errorHandlers');
+const {
+  logErrorInstance,
+} = require('../../../lib/errorHandlers/standardErrors');
 const { getAbsoluteFilePath } = require('@hubspot/cli-lib/path');
 const {
   isFileValidJSON,

--- a/packages/cli/commands/filemanager/upload.js
+++ b/packages/cli/commands/filemanager/upload.js
@@ -6,10 +6,10 @@ const { uploadFile } = require('@hubspot/cli-lib/api/fileManager');
 const { getCwd, convertToUnixPath } = require('@hubspot/cli-lib/path');
 const { logger } = require('@hubspot/cli-lib/logger');
 const {
-  logErrorInstance,
   ApiErrorContext,
   logApiUploadErrorInstance,
-} = require('@hubspot/cli-lib/errorHandlers');
+} = require('../../lib/errorHandlers/apiErrors');
+const { logErrorInstance } = require('../../lib/errorHandlers/standardErrors');
 const { validateSrcAndDestPaths } = require('@hubspot/cli-lib/modules');
 const { shouldIgnoreFile } = require('@hubspot/cli-lib/ignoreRules');
 

--- a/packages/cli/commands/functions/deploy.js
+++ b/packages/cli/commands/functions/deploy.js
@@ -9,7 +9,7 @@ const { trackCommandUsage } = require('../../lib/usageTracking');
 const {
   logApiErrorInstance,
   ApiErrorContext,
-} = require('@hubspot/cli-lib/errorHandlers');
+} = require('../../lib/errorHandlers/apiErrors');
 const { POLLING_DELAY } = require('@hubspot/cli-lib/lib/constants');
 const { logger } = require('@hubspot/cli-lib/logger');
 const {

--- a/packages/cli/commands/functions/list.js
+++ b/packages/cli/commands/functions/list.js
@@ -3,7 +3,7 @@ const { logger } = require('@hubspot/cli-lib/logger');
 const {
   logApiErrorInstance,
   ApiErrorContext,
-} = require('@hubspot/cli-lib/errorHandlers');
+} = require('../../lib/errorHandlers/apiErrors');
 const { getFunctionArrays } = require('../../lib/getFunctionArrays');
 const {
   getTableContents,

--- a/packages/cli/commands/hubdb/clear.js
+++ b/packages/cli/commands/hubdb/clear.js
@@ -1,5 +1,5 @@
 const { logger } = require('@hubspot/cli-lib/logger');
-const { logErrorInstance } = require('@hubspot/cli-lib/errorHandlers');
+const { logErrorInstance } = require('../../lib/errorHandlers/standardErrors');
 const { clearHubDbTableRows } = require('@hubspot/cli-lib/hubdb');
 const { publishTable } = require('@hubspot/cli-lib/api/hubdb');
 

--- a/packages/cli/commands/hubdb/create.js
+++ b/packages/cli/commands/hubdb/create.js
@@ -1,7 +1,7 @@
 const path = require('path');
 
 const { logger } = require('@hubspot/cli-lib/logger');
-const { logErrorInstance } = require('@hubspot/cli-lib/errorHandlers');
+const { logErrorInstance } = require('../../lib/errorHandlers/standardErrors');
 const { getCwd } = require('@hubspot/cli-lib/path');
 const { createHubDbTable } = require('@hubspot/cli-lib/hubdb');
 

--- a/packages/cli/commands/hubdb/delete.js
+++ b/packages/cli/commands/hubdb/delete.js
@@ -1,5 +1,5 @@
 const { logger } = require('@hubspot/cli-lib/logger');
-const { logErrorInstance } = require('@hubspot/cli-lib/errorHandlers');
+const { logErrorInstance } = require('../../lib/errorHandlers/standardErrors');
 const { deleteTable } = require('@hubspot/cli-lib/api/hubdb');
 const { loadAndValidateOptions } = require('../../lib/validation');
 const { trackCommandUsage } = require('../../lib/usageTracking');

--- a/packages/cli/commands/hubdb/fetch.js
+++ b/packages/cli/commands/hubdb/fetch.js
@@ -1,5 +1,5 @@
 const { logger } = require('@hubspot/cli-lib/logger');
-const { logErrorInstance } = require('@hubspot/cli-lib/errorHandlers');
+const { logErrorInstance } = require('../../lib/errorHandlers/standardErrors');
 const { downloadHubDbTable } = require('@hubspot/cli-lib/hubdb');
 
 const { loadAndValidateOptions } = require('../../lib/validation');

--- a/packages/cli/commands/init.js
+++ b/packages/cli/commands/init.js
@@ -9,7 +9,7 @@ const {
 const { addConfigOptions } = require('../lib/commonOpts');
 const { handleExit } = require('../lib/process');
 const { checkAndUpdateGitignore } = require('@hubspot/cli-lib/lib/git');
-const { logErrorInstance } = require('@hubspot/cli-lib/errorHandlers');
+const { logErrorInstance } = require('../lib/errorHandlers/standardErrors');
 const {
   DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME,
   PERSONAL_ACCESS_KEY_AUTH_METHOD,

--- a/packages/cli/commands/lint.js
+++ b/packages/cli/commands/lint.js
@@ -1,7 +1,7 @@
 const { lint } = require('@hubspot/cli-lib/validate');
 const { printHublValidationResult } = require('../lib/hublValidate');
 const { logger } = require('@hubspot/cli-lib/logger');
-const { logErrorInstance } = require('@hubspot/cli-lib/errorHandlers');
+const { logErrorInstance } = require('../lib/errorHandlers/standardErrors');
 
 const {
   addConfigOptions,

--- a/packages/cli/commands/list.js
+++ b/packages/cli/commands/list.js
@@ -12,7 +12,7 @@ const { logger } = require('@hubspot/cli-lib/logger');
 const {
   logApiErrorInstance,
   ApiErrorContext,
-} = require('@hubspot/cli-lib/errorHandlers');
+} = require('../lib/errorHandlers/apiErrors');
 const {
   getDirectoryContentsByPath,
 } = require('@hubspot/cli-lib/api/fileMapper');

--- a/packages/cli/commands/mv.js
+++ b/packages/cli/commands/mv.js
@@ -3,7 +3,7 @@ const { logger } = require('@hubspot/cli-lib/logger');
 const {
   logApiErrorInstance,
   ApiErrorContext,
-} = require('@hubspot/cli-lib/errorHandlers');
+} = require('../lib/errorHandlers/apiErrors');
 
 const {
   addConfigOptions,

--- a/packages/cli/commands/project/add.js
+++ b/packages/cli/commands/project/add.js
@@ -1,6 +1,6 @@
 const { logger } = require('@hubspot/cli-lib/logger');
 const { getAccountId } = require('@hubspot/cli-lib/lib/config');
-const { logErrorInstance } = require('@hubspot/cli-lib/errorHandlers');
+const { logErrorInstance } = require('../../lib/errorHandlers/standardErrors');
 const { fetchReleaseData } = require('@hubspot/cli-lib/github');
 
 const { trackCommandUsage } = require('../../lib/usageTracking');

--- a/packages/cli/commands/project/deploy.js
+++ b/packages/cli/commands/project/deploy.js
@@ -9,7 +9,7 @@ const { trackCommandUsage } = require('../../lib/usageTracking');
 const {
   logApiErrorInstance,
   ApiErrorContext,
-} = require('@hubspot/cli-lib/errorHandlers');
+} = require('../../lib/errorHandlers/apiErrors');
 const { logger } = require('@hubspot/cli-lib/logger');
 const { deployProject, fetchProject } = require('@hubspot/cli-lib/api/dfs');
 const { loadAndValidateOptions } = require('../../lib/validation');

--- a/packages/cli/commands/project/dev.js
+++ b/packages/cli/commands/project/dev.js
@@ -50,18 +50,17 @@ const {
   PROJECT_DEPLOY_TEXT,
   ERROR_TYPES,
 } = require('@hubspot/cli-lib/lib/constants');
-const {
-  logErrorInstance,
-  logApiErrorInstance,
-  ApiErrorContext,
-} = require('@hubspot/cli-lib/errorHandlers');
+
 const { buildSandbox } = require('../../lib/sandbox-create');
 const { syncSandbox } = require('../../lib/sandbox-sync');
 const { getHubSpotWebsiteOrigin } = require('@hubspot/cli-lib/lib/urls');
 const {
+  logApiErrorInstance,
+  ApiErrorContext,
   isMissingScopeError,
   isSpecifiedError,
-} = require('@hubspot/cli-lib/errorHandlers/apiErrors');
+} = require('../../lib/errorHandlers/apiErrors');
+const { logErrorInstance } = require('../../lib/errorHandlers/standardErrors');
 
 const i18nKey = 'cli.commands.project.subcommands.dev';
 

--- a/packages/cli/commands/project/download.js
+++ b/packages/cli/commands/project/download.js
@@ -10,7 +10,7 @@ const { getCwd } = require('@hubspot/cli-lib/path');
 const {
   logApiErrorInstance,
   ApiErrorContext,
-} = require('@hubspot/cli-lib/errorHandlers');
+} = require('../../lib/errorHandlers/apiErrors');
 const { logger } = require('@hubspot/cli-lib/logger');
 const { extractZipArchive } = require('@hubspot/cli-lib/archive');
 const {

--- a/packages/cli/commands/project/listBuilds.js
+++ b/packages/cli/commands/project/listBuilds.js
@@ -11,7 +11,7 @@ const { i18n } = require('../../lib/lang');
 const {
   logApiErrorInstance,
   ApiErrorContext,
-} = require('@hubspot/cli-lib/errorHandlers');
+} = require('../../lib/errorHandlers/apiErrors');
 const { logger } = require('@hubspot/cli-lib/logger');
 const {
   fetchProject,

--- a/packages/cli/commands/project/logs.js
+++ b/packages/cli/commands/project/logs.js
@@ -25,7 +25,7 @@ const {
 // const {
 //   logApiErrorInstance,
 //   ApiErrorContext,
-// } = require('@hubspot/cli-lib/errorHandlers');
+// } = require('../../lib/errorHandlers/apiErrors');
 // const {
 //   getFunctionLogs,
 //   getLatestFunctionLog,

--- a/packages/cli/commands/project/upload.js
+++ b/packages/cli/commands/project/upload.js
@@ -22,12 +22,10 @@ const { i18n } = require('../../lib/lang');
 const { getAccountConfig } = require('@hubspot/cli-lib');
 const { ERROR_TYPES } = require('@hubspot/cli-lib/lib/constants');
 const {
-  isSpecifiedError,
-} = require('@hubspot/cli-lib/errorHandlers/apiErrors');
-const {
   logApiErrorInstance,
   ApiErrorContext,
-} = require('@hubspot/cli-lib/errorHandlers');
+  isSpecifiedError,
+} = require('../../lib/errorHandlers/apiErrors');
 const { EXIT_CODES } = require('../../lib/enums/exitCodes');
 
 const i18nKey = 'cli.commands.project.subcommands.upload';

--- a/packages/cli/commands/project/watch.js
+++ b/packages/cli/commands/project/watch.js
@@ -3,7 +3,7 @@ const { createWatcher } = require('../../lib/projectsWatch');
 const {
   logApiErrorInstance,
   ApiErrorContext,
-} = require('@hubspot/cli-lib/errorHandlers');
+} = require('../../lib/errorHandlers/apiErrors');
 const { logger } = require('@hubspot/cli-lib/logger');
 const { ERROR_TYPES } = require('@hubspot/cli-lib/lib/constants');
 const {

--- a/packages/cli/commands/remove.js
+++ b/packages/cli/commands/remove.js
@@ -3,7 +3,7 @@ const { logger } = require('@hubspot/cli-lib/logger');
 const {
   logApiErrorInstance,
   ApiErrorContext,
-} = require('@hubspot/cli-lib/errorHandlers');
+} = require('../lib/errorHandlers/apiErrors');
 
 const {
   addConfigOptions,

--- a/packages/cli/commands/sandbox/create.js
+++ b/packages/cli/commands/sandbox/create.js
@@ -32,10 +32,8 @@ const {
 } = require('../../lib/prompts/sandboxesPrompt');
 const { promptUser } = require('../../lib/prompts/promptUtils');
 const { syncSandbox } = require('../../lib/sandbox-sync');
-const { logErrorInstance } = require('@hubspot/cli-lib/errorHandlers');
-const {
-  isMissingScopeError,
-} = require('@hubspot/cli-lib/errorHandlers/apiErrors');
+const { logErrorInstance } = require('../../lib/errorHandlers/standardErrors');
+const { isMissingScopeError } = require('../../lib/errorHandlers/apiErrors');
 const { getHubSpotWebsiteOrigin } = require('@hubspot/cli-lib/lib/urls');
 
 const i18nKey = 'cli.commands.sandbox.subcommands.create';

--- a/packages/cli/commands/sandbox/delete.js
+++ b/packages/cli/commands/sandbox/delete.js
@@ -9,9 +9,13 @@ const { logger } = require('@hubspot/cli-lib/logger');
 const { trackCommandUsage } = require('../../lib/usageTracking');
 const { loadAndValidateOptions } = require('../../lib/validation');
 const {
+  logErrorInstance,
   debugErrorAndContext,
-} = require('@hubspot/cli-lib/errorHandlers/standardErrors');
-const { logErrorInstance } = require('@hubspot/cli-lib/errorHandlers');
+} = require('../../lib/errorHandlers/standardErrors');
+const {
+  isSpecifiedError,
+  isSpecifiedHubSpotAuthError,
+} = require('../../lib/errorHandlers/apiErrors');
 const { deleteSandbox } = require('@hubspot/cli-lib/sandboxes');
 const { i18n } = require('../../lib/lang');
 const { getConfig, getEnv, getAccountConfig } = require('@hubspot/cli-lib');
@@ -26,10 +30,7 @@ const {
 const { EXIT_CODES } = require('../../lib/enums/exitCodes');
 const { promptUser } = require('../../lib/prompts/promptUtils');
 const { getHubSpotWebsiteOrigin } = require('@hubspot/cli-lib/lib/urls');
-const {
-  isSpecifiedError,
-  isSpecifiedHubSpotAuthError,
-} = require('@hubspot/cli-lib/errorHandlers/apiErrors');
+
 const { getAccountName } = require('../../lib/sandboxes');
 const { getValidEnv } = require('@hubspot/cli-lib/lib/environment');
 

--- a/packages/cli/commands/sandbox/sync.js
+++ b/packages/cli/commands/sandbox/sync.js
@@ -24,12 +24,8 @@ const {
 } = require('../../lib/sandboxes');
 const { syncSandbox } = require('../../lib/sandbox-sync');
 const { getValidEnv } = require('@hubspot/cli-lib/lib/environment');
-const {
-  isSpecifiedError,
-} = require('@hubspot/cli-lib/errorHandlers/apiErrors');
-const {
-  logErrorInstance,
-} = require('@hubspot/cli-lib/errorHandlers/standardErrors');
+const { isSpecifiedError } = require('../../lib/errorHandlers/apiErrors');
+const { logErrorInstance } = require('../../lib/errorHandlers/standardErrors');
 
 const i18nKey = 'cli.commands.sandbox.subcommands.sync';
 

--- a/packages/cli/commands/secrets/addSecret.js
+++ b/packages/cli/commands/secrets/addSecret.js
@@ -2,7 +2,7 @@ const { logger } = require('@hubspot/cli-lib/logger');
 const {
   logServerlessFunctionApiErrorInstance,
   ApiErrorContext,
-} = require('@hubspot/cli-lib/errorHandlers');
+} = require('../../lib/errorHandlers/apiErrors');
 const { addSecret } = require('@hubspot/cli-lib/api/secrets');
 
 const { loadAndValidateOptions } = require('../../lib/validation');

--- a/packages/cli/commands/secrets/deleteSecret.js
+++ b/packages/cli/commands/secrets/deleteSecret.js
@@ -2,7 +2,7 @@ const { logger } = require('@hubspot/cli-lib/logger');
 const {
   logServerlessFunctionApiErrorInstance,
   ApiErrorContext,
-} = require('@hubspot/cli-lib/errorHandlers');
+} = require('../../lib/errorHandlers/apiErrors');
 const { deleteSecret } = require('@hubspot/cli-lib/api/secrets');
 
 const { loadAndValidateOptions } = require('../../lib/validation');

--- a/packages/cli/commands/secrets/listSecrets.js
+++ b/packages/cli/commands/secrets/listSecrets.js
@@ -2,7 +2,7 @@ const { logger } = require('@hubspot/cli-lib/logger');
 const {
   logServerlessFunctionApiErrorInstance,
   ApiErrorContext,
-} = require('@hubspot/cli-lib/errorHandlers');
+} = require('../../lib/errorHandlers/apiErrors');
 const { fetchSecrets } = require('@hubspot/cli-lib/api/secrets');
 
 const { loadAndValidateOptions } = require('../../lib/validation');

--- a/packages/cli/commands/secrets/updateSecret.js
+++ b/packages/cli/commands/secrets/updateSecret.js
@@ -2,7 +2,7 @@ const { logger } = require('@hubspot/cli-lib/logger');
 const {
   logServerlessFunctionApiErrorInstance,
   ApiErrorContext,
-} = require('@hubspot/cli-lib/errorHandlers');
+} = require('../../lib/errorHandlers/apiErrors');
 const { updateSecret } = require('@hubspot/cli-lib/api/secrets');
 
 const { loadAndValidateOptions } = require('../../lib/validation');

--- a/packages/cli/commands/upload.js
+++ b/packages/cli/commands/upload.js
@@ -10,10 +10,10 @@ const {
 } = require('@hubspot/cli-lib/path');
 const { logger } = require('@hubspot/cli-lib/logger');
 const {
-  logErrorInstance,
   ApiErrorContext,
   logApiUploadErrorInstance,
-} = require('@hubspot/cli-lib/errorHandlers');
+} = require('../lib/errorHandlers/apiErrors');
+const { logErrorInstance } = require('../lib/errorHandlers/standardErrors');
 const { validateSrcAndDestPaths } = require('@hubspot/cli-lib/modules');
 const { shouldIgnoreFile } = require('@hubspot/cli-lib/ignoreRules');
 

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -1259,6 +1259,28 @@ en:
               label: "Lead Flows"
             marketing-email:
               label: "Marketing emails"
+      errorHandlers:
+        apiErrors:
+          messageDetail: "{{ request }} in account {{ accountId }}"
+          unableToUpload: 'Unable to upload "{{ payload }}.'
+          codes:
+            400: "The {{ messageDetail }} was bad."
+            401: "The {{ messageDetail }} was unauthorized."
+            403MissingScope: "Couldn't run the project command because there are scopes missing in your production account. To update scopes, deactivate your current personal access key for {{ accountId }}, and generate a new one. Then run `hs auth` to update the CLI with the new key."
+            403Gating: "The current target account {{ accountId }} does not have access to HubSpot projects. To opt in to the CRM Development Beta and use projects, visit https://app.hubspot.com/l/whats-new/betas?productUpdateId=13860216."
+            403: "The {{ messageDetail }} was forbidden."
+            404Request: 'The {{ action }} failed because "{{ request }}" was not found in account {{ accountId }}.'
+            404: "The {{ messageDetail }} was not found."
+            429: "The {{ messageDetail }} surpassed the rate limit. Retry in one minute."
+            503: "The {{ messageDetail }} could not be handled at this time. Please try again or visit https://help.hubspot.com/ to submit a ticket or contact HubSpot Support if the issue persists."
+            500generic: "The {{ messageDetail }} failed due to a server error. Please try again or visit https://help.hubspot.com/ to submit a ticket or contact HubSpot Support if the issue persists."
+            400generic: "The {{ messageDetail }} failed due to a client error."
+            generic: "The {{ messageDetail }} failed."
+          verifyAccessKeyAndUserAccess:
+            fetchScopeDataError: "Error verifying access of scopeGroup {{ scopeGroup }}: {{ error }}"
+            portalMissingScope: "Your account does not have access to this action. Talk to an account admin to request it."
+            userMissingScope: "You don't have access to this action. Ask an account admin to change your permissions in Users & Teams settings."
+            genericMissingScope: "Your access key does not allow this action. Please generate a new access key by running `hs auth personalaccesskey`."
 
 
 

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -1260,6 +1260,15 @@ en:
             marketing-email:
               label: "Marketing emails"
       errorHandlers:
+        standardErrors:
+          errorOccurred: "Error: {{ error }}"
+          errorContext: "Context: {{ context }}"
+          systemErrorOccurred: "A system error has occured: {{ errorMessage }}"
+          genericErrorOccured: "A {{ name }} has occurred."
+          unknownErrorOccured: "An unknown error has occured"
+        fileSystemErrors:
+          errorOccured: "An error occurred while {{ fileAction }} {{ filepath }}."
+          errorExplanation: "This is the result of a system error: {{ errorMessage }}"
         apiErrors:
           messageDetail: "{{ request }} in account {{ accountId }}"
           unableToUpload: 'Unable to upload "{{ payload }}.'

--- a/packages/cli/lib/errorHandlers/apiErrors.js
+++ b/packages/cli/lib/errorHandlers/apiErrors.js
@@ -1,0 +1,343 @@
+const { logger } = require('@hubspot/cli-lib/logger');
+const { getAccountConfig } = require('@hubspot/cli-lib/lib/config');
+const {
+  SCOPE_GROUPS,
+  PERSONAL_ACCESS_KEY_AUTH_METHOD,
+} = require('@hubspot/cli-lib/lib/constants');
+const {
+  fetchScopeData,
+} = require('@hubspot/cli-lib/api/localDevAuth/authenticated');
+const {
+  debugErrorAndContext,
+  logErrorInstance,
+  ErrorContext,
+} = require('./standardErrors');
+
+const isApiStatusCodeError = err =>
+  err.name === 'StatusCodeError' ||
+  (err.statusCode >= 100 && err.statusCode < 600);
+
+const isApiUploadValidationError = err =>
+  !!(
+    err.statusCode === 400 &&
+    err.response &&
+    err.response.body &&
+    (err.response.body.message || err.response.body.errors)
+  );
+
+const isMissingScopeError = err =>
+  err.name === 'StatusCodeError' &&
+  err.statusCode === 403 &&
+  err.error &&
+  err.error.category === 'MISSING_SCOPES';
+
+const isGatingError = err =>
+  isSpecifiedError(err, { statusCode: 403, category: 'GATED' });
+
+const isSpecifiedError = (err, { statusCode, category, subCategory } = {}) => {
+  const statusCodeErr = !statusCode || err.statusCode === statusCode;
+  const categoryErr =
+    !category || (err.error && err.error.category === category);
+  const subCategoryErr =
+    !subCategory || (err.error && err.error.subCategory === subCategory);
+
+  return (
+    err.name === 'StatusCodeError' &&
+    statusCodeErr &&
+    categoryErr &&
+    subCategoryErr
+  );
+};
+
+const isSpecifiedHubSpotAuthError = (
+  err,
+  { statusCode, category, subCategory }
+) => {
+  const statusCodeErr = !statusCode || err.statusCode === statusCode;
+  const categoryErr = !category || err.category === category;
+  const subCategoryErr = !subCategory || err.subCategory === subCategory;
+  return (
+    err.name === 'HubSpotAuthError' &&
+    statusCodeErr &&
+    categoryErr &&
+    subCategoryErr
+  );
+};
+
+const contactSupportString =
+  'Please try again or visit https://help.hubspot.com/ to submit a ticket or contact HubSpot Support if the issue persists.';
+
+const parseValidationErrors = (responseBody = {}) => {
+  const errorMessages = [];
+
+  const { errors, message } = responseBody;
+
+  if (message) {
+    errorMessages.push(message);
+  }
+
+  if (errors) {
+    const specificErrors = errors.map(error => {
+      let errorMessage = error.message;
+      if (error.errorTokens && error.errorTokens.line) {
+        errorMessage = `line ${error.errorTokens.line}: ${errorMessage}`;
+      }
+      return errorMessage;
+    });
+    errorMessages.push(...specificErrors);
+  }
+
+  return errorMessages;
+};
+
+class ApiErrorContext extends ErrorContext {
+  constructor(props = {}) {
+    super(props);
+    /** @type {string} */
+    this.request = props.request || '';
+    /** @type {string} */
+    this.payload = props.payload || '';
+    /** @type {string} */
+    this.projectName = props.projectName || '';
+  }
+}
+
+/**
+ * @param {Error}           error
+ * @param {ApiErrorContext} context
+ */
+function logValidationErrors(error, context) {
+  const { response = {} } = error;
+  const validationErrors = parseValidationErrors(response.body);
+  if (validationErrors.length) {
+    validationErrors.forEach(err => {
+      logger.error(err);
+    });
+  }
+  debugErrorAndContext(error, context);
+}
+
+/**
+ * Message segments for API messages.
+ *
+ * @enum {string}
+ */
+const ApiMethodVerbs = {
+  DEFAULT: 'request',
+  DELETE: 'delete',
+  GET: 'request',
+  PATCH: 'update',
+  POST: 'post',
+  PUT: 'update',
+};
+
+/**
+ * Message segments for API messages.
+ *
+ * @enum {string}
+ */
+const ApiMethodPrepositions = {
+  DEFAULT: 'for',
+  DELETE: 'of',
+  GET: 'for',
+  PATCH: 'to',
+  POST: 'to',
+  PUT: 'to',
+};
+
+/**
+ * Logs messages for an error instance resulting from API interaction.
+ *
+ * @param {StatusCodeError} error
+ * @param {ApiErrorContext} context
+ */
+function logApiStatusCodeError(error, context) {
+  const { statusCode } = error;
+  const { method } = error.options || {};
+  const { projectName } = context;
+  const isPutOrPost = method === 'PUT' || method === 'POST';
+  const action = ApiMethodVerbs[method] || ApiMethodVerbs.DEFAULT;
+  const preposition =
+    ApiMethodPrepositions[method] || ApiMethodPrepositions.DEFAULT;
+  let messageDetail = '';
+  {
+    const request = context.request
+      ? `${action} ${preposition} "${context.request}"`
+      : action;
+    messageDetail = `${request} in account ${context.accountId}`;
+  }
+  const errorMessage = [];
+  if (isPutOrPost && context.payload) {
+    errorMessage.push(`Unable to upload "${context.payload}".`);
+  }
+  const isProjectMissingScopeError = isMissingScopeError(error) && projectName;
+  const isProjectGatingError = isGatingError(error) && projectName;
+  switch (statusCode) {
+    case 400:
+      errorMessage.push(`The ${messageDetail} was bad.`);
+      break;
+    case 401:
+      errorMessage.push(`The ${messageDetail} was unauthorized.`);
+      break;
+    case 403:
+      if (isProjectMissingScopeError) {
+        errorMessage.push(
+          `Couldn't run the project command because there are scopes missing in your production account. To update scopes, deactivate your current personal access key for ${context.accountId}, and generate a new one. Then run \`hs auth\` to update the CLI with the new key.`
+        );
+      } else if (isProjectGatingError) {
+        errorMessage.push(
+          `The current target account ${context.accountId} does not have access to HubSpot projects. To opt in to the CRM Development Beta and use projects, visit https://app.hubspot.com/l/whats-new/betas?productUpdateId=13860216.`
+        );
+      } else {
+        errorMessage.push(`The ${messageDetail} was forbidden.`);
+      }
+      break;
+    case 404:
+      if (context.request) {
+        errorMessage.push(
+          `The ${action} failed because "${context.request}" was not found in account ${context.accountId}.`
+        );
+      } else {
+        errorMessage.push(`The ${messageDetail} was not found.`);
+      }
+      break;
+    case 429:
+      errorMessage.push(
+        `The ${messageDetail} surpassed the rate limit. Retry in one minute.`
+      );
+      break;
+    case 503:
+      errorMessage.push(
+        `The ${messageDetail} could not be handled at this time. ${contactSupportString}`
+      );
+      break;
+    default:
+      if (statusCode >= 500 && statusCode < 600) {
+        errorMessage.push(
+          `The ${messageDetail} failed due to a server error. ${contactSupportString}`
+        );
+      } else if (statusCode >= 400 && statusCode < 500) {
+        errorMessage.push(`The ${messageDetail} failed due to a client error.`);
+      } else {
+        errorMessage.push(`The ${messageDetail} failed.`);
+      }
+      break;
+  }
+  if (
+    error.error &&
+    error.error.message &&
+    !isProjectMissingScopeError &&
+    !isProjectGatingError
+  ) {
+    errorMessage.push(error.error.message);
+  }
+  if (error.error && error.error.errors) {
+    error.error.errors.forEach(err => {
+      errorMessage.push('\n- ' + err.message);
+    });
+  }
+  logger.error(errorMessage.join(' '));
+  debugErrorAndContext(error, context);
+}
+
+/**
+ * Logs a message for an error instance resulting from API interaction.
+ *
+ * @param {Error|SystemError|Object} error
+ * @param {ApiErrorContext}          context
+ */
+function logApiErrorInstance(error, context) {
+  // StatusCodeError
+  if (isApiStatusCodeError(error)) {
+    logApiStatusCodeError(error, context);
+    return;
+  }
+  logErrorInstance(error, context);
+}
+
+/**
+ * Logs a message for an error instance resulting from filemapper API upload.
+ *
+ * @param {Error|SystemError|Object} error
+ * @param {ApiErrorContext}          context
+ */
+function logApiUploadErrorInstance(error, context) {
+  if (isApiUploadValidationError(error)) {
+    logValidationErrors(error, context);
+    return;
+  }
+  logApiErrorInstance(error, context);
+}
+
+async function verifyAccessKeyAndUserAccess(accountId, scopeGroup) {
+  const accountConfig = getAccountConfig(accountId);
+  const { authType } = accountConfig;
+  if (authType !== PERSONAL_ACCESS_KEY_AUTH_METHOD.value) {
+    return;
+  }
+
+  let scopesData;
+  try {
+    scopesData = await fetchScopeData(accountId, scopeGroup);
+  } catch (e) {
+    logger.debug(`Error verifying access of scopeGroup ${scopeGroup}: ${e}`);
+    return;
+  }
+  const { portalScopesInGroup, userScopesInGroup } = scopesData;
+
+  if (!portalScopesInGroup.length) {
+    logger.error(
+      'Your account does not have access to this action. Talk to an account admin to request it.'
+    );
+    return;
+  }
+
+  if (!portalScopesInGroup.every(s => userScopesInGroup.includes(s))) {
+    logger.error(
+      "You don't have access to this action. Ask an account admin to change your permissions in Users & Teams settings."
+    );
+    return;
+  } else {
+    logger.error(
+      'Your access key does not allow this action. Please generate a new access key by running "hs auth personalaccesskey".'
+    );
+    return;
+  }
+}
+
+/**
+ * Logs a message for an error instance resulting from API interaction
+ * related to serverless function.
+ *
+ * @param {int} accountId
+ * @param {Error|SystemError|Object} error
+ * @param {ApiErrorContext}          context
+ */
+async function logServerlessFunctionApiErrorInstance(
+  accountId,
+  error,
+  context
+) {
+  if (isMissingScopeError(error)) {
+    await verifyAccessKeyAndUserAccess(accountId, SCOPE_GROUPS.functions);
+    return;
+  }
+
+  // StatusCodeError
+  if (isApiStatusCodeError(error)) {
+    logApiStatusCodeError(error, context);
+    return;
+  }
+  logErrorInstance(error, context);
+}
+
+module.exports = {
+  ApiErrorContext,
+  parseValidationErrors,
+  logApiErrorInstance,
+  logApiUploadErrorInstance,
+  logServerlessFunctionApiErrorInstance,
+  isMissingScopeError,
+  isSpecifiedError,
+  isSpecifiedHubSpotAuthError,
+};

--- a/packages/cli/lib/errorHandlers/fileSystemErrors.js
+++ b/packages/cli/lib/errorHandlers/fileSystemErrors.js
@@ -4,6 +4,9 @@ const {
   isSystemError,
   debugErrorAndContext,
 } = require('./standardErrors');
+const { i18n } = require('../lang');
+
+const i18nKey = 'cli.lib.errorHandlers.fileSystemErrors';
 
 class FileSystemErrorContext extends ErrorContext {
   constructor(props = {}) {
@@ -35,10 +38,12 @@ function logFileSystemErrorInstance(error, context) {
   const filepath = context.filepath
     ? `"${context.filepath}"`
     : 'a file or folder';
-  const message = [`An error occurred while ${fileAction} ${filepath}.`];
+  const message = [i18n(`${i18nKey}.errorOccured`, { fileAction, filepath })];
   // Many `fs` errors will be `SystemError`s
   if (isSystemError(error)) {
-    message.push(`This is the result of a system error: ${error.message}`);
+    message.push(
+      i18n(`${i18nKey}.errorExplanation`, { errorMessage: error.message })
+    );
   }
   logger.error(message.join(' '));
   debugErrorAndContext(error, context);

--- a/packages/cli/lib/errorHandlers/fileSystemErrors.js
+++ b/packages/cli/lib/errorHandlers/fileSystemErrors.js
@@ -1,0 +1,50 @@
+const { logger } = require('@hubspot/cli-lib/logger');
+const {
+  ErrorContext,
+  isSystemError,
+  debugErrorAndContext,
+} = require('./standardErrors');
+
+class FileSystemErrorContext extends ErrorContext {
+  constructor(props = {}) {
+    super(props);
+    /** @type {string} */
+    this.filepath = props.filepath || '';
+    /** @type {boolean} */
+    this.read = !!props.read;
+    /** @type {boolean} */
+    this.write = !!props.write;
+  }
+}
+
+/**
+ * Logs a message for an error instance resulting from filesystem interaction.
+ *
+ * @param {Error|SystemError|Object} error
+ * @param {FileSystemErrorContext}   context
+ */
+function logFileSystemErrorInstance(error, context) {
+  let fileAction = '';
+  if (context.read) {
+    fileAction = 'reading from';
+  } else if (context.write) {
+    fileAction = 'writing to';
+  } else {
+    fileAction = 'accessing';
+  }
+  const filepath = context.filepath
+    ? `"${context.filepath}"`
+    : 'a file or folder';
+  const message = [`An error occurred while ${fileAction} ${filepath}.`];
+  // Many `fs` errors will be `SystemError`s
+  if (isSystemError(error)) {
+    message.push(`This is the result of a system error: ${error.message}`);
+  }
+  logger.error(message.join(' '));
+  debugErrorAndContext(error, context);
+}
+
+module.exports = {
+  FileSystemErrorContext,
+  logFileSystemErrorInstance,
+};

--- a/packages/cli/lib/errorHandlers/standardErrors.js
+++ b/packages/cli/lib/errorHandlers/standardErrors.js
@@ -70,9 +70,8 @@ function logErrorInstance(error, context) {
   if (error instanceof Error || error.message || error.reason) {
     // Error or Error subclass
     const name = error.name || 'Error';
-    const message = i18n(`${i18nKey}.genericErrorOcurred`, { name })[
-      (error.message, error.reason)
-    ].forEach(msg => {
+    const message = i18n(`${i18nKey}.genericErrorOcurred`, { name });
+    [(error.message, error.reason)].forEach(msg => {
       if (msg) {
         message.push(msg);
       }

--- a/packages/cli/lib/errorHandlers/standardErrors.js
+++ b/packages/cli/lib/errorHandlers/standardErrors.js
@@ -1,0 +1,86 @@
+const { HubSpotAuthError } = require('@hubspot/cli-lib/lib/models/Errors');
+const { logger } = require('@hubspot/cli-lib/logger');
+
+const isSystemError = err =>
+  err.errno != null && err.code != null && err.syscall != null;
+const isFatalError = err => err instanceof HubSpotAuthError;
+
+// TODO: Make these TS interfaces
+class ErrorContext {
+  constructor(props = {}) {
+    /** @type {number} */
+    this.accountId = props.accountId;
+  }
+}
+
+/**
+ * Logs (debug) the error and context objects.
+ *
+ * @param {SystemError}  error
+ * @param {ErrorContext} context
+ */
+function debugErrorAndContext(error, context) {
+  if (error.name === 'StatusCodeError') {
+    const { statusCode, message, response } = error;
+    logger.debug('Error: %o', {
+      statusCode,
+      message,
+      url: response.request.href,
+      method: response.request.method,
+      response: response.body,
+      headers: response.headers,
+    });
+  } else {
+    logger.debug('Error: %o', error);
+  }
+  logger.debug('Context: %o', context);
+}
+
+/**
+ * Logs a SystemError
+ * @see {@link https://nodejs.org/api/errors.html#errors_class_systemerror}
+ *
+ * @param {SystemError}  error
+ * @param {ErrorContext} context
+ */
+function logSystemError(error, context) {
+  logger.error(`A system error has occurred: ${error.message}`);
+  debugErrorAndContext(error, context);
+}
+
+/**
+ * Logs a message for an error instance of type not asserted.
+ *
+ * @param {Error|SystemError|Object} error
+ * @param {ErrorContext}             context
+ */
+function logErrorInstance(error, context) {
+  // SystemError
+  if (isSystemError(error)) {
+    logSystemError(error, context);
+    return;
+  }
+  if (error instanceof Error || error.message || error.reason) {
+    // Error or Error subclass
+    const name = error.name || 'Error';
+    const message = [`A ${name} has occurred.`];
+    [error.message, error.reason].forEach(msg => {
+      if (msg) {
+        message.push(msg);
+      }
+    });
+    logger.error(message.join(' '));
+  } else {
+    // Unknown errors
+    logger.error(`An unknown error has occurred.`);
+  }
+  debugErrorAndContext(error, context);
+}
+
+module.exports = {
+  debugErrorAndContext,
+  ErrorContext,
+  isFatalError,
+  isSystemError,
+  logErrorInstance,
+};

--- a/packages/cli/lib/errorHandlers/standardErrors.js
+++ b/packages/cli/lib/errorHandlers/standardErrors.js
@@ -70,7 +70,7 @@ function logErrorInstance(error, context) {
   if (error instanceof Error || error.message || error.reason) {
     // Error or Error subclass
     const name = error.name || 'Error';
-    const message = i18n(`${i18nKey}.genericErrorOcurred`, { name });
+    const message = [i18n(`${i18nKey}.genericErrorOccured`, { name })];
     [(error.message, error.reason)].forEach(msg => {
       if (msg) {
         message.push(msg);
@@ -79,7 +79,7 @@ function logErrorInstance(error, context) {
     logger.error(message.join(' '));
   } else {
     // Unknown errors
-    logger.error(i18n(`${i18nKey}.unknownErrorOcurred`));
+    logger.error(i18n(`${i18nKey}.unknownErrorOccured`));
   }
   debugErrorAndContext(error, context);
 }

--- a/packages/cli/lib/errorHandlers/standardErrors.js
+++ b/packages/cli/lib/errorHandlers/standardErrors.js
@@ -1,5 +1,8 @@
 const { HubSpotAuthError } = require('@hubspot/cli-lib/lib/models/Errors');
 const { logger } = require('@hubspot/cli-lib/logger');
+const { i18n } = require('../lang');
+
+const i18nKey = 'cli.lib.errorHandlers.standardErrors';
 
 const isSystemError = err =>
   err.errno != null && err.code != null && err.syscall != null;
@@ -22,18 +25,22 @@ class ErrorContext {
 function debugErrorAndContext(error, context) {
   if (error.name === 'StatusCodeError') {
     const { statusCode, message, response } = error;
-    logger.debug('Error: %o', {
-      statusCode,
-      message,
-      url: response.request.href,
-      method: response.request.method,
-      response: response.body,
-      headers: response.headers,
-    });
+    logger.debug(
+      i18n(`${i18nKey}.errorOccured`, {
+        error: {
+          statusCode,
+          message,
+          url: response.request.href,
+          method: response.request.method,
+          response: response.body,
+          headers: response.headers,
+        },
+      })
+    );
   } else {
-    logger.debug('Error: %o', error);
+    logger.debug(i18n(`${i18nKey}.errorOccured`, { error }));
   }
-  logger.debug('Context: %o', context);
+  logger.debug(i18n(`${i18nKey}.errorContect`, { context }));
 }
 
 /**
@@ -44,7 +51,7 @@ function debugErrorAndContext(error, context) {
  * @param {ErrorContext} context
  */
 function logSystemError(error, context) {
-  logger.error(`A system error has occurred: ${error.message}`);
+  logger.error(i18n(`${i18nKey}.systemErrorOccured`, { error: error.message }));
   debugErrorAndContext(error, context);
 }
 
@@ -63,8 +70,9 @@ function logErrorInstance(error, context) {
   if (error instanceof Error || error.message || error.reason) {
     // Error or Error subclass
     const name = error.name || 'Error';
-    const message = [`A ${name} has occurred.`];
-    [error.message, error.reason].forEach(msg => {
+    const message = i18n(`${i18nKey}.genericErrorOcurred`, { name })[
+      (error.message, error.reason)
+    ].forEach(msg => {
       if (msg) {
         message.push(msg);
       }
@@ -72,7 +80,7 @@ function logErrorInstance(error, context) {
     logger.error(message.join(' '));
   } else {
     // Unknown errors
-    logger.error(`An unknown error has occurred.`);
+    logger.error(i18n(`${i18nKey}.unknownErrorOcurred`));
   }
   debugErrorAndContext(error, context);
 }

--- a/packages/cli/lib/projects.js
+++ b/packages/cli/lib/projects.js
@@ -29,10 +29,6 @@ const {
   fetchProject,
   uploadProject,
 } = require('@hubspot/cli-lib/api/dfs');
-const {
-  logApiErrorInstance,
-  ApiErrorContext,
-} = require('@hubspot/cli-lib/errorHandlers');
 const { shouldIgnoreFile } = require('@hubspot/cli-lib/ignoreRules');
 const { getCwd, getAbsoluteFilePath } = require('@hubspot/cli-lib/path');
 const { downloadGitHubRepoContents } = require('@hubspot/cli-lib/github');
@@ -42,9 +38,11 @@ const { uiLine, uiLink, uiAccountDescription } = require('../lib/ui');
 const { i18n } = require('./lang');
 const SpinniesManager = require('./SpinniesManager');
 const {
+  logApiErrorInstance,
+  ApiErrorContext,
   isSpecifiedError,
   isSpecifiedHubSpotAuthError,
-} = require('@hubspot/cli-lib/errorHandlers/apiErrors');
+} = require('./errorHandlers/apiErrors');
 const { HUBSPOT_PROJECT_COMPONENTS_GITHUB_PATH } = require('./constants');
 
 const i18nKey = 'cli.lib.projects';

--- a/packages/cli/lib/projectsWatch.js
+++ b/packages/cli/lib/projectsWatch.js
@@ -5,7 +5,7 @@ const { default: PQueue } = require('p-queue');
 const {
   logApiErrorInstance,
   ApiErrorContext,
-} = require('@hubspot/cli-lib/errorHandlers');
+} = require('./errorHandlers/apiErrors');
 const { i18n } = require('@hubspot/cli-lib/lib/lang');
 const { logger } = require('@hubspot/cli-lib/logger');
 const { isAllowedExtension } = require('@hubspot/cli-lib/path');

--- a/packages/cli/lib/prompts/downloadProjectPrompt.js
+++ b/packages/cli/lib/prompts/downloadProjectPrompt.js
@@ -4,7 +4,7 @@ const { fetchProjects } = require('@hubspot/cli-lib/api/dfs');
 const {
   logApiErrorInstance,
   ApiErrorContext,
-} = require('@hubspot/cli-lib/errorHandlers');
+} = require('../../lib/errorHandlers/apiErrors');
 const { EXIT_CODES } = require('../enums/exitCodes');
 const { i18n } = require('../lang');
 

--- a/packages/cli/lib/prompts/projectsLogsPrompt.js
+++ b/packages/cli/lib/prompts/projectsLogsPrompt.js
@@ -6,7 +6,7 @@ const { getProjectConfig, ensureProjectExists } = require('../projects');
 const {
   logApiErrorInstance,
   ApiErrorContext,
-} = require('@hubspot/cli-lib/errorHandlers');
+} = require('../../lib/errorHandlers/apiErrors');
 const { logger } = require('@hubspot/cli-lib/logger');
 const { EXIT_CODES } = require('../enums/exitCodes');
 

--- a/packages/cli/lib/sandbox-create.js
+++ b/packages/cli/lib/sandbox-create.js
@@ -12,11 +12,11 @@ const { logger } = require('@hubspot/cli-lib/logger');
 const {
   debugErrorAndContext,
   logErrorInstance,
-} = require('@hubspot/cli-lib/errorHandlers/standardErrors');
+} = require('./errorHandlers/standardErrors');
 const {
   isMissingScopeError,
   isSpecifiedError,
-} = require('@hubspot/cli-lib/errorHandlers/apiErrors');
+} = require('./errorHandlers/apiErrors');
 const { getHubSpotWebsiteOrigin } = require('@hubspot/cli-lib/lib/urls');
 const { getEnv, getAccountId } = require('@hubspot/cli-lib');
 const { createSandbox } = require('@hubspot/cli-lib/sandboxes');

--- a/packages/cli/lib/sandbox-sync.js
+++ b/packages/cli/lib/sandbox-sync.js
@@ -11,17 +11,17 @@ const {
   syncTypes,
 } = require('./sandboxes');
 const { initiateSync } = require('@hubspot/cli-lib/sandboxes');
-const { logErrorInstance } = require('@hubspot/cli-lib/errorHandlers');
+const {
+  debugErrorAndContext,
+  logErrorInstance,
+} = require('./errorHandlers/standardErrors');
 const {
   isSpecifiedError,
   isMissingScopeError,
-} = require('@hubspot/cli-lib/errorHandlers/apiErrors');
+} = require('./errorHandlers/apiErrors');
 const { getSandboxTypeAsString } = require('./sandboxes');
 const { getAccountId } = require('@hubspot/cli-lib');
 const { uiAccountDescription } = require('./ui');
-const {
-  debugErrorAndContext,
-} = require('@hubspot/cli-lib/errorHandlers/standardErrors');
 
 const i18nKey = 'cli.lib.sandbox.sync';
 

--- a/packages/cli/lib/serverlessLogs.js
+++ b/packages/cli/lib/serverlessLogs.js
@@ -8,7 +8,7 @@ const {
   logServerlessFunctionApiErrorInstance,
   logApiErrorInstance,
   ApiErrorContext,
-} = require('@hubspot/cli-lib/errorHandlers');
+} = require('./errorHandlers/apiErrors');
 const { base64EncodeString } = require('@hubspot/cli-lib/lib/encoding');
 
 const { EXIT_CODES } = require('../lib/enums/exitCodes');

--- a/packages/serverless-dev-runtime/lib/server.js
+++ b/packages/serverless-dev-runtime/lib/server.js
@@ -4,9 +4,6 @@ const cors = require('cors');
 const chalk = require('chalk');
 const { logger, setLogLevel, LOG_LEVEL } = require('@hubspot/cli-lib/logger');
 const {
-  logErrorInstance,
-} = require('@hubspot/cli-lib/errorHandlers/standardErrors');
-const {
   getTableContents,
   getTableHeader,
 } = require('@hubspot/cli-lib/lib/table');
@@ -181,7 +178,9 @@ const startServer = async callback => {
       },
     };
   } catch (e) {
-    logErrorInstance(e, {
+    logger.error(`A system error has occurred: ${e.message}`);
+    logger.debug(e);
+    logger.debug({
       port,
       accountId,
       functionPath,


### PR DESCRIPTION
## Description and Context
See https://git.hubteam.com/HubSpot/hubspot-cli-issues/issues/481

The CLI uses these `errorHandler` utils to log errors in a user friendly fashion. Since they are interface related, we're moving them from `cli-lib` to the CLI. There is one instance in `webpack-cms-plugins` where I had to copy some stuff over, but don't think that one spot is worth keeping these in `cli-lib` for.

## Who to Notify
@brandenrodgers 
