### PR TITLE
Add sample projects link to hs project create

### DIFF
--- a/packages/cli/commands/project/create.js
+++ b/packages/cli/commands/project/create.js
@@ -67,6 +67,7 @@ exports.handler = async options => {
     'projectDevCommand',
     'projectHelpCommand',
     'feedbackCommand',
+    'sampleProjects',
   ]);
 };
 

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -994,6 +994,10 @@ en:
             sandboxSyncStandardCommand:
               command: "hs sandbox sync"
               message: "Run {{ command }} to to update all supported assets to your sandbox from production"
+            sampleProjects:
+              linkText: "HubSpot's sample projects"
+              url: "https://developers.hubspot.com/docs/platform/sample-projects?utm_source=cli&utm_content=project_create_whats_next"
+              message: "See {{ link }}"
       commonOpts:
         options:
           portal:

--- a/packages/cli/lib/ui.js
+++ b/packages/cli/lib/ui.js
@@ -106,6 +106,7 @@ const uiFeatureHighlight = (commands, title) => {
       const commandKey = `${i18nKey}.commandKeys.${c}`;
       const message = i18n(`${commandKey}.message`, {
         command: uiCommandReference(i18n(`${commandKey}.command`)),
+        link: uiLink(i18n(`${commandKey}.linkText`), i18n(`${commandKey}.url`)),
       });
       if (i !== 0) {
         logger.log('');


### PR DESCRIPTION
## Description and Context
See https://git.hubteam.com/HubSpot/hubspot-cli-issues/issues/478
This adds a link to the sample projects page in our doc to the "What's next" section shown after running `hs project create`

## Screenshots
<img width="590" alt="Screenshot 2023-10-23 at 2 26 00 PM" src="https://github.com/HubSpot/hubspot-cli/assets/10413161/1b5e2046-a66e-43e0-8cd3-922da0df82ca">


## Who to Notify
@brandenrodgers @markhazlewood
