### PR TITLE
Fix error message lang errors

### DIFF
--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -1267,11 +1267,11 @@ en:
         standardErrors:
           errorOccurred: "Error: {{ error }}"
           errorContext: "Context: {{ context }}"
-          systemErrorOccurred: "A system error has occured: {{ errorMessage }}"
-          genericErrorOccured: "A {{ name }} has occurred."
-          unknownErrorOccured: "An unknown error has occured"
+          systemErrorOccurred: "A system error has occurred: {{ errorMessage }}"
+          genericErrorOccurred: "A {{ name }} has occurred."
+          unknownErrorOccurred: "An unknown error has occurred"
         fileSystemErrors:
-          errorOccured: "An error occurred while {{ fileAction }} {{ filepath }}."
+          errorOccurred: "An error occurred while {{ fileAction }} {{ filepath }}."
           errorExplanation: "This is the result of a system error: {{ errorMessage }}"
         apiErrors:
           messageDetail: "{{ request }} in account {{ accountId }}"

--- a/packages/cli/lib/errorHandlers/fileSystemErrors.js
+++ b/packages/cli/lib/errorHandlers/fileSystemErrors.js
@@ -38,7 +38,7 @@ function logFileSystemErrorInstance(error, context) {
   const filepath = context.filepath
     ? `"${context.filepath}"`
     : 'a file or folder';
-  const message = [i18n(`${i18nKey}.errorOccured`, { fileAction, filepath })];
+  const message = [i18n(`${i18nKey}.errorOccurred`, { fileAction, filepath })];
   // Many `fs` errors will be `SystemError`s
   if (isSystemError(error)) {
     message.push(

--- a/packages/cli/lib/errorHandlers/standardErrors.js
+++ b/packages/cli/lib/errorHandlers/standardErrors.js
@@ -26,7 +26,7 @@ function debugErrorAndContext(error, context) {
   if (error.name === 'StatusCodeError') {
     const { statusCode, message, response } = error;
     logger.debug(
-      i18n(`${i18nKey}.errorOccured`, {
+      i18n(`${i18nKey}.errorOccurred`, {
         error: {
           statusCode,
           message,
@@ -38,9 +38,9 @@ function debugErrorAndContext(error, context) {
       })
     );
   } else {
-    logger.debug(i18n(`${i18nKey}.errorOccured`, { error }));
+    logger.debug(i18n(`${i18nKey}.errorOccurred`, { error }));
   }
-  logger.debug(i18n(`${i18nKey}.errorContect`, { context }));
+  logger.debug(i18n(`${i18nKey}.errorContext`, { context }));
 }
 
 /**
@@ -51,7 +51,9 @@ function debugErrorAndContext(error, context) {
  * @param {ErrorContext} context
  */
 function logSystemError(error, context) {
-  logger.error(i18n(`${i18nKey}.systemErrorOccured`, { error: error.message }));
+  logger.error(
+    i18n(`${i18nKey}.systemErrorOccurred`, { error: error.message })
+  );
   debugErrorAndContext(error, context);
 }
 
@@ -70,7 +72,7 @@ function logErrorInstance(error, context) {
   if (error instanceof Error || error.message || error.reason) {
     // Error or Error subclass
     const name = error.name || 'Error';
-    const message = [i18n(`${i18nKey}.genericErrorOccured`, { name })];
+    const message = [i18n(`${i18nKey}.genericErrorOccurred`, { name })];
     [(error.message, error.reason)].forEach(msg => {
       if (msg) {
         message.push(msg);
@@ -79,7 +81,7 @@ function logErrorInstance(error, context) {
     logger.error(message.join(' '));
   } else {
     // Unknown errors
-    logger.error(i18n(`${i18nKey}.unknownErrorOccured`));
+    logger.error(i18n(`${i18nKey}.unknownErrorOccurred`));
   }
   debugErrorAndContext(error, context);
 }


### PR DESCRIPTION
## Description and Context
I'm not proud that I have to make this PR but apparently I spelled "occurred" wrong in 11 different places (and also through in a "contect" for good measure) when porting over the error handlers from cli-lib. This was preventing error context from being logged to the CLI

## Who to Notify
@brandenrodgers 
