### PR TITLE
Swap cli lib deps 2

### DIFF
--- a/packages/cli/commands/cms/convertFields.js
+++ b/packages/cli/commands/cms/convertFields.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const fs = require('fs');
-const { createIgnoreFilter } = require('@hubspot/cli-lib/ignoreRules');
+const { createIgnoreFilter } = require('@hubspot/local-dev-lib/ignoreRules');
 const { isAllowedExtension, getCwd } = require('@hubspot/cli-lib/path');
 const { logger } = require('@hubspot/cli-lib/logger');
 const { walk } = require('@hubspot/cli-lib/lib/walk');

--- a/packages/cli/commands/filemanager/upload.js
+++ b/packages/cli/commands/filemanager/upload.js
@@ -11,7 +11,7 @@ const {
 } = require('../../lib/errorHandlers/apiErrors');
 const { logErrorInstance } = require('../../lib/errorHandlers/standardErrors');
 const { validateSrcAndDestPaths } = require('@hubspot/cli-lib/modules');
-const { shouldIgnoreFile } = require('@hubspot/cli-lib/ignoreRules');
+const { shouldIgnoreFile } = require('@hubspot/local-dev-lib/ignoreRules');
 
 const {
   addConfigOptions,

--- a/packages/cli/commands/lint.js
+++ b/packages/cli/commands/lint.js
@@ -1,4 +1,4 @@
-const { lint } = require('@hubspot/cli-lib/validate');
+const { lint } = require('@hubspot/local-dev-lib/validate');
 const { printHublValidationResult } = require('../lib/hublValidate');
 const { logger } = require('@hubspot/cli-lib/logger');
 const { logErrorInstance } = require('../lib/errorHandlers/standardErrors');

--- a/packages/cli/commands/project/dev.js
+++ b/packages/cli/commands/project/dev.js
@@ -47,7 +47,7 @@ const {
   DEVELOPER_SANDBOX,
   getAvailableSyncTypes,
 } = require('../../lib/sandboxes');
-const { getValidEnv } = require('@hubspot/cli-lib/lib/environment');
+const { getValidEnv } = require('@hubspot/local-dev-lib/environment');
 const {
   PROJECT_BUILD_TEXT,
   PROJECT_DEPLOY_TEXT,

--- a/packages/cli/commands/sandbox/create.js
+++ b/packages/cli/commands/sandbox/create.js
@@ -20,7 +20,7 @@ const {
   syncTypes,
   validateSandboxUsageLimits,
 } = require('../../lib/sandboxes');
-const { getValidEnv } = require('@hubspot/cli-lib/lib/environment');
+const { getValidEnv } = require('@hubspot/local-dev-lib/environment');
 const { logger } = require('@hubspot/cli-lib/logger');
 const {
   trackCommandUsage,

--- a/packages/cli/commands/sandbox/delete.js
+++ b/packages/cli/commands/sandbox/delete.js
@@ -34,7 +34,7 @@ const { promptUser } = require('../../lib/prompts/promptUtils');
 const { getHubSpotWebsiteOrigin } = require('@hubspot/cli-lib/lib/urls');
 
 const { getAccountName } = require('../../lib/sandboxes');
-const { getValidEnv } = require('@hubspot/cli-lib/lib/environment');
+const { getValidEnv } = require('@hubspot/local-dev-lib/environment');
 
 const i18nKey = 'cli.commands.sandbox.subcommands.delete';
 

--- a/packages/cli/commands/sandbox/sync.js
+++ b/packages/cli/commands/sandbox/sync.js
@@ -23,7 +23,7 @@ const {
   getSyncTypesWithContactRecordsPrompt,
 } = require('../../lib/sandboxes');
 const { syncSandbox } = require('../../lib/sandbox-sync');
-const { getValidEnv } = require('@hubspot/cli-lib/lib/environment');
+const { getValidEnv } = require('@hubspot/local-dev-lib/environment');
 const { isSpecifiedError } = require('../../lib/errorHandlers/apiErrors');
 const { logErrorInstance } = require('../../lib/errorHandlers/standardErrors');
 

--- a/packages/cli/commands/upload.js
+++ b/packages/cli/commands/upload.js
@@ -15,7 +15,7 @@ const {
 } = require('../lib/errorHandlers/apiErrors');
 const { logErrorInstance } = require('../lib/errorHandlers/standardErrors');
 const { validateSrcAndDestPaths } = require('@hubspot/cli-lib/modules');
-const { shouldIgnoreFile } = require('@hubspot/cli-lib/ignoreRules');
+const { shouldIgnoreFile } = require('@hubspot/local-dev-lib/ignoreRules');
 
 const {
   addConfigOptions,

--- a/packages/cli/lib/projects.js
+++ b/packages/cli/lib/projects.js
@@ -29,7 +29,7 @@ const {
   fetchProject,
   uploadProject,
 } = require('@hubspot/cli-lib/api/dfs');
-const { shouldIgnoreFile } = require('@hubspot/cli-lib/ignoreRules');
+const { shouldIgnoreFile } = require('@hubspot/local-dev-lib/ignoreRules');
 const { getCwd, getAbsoluteFilePath } = require('@hubspot/cli-lib/path');
 const { downloadGitHubRepoContents } = require('@hubspot/cli-lib/github');
 const { promptUser } = require('./prompts/promptUtils');

--- a/packages/cli/lib/projectsWatch.js
+++ b/packages/cli/lib/projectsWatch.js
@@ -9,7 +9,7 @@ const {
 const { i18n } = require('@hubspot/cli-lib/lib/lang');
 const { logger } = require('@hubspot/cli-lib/logger');
 const { isAllowedExtension } = require('@hubspot/cli-lib/path');
-const { shouldIgnoreFile } = require('@hubspot/cli-lib/ignoreRules');
+const { shouldIgnoreFile } = require('@hubspot/local-dev-lib/ignoreRules');
 const {
   cancelStagedBuild,
   provisionBuild,

--- a/packages/cli/lib/sandbox-create.js
+++ b/packages/cli/lib/sandbox-create.js
@@ -20,7 +20,7 @@ const {
 const { getHubSpotWebsiteOrigin } = require('@hubspot/cli-lib/lib/urls');
 const { getEnv, getAccountId } = require('@hubspot/local-dev-lib/config');
 const { createSandbox } = require('@hubspot/cli-lib/sandboxes');
-const { getValidEnv } = require('@hubspot/cli-lib/lib/environment');
+const { getValidEnv } = require('@hubspot/local-dev-lib/environment');
 
 const i18nKey = 'cli.lib.sandbox.create';
 

--- a/packages/cli/lib/upload.js
+++ b/packages/cli/lib/upload.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const { walk } = require('@hubspot/cli-lib/lib/walk');
-const { createIgnoreFilter } = require('@hubspot/cli-lib/ignoreRules');
+const { createIgnoreFilter } = require('@hubspot/local-dev-lib/ignoreRules');
 const { fieldsJsPrompt } = require('../lib/prompts/cmsFieldPrompt');
 const { isAllowedExtension } = require('@hubspot/cli-lib/path');
 const { isConvertableFieldJs } = require('@hubspot/cli-lib/lib/handleFieldsJs');

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@hubspot/cli-lib": "^6.0.0",
-    "@hubspot/local-dev-lib": "^0.0.7",
+    "@hubspot/local-dev-lib": "^0.0.8",
     "@hubspot/serverless-dev-runtime": "5.0.2",
     "@hubspot/ui-extensions-dev-server": "^0.8.0",
     "archiver": "^5.3.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/HubSpot/hubspot-cms-tools"
   },
   "dependencies": {
-    "@hubspot/cli-lib": "^6.0.0",
+    "@hubspot/cli-lib": "^7.0.0",
     "@hubspot/local-dev-lib": "^0.0.8",
     "@hubspot/serverless-dev-runtime": "5.0.2",
     "@hubspot/ui-extensions-dev-server": "^0.8.0",

--- a/packages/serverless-dev-runtime/package.json
+++ b/packages/serverless-dev-runtime/package.json
@@ -7,7 +7,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@hubspot/cli-lib": "^6.0.0",
-    "@hubspot/local-dev-lib": "^0.0.7",
+    "@hubspot/local-dev-lib": "^0.0.8",
     "body-parser": "^1.19.0",
     "chalk": "^4.1.0",
     "chokidar": "^3.4.3",

--- a/packages/serverless-dev-runtime/package.json
+++ b/packages/serverless-dev-runtime/package.json
@@ -6,7 +6,7 @@
   "repository": "https://github.com/HubSpot/hubspot-cli",
   "license": "Apache-2.0",
   "dependencies": {
-    "@hubspot/cli-lib": "^6.0.0",
+    "@hubspot/cli-lib": "^7.0.0",
     "@hubspot/local-dev-lib": "^0.0.8",
     "body-parser": "^1.19.0",
     "chalk": "^4.1.0",

--- a/packages/webpack-cms-plugins/package.json
+++ b/packages/webpack-cms-plugins/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@hubspot/cli-lib": "^6.0.0",
-    "@hubspot/local-dev-lib": "^0.0.7"
+    "@hubspot/local-dev-lib": "^0.0.8"
   },
   "gitHead": "0659fd19cabc3645af431b177c11d0c1b089e0f8"
 }

--- a/packages/webpack-cms-plugins/package.json
+++ b/packages/webpack-cms-plugins/package.json
@@ -17,7 +17,7 @@
     "test": "echo \"Error: run tests from root\" && exit 1"
   },
   "dependencies": {
-    "@hubspot/cli-lib": "^6.0.0",
+    "@hubspot/cli-lib": "^7.0.0",
     "@hubspot/local-dev-lib": "^0.0.8"
   },
   "gitHead": "0659fd19cabc3645af431b177c11d0c1b089e0f8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -538,10 +538,30 @@
     table "^6.6.0"
     unixify "1.0.0"
 
-"@hubspot/local-dev-lib@0.0.7", "@hubspot/local-dev-lib@^0.0.7":
+"@hubspot/local-dev-lib@0.0.7":
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/@hubspot/local-dev-lib/-/local-dev-lib-0.0.7.tgz#039d27dcbac71132dea7dd379b3245a7c5ace1b1"
   integrity sha512-wKWK3aT1yX54Q40ow+IvXUVY7yworav+fjFURSFFkqND2EvlijuCeeGObgx4xfYZRjYa+Sv56Sn6mFKZjdgQSQ==
+  dependencies:
+    axios "^1.3.5"
+    chokidar "^3.5.3"
+    content-disposition "^0.5.4"
+    extract-zip "^2.0.1"
+    findup-sync "^5.0.0"
+    fs-extra "^11.1.0"
+    ignore "^5.1.4"
+    js-yaml "^4.1.0"
+    moment "^2.29.4"
+    p-queue "^6.0.2"
+    prettier "^3.0.3"
+    semver "^6.3.0"
+    table "^6.8.1"
+    unixify "^1.0.0"
+
+"@hubspot/local-dev-lib@^0.0.8":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@hubspot/local-dev-lib/-/local-dev-lib-0.0.8.tgz#ce3dd8d3308d9a9e10b6580c57761970286e0e37"
+  integrity sha512-3xtacv8b4/cn8moU4+mQR/s07UngJvk+BC9GxT/wsI7mZQsXIov2U781ebxM6vLFEVgvF8eCNB6yjQTD9iLwWw==
   dependencies:
     axios "^1.3.5"
     chokidar "^3.5.3"


### PR DESCRIPTION
## Description and Context
This switches to using hubspot-local-dev-lib for the following dependancies:
* `@hubspot/cli-lib/lib/validate`
* `@hubspot/cli-lib/lib/environment`
* `@hubspot/cli-lib/lib/ignoreRules`

Also bumps the deps on `local-dev-lib` and `cli-lib` to the latest versions

## Who to Notify
@brandenrodgers 
