### PR TITLE
Fix project local dev exit cleanup

### DIFF
--- a/packages/cli/commands/project/dev.js
+++ b/packages/cli/commands/project/dev.js
@@ -338,7 +338,7 @@ exports.handler = async options => {
 
   await LocalDev.start();
 
-  handleExit(() => LocalDev.stop());
+  handleExit(({ isSIGHUP }) => LocalDev.stop(!isSIGHUP));
 };
 
 exports.builder = yargs => {

--- a/packages/cli/commands/project/dev.js
+++ b/packages/cli/commands/project/dev.js
@@ -338,7 +338,7 @@ exports.handler = async options => {
 
   await LocalDev.start();
 
-  handleExit(LocalDev.stop);
+  handleExit(() => LocalDev.stop());
 };
 
 exports.builder = yargs => {

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -885,6 +885,8 @@ en:
           options:
             describe: "Options to pass to javascript fields files"
     lib:
+      process:
+        exitDebug: "Attempting to gracefully exit. Triggered by {{ signal }}"
       DevServerManager:
         portConflict: "The port {{ port }} is already in use."
         notInitialized: "The Dev Server Manager must be initialized before it is started."

--- a/packages/cli/lib/LocalDevManager.js
+++ b/packages/cli/lib/LocalDevManager.js
@@ -141,25 +141,30 @@ class LocalDevManager {
     this.compareLocalProjectToDeployed(runnableComponents);
   }
 
-  async stop() {
-    SpinniesManager.add('cleanupMessage', {
-      text: i18n(`${i18nKey}.exitingStart`),
-    });
-
+  async stop(showProgress = true) {
+    if (showProgress) {
+      SpinniesManager.add('cleanupMessage', {
+        text: i18n(`${i18nKey}.exitingStart`),
+      });
+    }
     await this.stopWatching();
 
     const cleanupSucceeded = await this.devServerCleanup();
 
     if (!cleanupSucceeded) {
-      SpinniesManager.fail('cleanupMessage', {
-        text: i18n(`${i18nKey}.exitingFail`),
-      });
+      if (showProgress) {
+        SpinniesManager.fail('cleanupMessage', {
+          text: i18n(`${i18nKey}.exitingFail`),
+        });
+      }
       process.exit(EXIT_CODES.ERROR);
     }
 
-    SpinniesManager.succeed('cleanupMessage', {
-      text: i18n(`${i18nKey}.exitingSucceed`),
-    });
+    if (showProgress) {
+      SpinniesManager.succeed('cleanupMessage', {
+        text: i18n(`${i18nKey}.exitingSucceed`),
+      });
+    }
     process.exit(EXIT_CODES.SUCCESS);
   }
 

--- a/packages/cli/lib/process.js
+++ b/packages/cli/lib/process.js
@@ -1,4 +1,5 @@
 const readline = require('readline');
+const { logger } = require('@hubspot/cli-lib/logger');
 
 const handleExit = callback => {
   const terminationSignals = [
@@ -10,11 +11,18 @@ const handleExit = callback => {
     'SIGTERM',
     'SIGHUP',
   ];
+  let exitInProgress = false;
+
   terminationSignals.forEach(signal => {
     process.removeAllListeners(signal);
 
     process.on(signal, async () => {
-      await callback();
+      logger.debug(`Attempting to gracefully exit. Triggered by ${signal}`);
+      // Prevent duplicate exit handling
+      if (!exitInProgress) {
+        exitInProgress = true;
+        await callback();
+      }
     });
   });
 };

--- a/packages/cli/lib/process.js
+++ b/packages/cli/lib/process.js
@@ -1,5 +1,8 @@
 const readline = require('readline');
 const { logger, setLogLevel, LOG_LEVEL } = require('@hubspot/cli-lib/logger');
+const { i18n } = require('./lang');
+
+const i18nKey = 'cli.lib.process';
 
 const handleExit = callback => {
   const terminationSignals = [
@@ -20,14 +23,14 @@ const handleExit = callback => {
       // Prevent duplicate exit handling
       if (!exitInProgress) {
         exitInProgress = true;
-        const isSIGHUP = 'SIGHUP';
+        const isSIGHUP = signal === 'SIGHUP';
 
         // Prevent logs when terminal closes
         if (isSIGHUP) {
           setLogLevel(LOG_LEVEL.NONE);
         }
 
-        logger.debug(`Attempting to gracefully exit. Triggered by ${signal}`);
+        logger.debug(i18n(`${i18nKey}.exitDebug`, { signal }));
         await callback({ isSIGHUP });
       }
     });

--- a/packages/cli/lib/process.js
+++ b/packages/cli/lib/process.js
@@ -1,5 +1,5 @@
 const readline = require('readline');
-const { logger } = require('@hubspot/cli-lib/logger');
+const { logger, setLogLevel, LOG_LEVEL } = require('@hubspot/cli-lib/logger');
 
 const handleExit = callback => {
   const terminationSignals = [
@@ -21,7 +21,14 @@ const handleExit = callback => {
       // Prevent duplicate exit handling
       if (!exitInProgress) {
         exitInProgress = true;
-        await callback({ isSIGHUP: signal === 'SIGHUP' });
+        const isSIGHUP = 'SIGHUP';
+
+        // Prevent logs when terminal closes
+        if (isSIGHUP) {
+          setLogLevel(LOG_LEVEL.NONE);
+        }
+
+        await callback({ isSIGHUP });
       }
     });
   });

--- a/packages/cli/lib/process.js
+++ b/packages/cli/lib/process.js
@@ -17,7 +17,6 @@ const handleExit = callback => {
     process.removeAllListeners(signal);
 
     process.on(signal, async () => {
-      logger.debug(`Attempting to gracefully exit. Triggered by ${signal}`);
       // Prevent duplicate exit handling
       if (!exitInProgress) {
         exitInProgress = true;
@@ -28,6 +27,7 @@ const handleExit = callback => {
           setLogLevel(LOG_LEVEL.NONE);
         }
 
+        logger.debug(`Attempting to gracefully exit. Triggered by ${signal}`);
         await callback({ isSIGHUP });
       }
     });

--- a/packages/cli/lib/process.js
+++ b/packages/cli/lib/process.js
@@ -4,12 +4,12 @@ const { logger } = require('@hubspot/cli-lib/logger');
 const handleExit = callback => {
   const terminationSignals = [
     'beforeExit',
-    'SIGINT',
-    'SIGUSR1',
-    'SIGUSR2',
+    'SIGINT', // Terminal trying to interrupt (Ctrl + C)
+    'SIGUSR1', // Start Debugger User-defined signal 1
+    'SIGUSR2', // User-defined signal 2
     'uncaughtException',
-    'SIGTERM',
-    'SIGHUP',
+    'SIGTERM', // Represents a graceful termination
+    'SIGHUP', // Parent terminal has been closed
   ];
   let exitInProgress = false;
 
@@ -21,7 +21,7 @@ const handleExit = callback => {
       // Prevent duplicate exit handling
       if (!exitInProgress) {
         exitInProgress = true;
-        await callback();
+        await callback({ isSIGHUP: signal === 'SIGHUP' });
       }
     });
   });


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
Fixes https://github.com/HubSpot/hubspot-cli/issues/953

There were a handful of issues in our `handleExit` util. It's the util that attempts to catch the various different exit signals, which allows us to gracefully exit the process. The major things I changed:
- Only trigger the exit once (We were sometimes triggering multiple times, especially when uncaughtException is triggered)
- Prevent interacting with stdout when the parent terminal is closed
- Adds a debug log to the termination callback to make it easier to figure out what's happening

This article was a useful resource: https://thomashunter.name/posts/2021-03-08-the-death-of-a-nodejs-process

## Screenshots
<!-- Provide images of the before and after functionality -->

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
