### PR TITLE
Bump local-dev-lib dep to 0.0.9

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@hubspot/cli-lib": "^7.0.0",
-    "@hubspot/local-dev-lib": "^0.0.8",
+    "@hubspot/local-dev-lib": "^0.0.9",
     "@hubspot/serverless-dev-runtime": "5.0.2",
     "@hubspot/ui-extensions-dev-server": "^0.8.0",
     "archiver": "^5.3.0",

--- a/packages/serverless-dev-runtime/package.json
+++ b/packages/serverless-dev-runtime/package.json
@@ -7,7 +7,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@hubspot/cli-lib": "^7.0.0",
-    "@hubspot/local-dev-lib": "^0.0.8",
+    "@hubspot/local-dev-lib": "^0.0.9",
     "body-parser": "^1.19.0",
     "chalk": "^4.1.0",
     "chokidar": "^3.4.3",

--- a/packages/webpack-cms-plugins/package.json
+++ b/packages/webpack-cms-plugins/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@hubspot/cli-lib": "^7.0.0",
-    "@hubspot/local-dev-lib": "^0.0.8"
+    "@hubspot/local-dev-lib": "^0.0.9"
   },
   "gitHead": "0659fd19cabc3645af431b177c11d0c1b089e0f8"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -505,12 +505,11 @@
     table "^6.6.0"
     unixify "1.0.0"
 
-"@hubspot/cli-lib@^6.0.0":
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/@hubspot/cli-lib/-/cli-lib-6.0.0.tgz#835c8666a25aed0703a5546a023f4b19469729db"
-  integrity sha512-BNafBv9z0pJAw7p+z7acXtFH3p1godVNPQE28hItxe+YmVFsboAWpAE+ONBfbBOe+PHqE1+MIUw0bIuWVxnepQ==
+"@hubspot/cli-lib@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@hubspot/cli-lib/-/cli-lib-7.0.0.tgz#0d36cdaee0a22b8246fb3cf0c657f71094a52891"
+  integrity sha512-JL1K49pB9IUtMtRuSrsp//p132uprWVSiLuaEgx0DCEMZgIaFzcn82mIXLMpFue+/TZrenVmw4X25ABbJCrSGQ==
   dependencies:
-    "@hubspot/local-dev-lib" "0.0.7"
     chalk "^2.4.2"
     chokidar "^3.0.1"
     content-disposition "^0.5.3"
@@ -530,34 +529,17 @@
     table "^6.6.0"
     unixify "1.0.0"
 
-"@hubspot/local-dev-lib@0.0.7":
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/@hubspot/local-dev-lib/-/local-dev-lib-0.0.7.tgz#039d27dcbac71132dea7dd379b3245a7c5ace1b1"
-  integrity sha512-wKWK3aT1yX54Q40ow+IvXUVY7yworav+fjFURSFFkqND2EvlijuCeeGObgx4xfYZRjYa+Sv56Sn6mFKZjdgQSQ==
+"@hubspot/local-dev-lib@^0.0.9":
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/@hubspot/local-dev-lib/-/local-dev-lib-0.0.9.tgz#5ae63c50ed5be5b14cad4e04dc717a7ba7c5a57b"
+  integrity sha512-6TlvIhAMsymODIEeEogyyjw57Rn/9ZXixkYr0zhxcPceFpwtHfWVbjUL+xzZNcVJCgw9ueU/JutZDPb6TLhj0A==
   dependencies:
+    address "^2.0.1"
     axios "^1.3.5"
     chokidar "^3.5.3"
     content-disposition "^0.5.4"
-    extract-zip "^2.0.1"
-    findup-sync "^5.0.0"
-    fs-extra "^11.1.0"
-    ignore "^5.1.4"
-    js-yaml "^4.1.0"
-    moment "^2.29.4"
-    p-queue "^6.0.2"
-    prettier "^3.0.3"
-    semver "^6.3.0"
-    table "^6.8.1"
-    unixify "^1.0.0"
-
-"@hubspot/local-dev-lib@^0.0.8":
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/@hubspot/local-dev-lib/-/local-dev-lib-0.0.8.tgz#ce3dd8d3308d9a9e10b6580c57761970286e0e37"
-  integrity sha512-3xtacv8b4/cn8moU4+mQR/s07UngJvk+BC9GxT/wsI7mZQsXIov2U781ebxM6vLFEVgvF8eCNB6yjQTD9iLwWw==
-  dependencies:
-    axios "^1.3.5"
-    chokidar "^3.5.3"
-    content-disposition "^0.5.4"
+    cors "^2.8.5"
+    express "^4.18.2"
     extract-zip "^2.0.1"
     findup-sync "^5.0.0"
     fs-extra "^11.1.0"
@@ -2093,6 +2075,11 @@ address@^1.0.1:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/address/-/address-1.2.2.tgz#2b5248dac5485a6390532c6a517fda2e3faac89e"
   integrity sha512-4B/qKCfeE/ODUaAUpSwfzazo5x29WD4r3vXiWsB7I2mSDAihwEqKO+g8GELZUQSSAo5e1XTYh3ZVfLyxBc12nA==
+
+address@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/address/-/address-2.0.1.tgz#7740c2c46cd3f76724fd9d85396fcb01a7f0d414"
+  integrity sha512-Fd3nPUe+kPZ0P70sGkV8dAUchT3pQCyTPQO5xW9580oqVBPJe2PtWtK7KGnQBvgTrloWAOvOoX8DksyuIWssvQ==
 
 agent-base@6, agent-base@^6.0.2:
   version "6.0.2"


### PR DESCRIPTION
## Description and Context
This PR https://github.com/HubSpot/hubspot-cli/pull/936 uses the `portManager` from local-dev-lib, which doesn't exist in v0.0.8. This bumps the dep to v0.0.9 to fix this


## Who to Notify
@brandenrodgers 
