### PR TITLE
Fix logErrorInstance message builder

### DIFF
--- a/packages/cli/lib/errorHandlers/standardErrors.js
+++ b/packages/cli/lib/errorHandlers/standardErrors.js
@@ -73,7 +73,7 @@ function logErrorInstance(error, context) {
     // Error or Error subclass
     const name = error.name || 'Error';
     const message = [i18n(`${i18nKey}.genericErrorOccurred`, { name })];
-    [(error.message, error.reason)].forEach(msg => {
+    [error.message, error.reason].forEach(msg => {
       if (msg) {
         message.push(msg);
       }


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
logErrorMessage was migrated back from cli-lib ([original file here](https://github.com/HubSpot/cli-lib/blob/main/errorHandlers/standardErrors.js#L67)) but an additional parens was added, causing some error messages to not display correctly. Screenshots below of a sandboxes example (ignore the deprecation warning)

## Screenshots
<!-- Provide images of the before and after functionality -->
Before:
<img width="886" alt="Screenshot 2023-11-28 at 11 10 00" src="https://github.com/HubSpot/hubspot-cli/assets/16788677/a1648724-20f1-48ef-81d1-b3bf97ecb40e">


After:
<img width="894" alt="Screenshot 2023-11-28 at 11 10 21" src="https://github.com/HubSpot/hubspot-cli/assets/16788677/3a1fa2e3-c10b-4a9c-903f-0da2cc6372c7">



## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->
n/a

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@camden11 
