### PR TITLE
Bump local-dev-lib to 0.0.11

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@hubspot/cli-lib": "^7.0.0",
-    "@hubspot/local-dev-lib": "^0.0.10",
+    "@hubspot/local-dev-lib": "^0.0.11",
     "@hubspot/serverless-dev-runtime": "5.0.3-beta.1",
     "@hubspot/ui-extensions-dev-server": "^0.8.0",
     "archiver": "^5.3.0",

--- a/packages/serverless-dev-runtime/package.json
+++ b/packages/serverless-dev-runtime/package.json
@@ -7,7 +7,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@hubspot/cli-lib": "^7.0.0",
-    "@hubspot/local-dev-lib": "^0.0.10",
+    "@hubspot/local-dev-lib": "^0.0.11",
     "body-parser": "^1.19.0",
     "chalk": "^4.1.0",
     "chokidar": "^3.4.3",

--- a/packages/webpack-cms-plugins/package.json
+++ b/packages/webpack-cms-plugins/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@hubspot/cli-lib": "^7.0.0",
-    "@hubspot/local-dev-lib": "^0.0.10"
+    "@hubspot/local-dev-lib": "^0.0.11"
   },
   "gitHead": "0659fd19cabc3645af431b177c11d0c1b089e0f8"
 }


### PR DESCRIPTION
## Description and Context
This makes sure the CLI uses the latest version of `local-dev-lib`, which fixes a bug in `archive`

## Who to Notify
@brandenrodgers 
