### PR TITLE
Use local-dev-lib for archive and gitignore

### DIFF
--- a/packages/cli/commands/init.js
+++ b/packages/cli/commands/init.js
@@ -8,7 +8,9 @@ const {
 } = require('@hubspot/local-dev-lib/config');
 const { addConfigOptions } = require('../lib/commonOpts');
 const { handleExit } = require('../lib/process');
-const { checkAndUpdateGitignore } = require('@hubspot/cli-lib/lib/git');
+const {
+  checkAndAddConfigToGitignore,
+} = require('@hubspot/local-dev-lib/gitignore');
 const { logErrorInstance } = require('../lib/errorHandlers/standardErrors');
 const {
   DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME,
@@ -117,7 +119,7 @@ exports.handler = async options => {
     );
     const configPath = getConfigPath();
 
-    checkAndUpdateGitignore(configPath);
+    checkAndAddConfigToGitignore(configPath);
 
     logger.log('');
     logger.success(

--- a/packages/cli/commands/project/download.js
+++ b/packages/cli/commands/project/download.js
@@ -12,7 +12,7 @@ const {
   ApiErrorContext,
 } = require('../../lib/errorHandlers/apiErrors');
 const { logger } = require('@hubspot/cli-lib/logger');
-const { extractZipArchive } = require('@hubspot/cli-lib/archive');
+const { extractZipArchive } = require('@hubspot/local-dev-lib/archive');
 const {
   downloadProject,
   fetchProjectBuilds,
@@ -24,9 +24,15 @@ const {
 } = require('../../lib/prompts/downloadProjectPrompt');
 const { i18n } = require('../../lib/lang');
 const { uiBetaTag } = require('../../lib/ui');
+const { buildLogCallbacks } = require('../../lib/logCallbacks');
 
 const i18nKey = 'cli.commands.project.subcommands.download';
 const { EXIT_CODES } = require('../../lib/enums/exitCodes');
+
+const archiveLogCallbacks = buildLogCallbacks({
+  init: 'Extracting project source...',
+  copy: 'Copying project source...',
+});
 
 exports.command = 'download [--project]';
 exports.describe = uiBetaTag(i18n(`${i18nKey}.describe`), false);
@@ -93,7 +99,8 @@ exports.handler = async options => {
       zippedProject,
       projectName,
       path.resolve(absoluteDestPath),
-      { includesRootDir: false }
+      { includesRootDir: false },
+      archiveLogCallbacks
     );
 
     logger.log(

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -1271,6 +1271,7 @@ en:
         standardErrors:
           errorOccurred: "Error: {{ error }}"
           errorContext: "Context: {{ context }}"
+          errorCause: "Cause: {{ cause }}"
           systemErrorOccurred: "A system error has occurred: {{ errorMessage }}"
           genericErrorOccurred: "A {{ name }} has occurred."
           unknownErrorOccurred: "An unknown error has occurred"

--- a/packages/cli/lib/errorHandlers/standardErrors.js
+++ b/packages/cli/lib/errorHandlers/standardErrors.js
@@ -1,3 +1,4 @@
+const util = require('util');
 const { HubSpotAuthError } = require('@hubspot/cli-lib/lib/models/Errors');
 const { logger } = require('@hubspot/cli-lib/logger');
 const { i18n } = require('../lang');
@@ -40,7 +41,18 @@ function debugErrorAndContext(error, context) {
   } else {
     logger.debug(i18n(`${i18nKey}.errorOccurred`, { error }));
   }
-  logger.debug(i18n(`${i18nKey}.errorContext`, { context }));
+  if (error.cause) {
+    logger.debug(
+      i18n(`${i18nKey}.errorCause`, {
+        cause: util.inspect(error.cause, false, null, true),
+      })
+    );
+  }
+  logger.debug(
+    i18n(`${i18nKey}.errorContext`, {
+      context: util.inspect(context, false, null, true),
+    })
+  );
 }
 
 /**

--- a/packages/cli/lib/logCallbacks.js
+++ b/packages/cli/lib/logCallbacks.js
@@ -1,0 +1,13 @@
+const { logger } = require('@hubspot/cli-lib/logger');
+
+function buildLogCallbacks(logData) {
+  const callbacksObject = {};
+  for (let key in logData) {
+    callbacksObject[key] = () => logger.log(logData[key]);
+  }
+  return callbacksObject;
+}
+
+module.exports = {
+  buildLogCallbacks,
+};


### PR DESCRIPTION
## Description and Context
This swaps `@hubspot/cli-lib/lib/git` and `@hubspot/cli-lib/archive` for `@hubspot/local-dev-lib/gitignore` and `@hubspot/local-dev-lib/archive` respectively. Also adds a util for using logcallbacks, and updates `debugErrorAndContext` to include information about the `cause` of errors

## Who to Notify
@brandenrodgers 
