### PR TITLE
Use local-dev-lib for path

### DIFF
--- a/packages/cli/commands/cms/convertFields.js
+++ b/packages/cli/commands/cms/convertFields.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const fs = require('fs');
 const { createIgnoreFilter } = require('@hubspot/local-dev-lib/ignoreRules');
-const { isAllowedExtension, getCwd } = require('@hubspot/cli-lib/path');
+const { isAllowedExtension, getCwd } = require('@hubspot/local-dev-lib/path');
 const { logger } = require('@hubspot/cli-lib/logger');
 const { walk } = require('@hubspot/local-dev-lib/fs');
 const { getThemeJSONPath } = require('@hubspot/local-dev-lib/themes');

--- a/packages/cli/commands/customObject/create.js
+++ b/packages/cli/commands/customObject/create.js
@@ -1,6 +1,6 @@
 const { logger } = require('@hubspot/cli-lib/logger');
 const { logErrorInstance } = require('../../lib/errorHandlers/standardErrors');
-const { getAbsoluteFilePath } = require('@hubspot/cli-lib/path');
+const { getAbsoluteFilePath } = require('@hubspot/local-dev-lib/path');
 const {
   isFileValidJSON,
   loadAndValidateOptions,

--- a/packages/cli/commands/customObject/schema/create.js
+++ b/packages/cli/commands/customObject/schema/create.js
@@ -2,7 +2,7 @@ const { logger } = require('@hubspot/cli-lib/logger');
 const {
   logErrorInstance,
 } = require('../../../lib/errorHandlers/standardErrors');
-const { getAbsoluteFilePath } = require('@hubspot/cli-lib/path');
+const { getAbsoluteFilePath } = require('@hubspot/local-dev-lib/path');
 const {
   isFileValidJSON,
   loadAndValidateOptions,

--- a/packages/cli/commands/customObject/schema/fetch.js
+++ b/packages/cli/commands/customObject/schema/fetch.js
@@ -10,7 +10,7 @@ const {
   getResolvedPath,
 } = require('@hubspot/local-dev-lib/schema');
 const { fetchSchema } = require('@hubspot/cli-lib/api/fileTransport');
-const { getCwd } = require('@hubspot/cli-lib/path');
+const { getCwd } = require('@hubspot/local-dev-lib/path');
 
 const { loadAndValidateOptions } = require('../../../lib/validation');
 const { trackCommandUsage } = require('../../../lib/usageTracking');

--- a/packages/cli/commands/customObject/schema/update.js
+++ b/packages/cli/commands/customObject/schema/update.js
@@ -2,7 +2,7 @@ const { logger } = require('@hubspot/cli-lib/logger');
 const {
   logErrorInstance,
 } = require('../../../lib/errorHandlers/standardErrors');
-const { getAbsoluteFilePath } = require('@hubspot/cli-lib/path');
+const { getAbsoluteFilePath } = require('@hubspot/local-dev-lib/path');
 const {
   isFileValidJSON,
   loadAndValidateOptions,

--- a/packages/cli/commands/filemanager/upload.js
+++ b/packages/cli/commands/filemanager/upload.js
@@ -3,7 +3,7 @@ const path = require('path');
 
 const { uploadFolder } = require('@hubspot/cli-lib/fileManager');
 const { uploadFile } = require('@hubspot/cli-lib/api/fileManager');
-const { getCwd, convertToUnixPath } = require('@hubspot/cli-lib/path');
+const { getCwd, convertToUnixPath } = require('@hubspot/local-dev-lib/path');
 const { logger } = require('@hubspot/cli-lib/logger');
 const {
   ApiErrorContext,

--- a/packages/cli/commands/hubdb/create.js
+++ b/packages/cli/commands/hubdb/create.js
@@ -2,7 +2,7 @@ const path = require('path');
 
 const { logger } = require('@hubspot/cli-lib/logger');
 const { logErrorInstance } = require('../../lib/errorHandlers/standardErrors');
-const { getCwd } = require('@hubspot/cli-lib/path');
+const { getCwd } = require('@hubspot/local-dev-lib/path');
 const { createHubDbTable } = require('@hubspot/cli-lib/hubdb');
 
 const {

--- a/packages/cli/commands/init.js
+++ b/packages/cli/commands/init.js
@@ -26,7 +26,7 @@ const { logger } = require('@hubspot/cli-lib/logger');
 const {
   updateConfigWithPersonalAccessKey,
 } = require('@hubspot/cli-lib/personalAccessKey');
-const { getCwd } = require('@hubspot/cli-lib/path');
+const { getCwd } = require('@hubspot/local-dev-lib/path');
 const { trackCommandUsage, trackAuthAction } = require('../lib/usageTracking');
 const { setLogLevel, addTestingOptions } = require('../lib/commonOpts');
 const { promptUser } = require('../lib/prompts/promptUtils');

--- a/packages/cli/commands/project/create.js
+++ b/packages/cli/commands/project/create.js
@@ -6,7 +6,7 @@ const {
 } = require('../../lib/commonOpts');
 const { trackCommandUsage } = require('../../lib/usageTracking');
 const { loadAndValidateOptions } = require('../../lib/validation');
-const { getCwd } = require('@hubspot/cli-lib/path');
+const { getCwd } = require('@hubspot/local-dev-lib/path');
 const path = require('path');
 const chalk = require('chalk');
 const {

--- a/packages/cli/commands/project/download.js
+++ b/packages/cli/commands/project/download.js
@@ -6,7 +6,7 @@ const {
   addUseEnvironmentOptions,
 } = require('../../lib/commonOpts');
 const { trackCommandUsage } = require('../../lib/usageTracking');
-const { getCwd } = require('@hubspot/cli-lib/path');
+const { getCwd } = require('@hubspot/local-dev-lib/path');
 const {
   logApiErrorInstance,
   ApiErrorContext,

--- a/packages/cli/commands/project/listBuilds.js
+++ b/packages/cli/commands/project/listBuilds.js
@@ -21,7 +21,7 @@ const {
   getTableContents,
   getTableHeader,
 } = require('@hubspot/local-dev-lib/logging/table');
-const { getCwd } = require('@hubspot/cli-lib/path');
+const { getCwd } = require('@hubspot/local-dev-lib/path');
 const { uiBetaTag, uiLink } = require('../../lib/ui');
 const { loadAndValidateOptions } = require('../../lib/validation');
 const {

--- a/packages/cli/commands/upload.js
+++ b/packages/cli/commands/upload.js
@@ -7,7 +7,7 @@ const {
   getCwd,
   convertToUnixPath,
   isAllowedExtension,
-} = require('@hubspot/cli-lib/path');
+} = require('@hubspot/local-dev-lib/path');
 const { logger } = require('@hubspot/cli-lib/logger');
 const {
   ApiErrorContext,

--- a/packages/cli/commands/watch.js
+++ b/packages/cli/commands/watch.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const path = require('path');
 
 const { watch } = require('@hubspot/cli-lib');
-const { getCwd } = require('@hubspot/cli-lib/path');
+const { getCwd } = require('@hubspot/local-dev-lib/path');
 const { logger } = require('@hubspot/cli-lib/logger');
 
 const {

--- a/packages/cli/lib/filesystem.js
+++ b/packages/cli/lib/filesystem.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const { getCwd } = require('@hubspot/cli-lib/path');
+const { getCwd } = require('@hubspot/local-dev-lib/path');
 const { FOLDER_DOT_EXTENSIONS } = require('@hubspot/cli-lib/lib/constants');
 
 function resolveLocalPath(filepath) {

--- a/packages/cli/lib/projects.js
+++ b/packages/cli/lib/projects.js
@@ -30,7 +30,7 @@ const {
   uploadProject,
 } = require('@hubspot/cli-lib/api/dfs');
 const { shouldIgnoreFile } = require('@hubspot/local-dev-lib/ignoreRules');
-const { getCwd, getAbsoluteFilePath } = require('@hubspot/cli-lib/path');
+const { getCwd, getAbsoluteFilePath } = require('@hubspot/local-dev-lib/path');
 const { downloadGitHubRepoContents } = require('@hubspot/cli-lib/github');
 const { promptUser } = require('./prompts/promptUtils');
 const { EXIT_CODES } = require('./enums/exitCodes');

--- a/packages/cli/lib/projectsWatch.js
+++ b/packages/cli/lib/projectsWatch.js
@@ -8,7 +8,7 @@ const {
 } = require('./errorHandlers/apiErrors');
 const { i18n } = require('@hubspot/cli-lib/lib/lang');
 const { logger } = require('@hubspot/cli-lib/logger');
-const { isAllowedExtension } = require('@hubspot/cli-lib/path');
+const { isAllowedExtension } = require('@hubspot/local-dev-lib/path');
 const { shouldIgnoreFile } = require('@hubspot/local-dev-lib/ignoreRules');
 const {
   cancelStagedBuild,

--- a/packages/cli/lib/prompts/createProjectPrompt.js
+++ b/packages/cli/lib/prompts/createProjectPrompt.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const { getCwd } = require('@hubspot/cli-lib/path');
+const { getCwd } = require('@hubspot/local-dev-lib/path');
 const {
   PROJECT_COMPONENT_TYPES,
   PROJECT_PROPERTIES,

--- a/packages/cli/lib/prompts/uploadPrompt.js
+++ b/packages/cli/lib/prompts/uploadPrompt.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const { getCwd } = require('@hubspot/cli-lib/path');
+const { getCwd } = require('@hubspot/local-dev-lib/path');
 const { promptUser } = require('./promptUtils');
 const { i18n } = require('../lang');
 

--- a/packages/cli/lib/upload.js
+++ b/packages/cli/lib/upload.js
@@ -2,7 +2,7 @@ const path = require('path');
 const { walk } = require('@hubspot/local-dev-lib/fs');
 const { createIgnoreFilter } = require('@hubspot/local-dev-lib/ignoreRules');
 const { fieldsJsPrompt } = require('../lib/prompts/cmsFieldPrompt');
-const { isAllowedExtension } = require('@hubspot/cli-lib/path');
+const { isAllowedExtension } = require('@hubspot/local-dev-lib/path');
 const { isConvertableFieldJs } = require('@hubspot/cli-lib/lib/handleFieldsJs');
 const { logErrorInstance } = require('./errorHandlers/standardErrors');
 

--- a/packages/cli/lib/validation.js
+++ b/packages/cli/lib/validation.js
@@ -13,12 +13,12 @@ const {
   getAccountConfig,
   loadConfigFromEnvironment,
 } = require('@hubspot/local-dev-lib/config');
-const { getAbsoluteFilePath } = require('@hubspot/cli-lib/path');
+const { getAbsoluteFilePath } = require('@hubspot/local-dev-lib/path');
 const { getOauthManager } = require('@hubspot/cli-lib/oauth');
 const {
   accessTokenForPersonalAccessKey,
 } = require('@hubspot/cli-lib/personalAccessKey');
-const { getCwd, getExt } = require('@hubspot/cli-lib/path');
+const { getCwd, getExt } = require('@hubspot/local-dev-lib/path');
 const { getAccountId, getMode, setLogLevel } = require('./commonOpts');
 const { logDebugInfo } = require('./debugInfo');
 const fs = require('fs');

--- a/packages/webpack-cms-plugins/HubSpotAutoUploadPlugin.js
+++ b/packages/webpack-cms-plugins/HubSpotAutoUploadPlugin.js
@@ -6,7 +6,7 @@ const {
   getAccountId,
 } = require('@hubspot/local-dev-lib/config');
 const { logger } = require('@hubspot/cli-lib/logger');
-const { isAllowedExtension } = require('@hubspot/cli-lib/path');
+const { isAllowedExtension } = require('@hubspot/local-dev-lib/path');
 const {
   LOG_LEVEL,
   setLogLevel,


### PR DESCRIPTION
## Description and Context
This swaps the `path` dep to use `local-dev-lib`. `path`'s functionality is identical between the two packages, so this should be pretty safe despite things changing in a lot of files.

## Who to Notify
@brandenrodgers 
