### PR TITLE
chore: Pin ui-extensions-dev-server version.

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -11,7 +11,7 @@
     "@hubspot/cli-lib": "^7.0.0",
     "@hubspot/local-dev-lib": "^0.0.11",
     "@hubspot/serverless-dev-runtime": "5.0.3-beta.1",
-    "@hubspot/ui-extensions-dev-server": "^0.8.0",
+    "@hubspot/ui-extensions-dev-server": "0.8.4",
     "archiver": "^5.3.0",
     "chalk": "^4.1.2",
     "chokidar": "^3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -469,10 +469,10 @@
     node-fetch "^2.6.0"
     url-parse "^1.4.3"
 
-"@hubspot/app-functions-dev-server@^0.8.2":
-  version "0.8.2"
-  resolved "https://registry.yarnpkg.com/@hubspot/app-functions-dev-server/-/app-functions-dev-server-0.8.2.tgz#80f4fabd13013686ecf4faedf1d6df0ed4377626"
-  integrity sha512-+DtHvo04nWSv4IUDWraWRxRdVp7usoOaZLXtNcfsC0mS7w8jQoFzxX6XO6WJ8/UXMCdUu45kTAuhKdTVOiZ0fw==
+"@hubspot/app-functions-dev-server@^0.8.3":
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/@hubspot/app-functions-dev-server/-/app-functions-dev-server-0.8.3.tgz#1d3f04df23922413cd775415f7212ff829d8ecd6"
+  integrity sha512-daABSf7lLY3jQ+Z2Hpj8M1NRF5CRXarZFyUsrhFfwsUUWav10Bh4ew55s+ZmTz5nkPrJlT7z+WhOtm+isharjg==
   dependencies:
     "@hubspot/api-client" "^10.0.0"
     "@hubspot/cli-lib" "^4.1.6"
@@ -529,10 +529,10 @@
     table "^6.6.0"
     unixify "1.0.0"
 
-"@hubspot/local-dev-lib@^0.0.10":
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/@hubspot/local-dev-lib/-/local-dev-lib-0.0.10.tgz#62ed26f631dca21591847cacc21d2b74fef6262f"
-  integrity sha512-/Mg0YpobcAhNffSOt7622GO6GLeUgAs228CNmZvyzptu/n2Hhp7uKJDMvBOgKtQtpvXxN0VtGOa1o5IEpURyAA==
+"@hubspot/local-dev-lib@^0.0.11":
+  version "0.0.11"
+  resolved "https://registry.yarnpkg.com/@hubspot/local-dev-lib/-/local-dev-lib-0.0.11.tgz#c40a0a2d4add3ae32e0a657ee4ac50f410ef0f39"
+  integrity sha512-SAjCyCvJc8mZNQXhni9uFQWlBJiEMblM2sxGGJC+WLdgp2gJbeLjDGdgfwNbxVYrmesSGr8OCe2gFQk5LY0/BA==
   dependencies:
     address "^2.0.1"
     axios "^1.3.5"
@@ -552,12 +552,12 @@
     table "^6.8.1"
     unixify "^1.0.0"
 
-"@hubspot/ui-extensions-dev-server@^0.8.0":
-  version "0.8.2"
-  resolved "https://registry.yarnpkg.com/@hubspot/ui-extensions-dev-server/-/ui-extensions-dev-server-0.8.2.tgz#7f83592c322e7e255306607316cd968823f07a7f"
-  integrity sha512-AA6MoGXA9hdBS4DXIc1HbmgOA5r3KUNjOPPfyVmOP5BF+vSaJrPBnIp/VjogfP1SoY32eREdqjdTOlUYMSDjIw==
+"@hubspot/ui-extensions-dev-server@0.8.4":
+  version "0.8.4"
+  resolved "https://registry.yarnpkg.com/@hubspot/ui-extensions-dev-server/-/ui-extensions-dev-server-0.8.4.tgz#dec121f44507cb8f6fa9db287a2a7bc229b10673"
+  integrity sha512-uEadYEqdUgyPXs5uwVBB5IVA+2FrGachCAc6+voOp+uV0DgdbYMX+TssCkIHyqL9mf3ieVm2KAhjIhN0sr1x/Q==
   dependencies:
-    "@hubspot/app-functions-dev-server" "^0.8.2"
+    "@hubspot/app-functions-dev-server" "^0.8.3"
     "@hubspot/cli-lib" "^4.1.6"
     command-line-args "^5.2.1"
     command-line-usage "^7.0.1"


### PR DESCRIPTION
## Description and Context
Pin the version of `ui-extensions-dev-server` to the current version of the package.  For future releases we can manually update this version via PRs to assure that when users update `@hubspot/cli` that they get the expected version of `@hubspot/ui-extensions-dev-server`

