### PR TITLE
chore: Bump `@hubspot/ui-extensions-dev-server` version

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -11,7 +11,7 @@
     "@hubspot/cli-lib": "^7.0.0",
     "@hubspot/local-dev-lib": "^0.1.0",
     "@hubspot/serverless-dev-runtime": "5.0.3-beta.3",
-    "@hubspot/ui-extensions-dev-server": "0.8.4",
+    "@hubspot/ui-extensions-dev-server": "0.8.6",
     "archiver": "^5.3.0",
     "chalk": "^4.1.2",
     "chokidar": "^3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -552,10 +552,10 @@
     table "^6.8.1"
     unixify "^1.0.0"
 
-"@hubspot/ui-extensions-dev-server@0.8.4":
-  version "0.8.4"
-  resolved "https://registry.yarnpkg.com/@hubspot/ui-extensions-dev-server/-/ui-extensions-dev-server-0.8.4.tgz#dec121f44507cb8f6fa9db287a2a7bc229b10673"
-  integrity sha512-uEadYEqdUgyPXs5uwVBB5IVA+2FrGachCAc6+voOp+uV0DgdbYMX+TssCkIHyqL9mf3ieVm2KAhjIhN0sr1x/Q==
+"@hubspot/ui-extensions-dev-server@0.8.6":
+  version "0.8.6"
+  resolved "https://registry.yarnpkg.com/@hubspot/ui-extensions-dev-server/-/ui-extensions-dev-server-0.8.6.tgz#d526eb752df647eebcda60e383f376338125e953"
+  integrity sha512-L8KTFc9dBnlhupLJlmirfg6ZyxhU5yew86VhuQUMtootDrHqSvIAGbJeKoWndYMIFINSNntlryTkYaIPsGiQ2g==
   dependencies:
     "@hubspot/app-functions-dev-server" "^0.8.3"
     "@hubspot/cli-lib" "^4.1.6"


### PR DESCRIPTION
## Description and Context

A new version of `@hubspot/ui-extensions-dev-server` was released that added the following:
- feat: Integrate with port manager for dynamic dev server ports
- fix: Prevent multi-extension execution cross application

