### PR TITLE
bumping cli-lib version to 8

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/HubSpot/hubspot-cms-tools"
   },
   "dependencies": {
-    "@hubspot/cli-lib": "^7.0.0",
+    "@hubspot/cli-lib": "^8.0.0",
     "@hubspot/local-dev-lib": "^0.1.0",
     "@hubspot/serverless-dev-runtime": "5.1.0",
     "@hubspot/ui-extensions-dev-server": "0.8.4",

--- a/packages/serverless-dev-runtime/package.json
+++ b/packages/serverless-dev-runtime/package.json
@@ -6,7 +6,7 @@
   "repository": "https://github.com/HubSpot/hubspot-cli",
   "license": "Apache-2.0",
   "dependencies": {
-    "@hubspot/cli-lib": "^7.0.0",
+    "@hubspot/cli-lib": "^8.0.0",
     "@hubspot/local-dev-lib": "^0.1.0",
     "body-parser": "^1.19.0",
     "chalk": "^4.1.0",

--- a/packages/webpack-cms-plugins/package.json
+++ b/packages/webpack-cms-plugins/package.json
@@ -17,7 +17,7 @@
     "test": "echo \"Error: run tests from root\" && exit 1"
   },
   "dependencies": {
-    "@hubspot/cli-lib": "^7.0.0",
+    "@hubspot/cli-lib": "^8.0.0",
     "@hubspot/local-dev-lib": "^0.1.0"
   },
   "gitHead": "0659fd19cabc3645af431b177c11d0c1b089e0f8"


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
Fixing: https://github.com/HubSpot/hubspot-cli/issues/970

Fixing an issue caused by peer deps for cli-lib not being satisfied. (cli-lib update [here](https://github.com/HubSpot/cli-lib/pull/38))

This was causing multiple versions of local-dev-lib to be installed, which is an issue because the config-handling files rely on global variables.
## Screenshots
<!-- Provide images of the before and after functionality -->

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
