### PR TITLE
Remove cli-lib/http dep + use local-dev-lib for OAuth

### DIFF
--- a/packages/cli/commands/auth.js
+++ b/packages/cli/commands/auth.js
@@ -154,7 +154,8 @@ exports.handler = async options => {
     process.exit(EXIT_CODES.ERROR);
   }
 
-  const accountName = updatedConfig.name || validName;
+  const accountName =
+    (updatedConfig && updatedConfig.name) || validName || configData.name;
 
   const setAsDefault = await setAsDefaultAccountPrompt(accountName);
 

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -935,6 +935,10 @@ en:
           setupError: "Failed to setup local dev server: {{ message }}"
           startError: "Failed to start local dev server: {{ message }}"
           fileChangeError: "Failed to notify local dev server of file change: {{ message }}"
+      oauth:
+        logCallbacks:
+          init: "Updating configuration"
+          success: "Configuration updated"
       projects:
         config:
           srcOutsideProjectDir: "Invalid value for 'srcDir' in {{ projectConfig }}: {{#bold}}srcDir: \"{{ srcDir }}\"{{/bold}}\n\t'srcDir' must be a relative path to a folder under the project root, such as \".\" or \"./src\""

--- a/packages/cli/lib/DevServerManager.js
+++ b/packages/cli/lib/DevServerManager.js
@@ -1,4 +1,4 @@
-const httpClient = require('@hubspot/cli-lib/http');
+const httpClient = require('@hubspot/local-dev-lib/http');
 const { logger } = require('@hubspot/cli-lib/logger');
 const { COMPONENT_TYPES } = require('./projectStructure');
 const { i18n } = require('./lang');

--- a/packages/cli/lib/DevServerManager.js
+++ b/packages/cli/lib/DevServerManager.js
@@ -1,4 +1,3 @@
-const httpClient = require('@hubspot/local-dev-lib/http');
 const { logger } = require('@hubspot/cli-lib/logger');
 const { COMPONENT_TYPES } = require('./projectStructure');
 const { i18n } = require('./lang');
@@ -91,7 +90,6 @@ class DevServerManager {
           await serverInterface.start({
             accountId,
             debug: this.debug,
-            httpClient,
             projectConfig,
             requestPorts,
           });

--- a/packages/cli/lib/__tests__/validation.js
+++ b/packages/cli/lib/__tests__/validation.js
@@ -1,5 +1,5 @@
 const { getAccountConfig } = require('@hubspot/local-dev-lib/config');
-const { getOauthManager } = require('@hubspot/cli-lib/oauth');
+const { getOauthManager } = require('@hubspot/local-dev-lib/oauth');
 const {
   accessTokenForPersonalAccessKey,
 } = require('@hubspot/local-dev-lib/personalAccessKey');

--- a/packages/cli/lib/__tests__/validation.js
+++ b/packages/cli/lib/__tests__/validation.js
@@ -10,7 +10,7 @@ const { validateAccount } = require('../validation');
 jest.mock('@hubspot/cli-lib');
 jest.mock('@hubspot/local-dev-lib/config');
 jest.mock('@hubspot/cli-lib/logger');
-jest.mock('@hubspot/cli-lib/oauth');
+jest.mock('@hubspot/local-dev-lib/oauth');
 jest.mock('@hubspot/local-dev-lib/personalAccessKey');
 jest.mock('../commonOpts');
 

--- a/packages/cli/lib/oauth.js
+++ b/packages/cli/lib/oauth.js
@@ -1,15 +1,26 @@
 const express = require('express');
 const open = require('open');
-const OAuth2Manager = require('@hubspot/cli-lib/lib/models/OAuth2Manager');
+const OAuth2Manager = require('@hubspot/local-dev-lib/models/OAuth2Manager');
 const { getAccountConfig } = require('@hubspot/local-dev-lib/config');
-const { addOauthToAccountConfig } = require('@hubspot/cli-lib/oauth');
+const { addOauthToAccountConfig } = require('@hubspot/local-dev-lib/oauth');
 const { handleExit } = require('./process');
 const { getHubSpotWebsiteOrigin } = require('@hubspot/local-dev-lib/urls');
 const { logger } = require('@hubspot/cli-lib/logger');
 const { ENVIRONMENTS } = require('@hubspot/cli-lib/lib/constants');
+const { buildLogCallbacks } = require('./logCallbacks');
 
 const PORT = 3000;
 const redirectUri = `http://localhost:${PORT}/oauth-callback`;
+
+const i18nKey = 'cli.lib.oath';
+
+const oauthLogCallbacks = buildLogCallbacks({
+  init: `${i18nKey}.logCallbacks.init`,
+  success: {
+    key: `${i18nKey}.logCallbacks.success`,
+    logger: logger.success,
+  },
+});
 
 const buildAuthUrl = oauthManager => {
   return (
@@ -97,7 +108,7 @@ const authenticateWithOauth = async configData => {
   const oauthManager = setupOauth(configData);
   logger.log('Authorizing');
   await authorize(oauthManager);
-  addOauthToAccountConfig(oauthManager);
+  addOauthToAccountConfig(oauthManager, oauthLogCallbacks);
 };
 
 module.exports = {

--- a/packages/cli/lib/validation.js
+++ b/packages/cli/lib/validation.js
@@ -118,7 +118,7 @@ async function validateAccount(options) {
       logger.error(
         `The OAuth2 configuration for account ${accountId} is incorrect`
       );
-      logger.error('Run "hscms auth oauth2" to reauthenticate');
+      logger.error('Run "hs auth --type=oauth2" to reauthenticate');
       return false;
     }
 

--- a/packages/cli/lib/validation.js
+++ b/packages/cli/lib/validation.js
@@ -14,7 +14,7 @@ const {
   loadConfigFromEnvironment,
 } = require('@hubspot/local-dev-lib/config');
 const { getAbsoluteFilePath } = require('@hubspot/local-dev-lib/path');
-const { getOauthManager } = require('@hubspot/cli-lib/oauth');
+const { getOauthManager } = require('@hubspot/local-dev-lib/oauth');
 const {
   accessTokenForPersonalAccessKey,
 } = require('@hubspot/local-dev-lib/personalAccessKey');

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@hubspot/cli-lib": "^8.0.2",
-    "@hubspot/local-dev-lib": "^0.2.2",
+    "@hubspot/local-dev-lib": "^0.2.4",
     "@hubspot/serverless-dev-runtime": "5.1.3-beta.0",
     "@hubspot/ui-extensions-dev-server": "0.8.6",
     "archiver": "^5.3.0",

--- a/packages/serverless-dev-runtime/package.json
+++ b/packages/serverless-dev-runtime/package.json
@@ -7,7 +7,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@hubspot/cli-lib": "^8.0.2",
-    "@hubspot/local-dev-lib": "^0.2.2",
+    "@hubspot/local-dev-lib": "^0.2.4",
     "body-parser": "^1.19.0",
     "chalk": "^4.1.0",
     "chokidar": "^3.4.3",

--- a/packages/webpack-cms-plugins/package.json
+++ b/packages/webpack-cms-plugins/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@hubspot/cli-lib": "^8.0.2",
-    "@hubspot/local-dev-lib": "^0.2.2"
+    "@hubspot/local-dev-lib": "^0.2.4"
   },
   "gitHead": "0659fd19cabc3645af431b177c11d0c1b089e0f8"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -537,10 +537,10 @@
     table "^6.6.0"
     unixify "1.0.0"
 
-"@hubspot/local-dev-lib@^0.2.2":
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/@hubspot/local-dev-lib/-/local-dev-lib-0.2.2.tgz#bd979197849172190a0fad558b192b6a05933fd7"
-  integrity sha512-zKAlj5ITHzEqEW6Qwz9tZx452kZEKgFEJJxag/MYlANgs+8JF2mu7HC1yB2Zs92mR7WJ1HNgOxrrQuLNd+MdWA==
+"@hubspot/local-dev-lib@^0.2.4":
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/@hubspot/local-dev-lib/-/local-dev-lib-0.2.4.tgz#af80a37283d08e55fa71ecff6a9832e01e459057"
+  integrity sha512-J/5cuPHqn5T2/Vh/yNe5UsPRROyfuujKI0KeRn+yd+A5ZCA0ei+GQaIsXrQbEAhcSJT+39o3umdeaEZZFACVeQ==
   dependencies:
     address "^2.0.1"
     axios "^1.3.5"


### PR DESCRIPTION
## Description and Context
This removes three more dependancies on cli-lib modules:
* `http` is no longer needed (see https://hubspot.slack.com/archives/C01GV708YH3/p1706644044503449)
* Switches to local-dev-lib for `oauth`
* Switches to local-dev-lib for `OAuth2Manager`

This also fixes a big that would cause `hs auth --type=oauth2` to display an error message even when working properly.

## Todo
* Need to merge + release this https://github.com/HubSpot/hubspot-local-dev-lib/pull/92

## Who to Notify
@brandenrodgers 
