### PR TITLE
Remove cli lib error handlers

### DIFF
--- a/packages/cli/commands/auth.js
+++ b/packages/cli/commands/auth.js
@@ -44,7 +44,7 @@ const { trackAuthAction, trackCommandUsage } = require('../lib/usageTracking');
 const { authenticateWithOauth } = require('../lib/oauth');
 const { EXIT_CODES } = require('../lib/enums/exitCodes');
 const { uiFeatureHighlight } = require('../lib/ui');
-const { logErrorInstance } = require('@hubspot/cli-lib/errorHandlers');
+const { logErrorInstance } = require('../lib/errorHandlers/standardErrors');
 
 const i18nKey = 'cli.commands.auth';
 

--- a/packages/cli/commands/cms/convertFields.js
+++ b/packages/cli/commands/cms/convertFields.js
@@ -12,7 +12,7 @@ const {
 } = require('@hubspot/cli-lib/lib/handleFieldsJs');
 
 const { trackConvertFieldsUsage } = require('../../lib/usageTracking');
-const { logErrorInstance } = require('@hubspot/cli-lib/errorHandlers');
+const { logErrorInstance } = require('../../lib/errorHandlers/standardErrors');
 const i18nKey = 'cli.commands.convertFields';
 
 exports.command = 'convert-fields';

--- a/packages/cli/commands/fetch.js
+++ b/packages/cli/commands/fetch.js
@@ -18,7 +18,7 @@ const { i18n } = require('../lib/lang');
 const i18nKey = 'cli.commands.fetch';
 const { EXIT_CODES } = require('../lib/enums/exitCodes');
 const { buildLogCallbacks } = require('../lib/logCallbacks');
-const { logErrorInstance } = require('@hubspot/cli-lib/errorHandlers');
+const { logErrorInstance } = require('../lib/errorHandlers/standardErrors');
 
 const fileMapperLogCallbacks = buildLogCallbacks({
   skippedExisting: `${i18nKey}.fileMapperLogCallbacks.skippedExisting`,

--- a/packages/cli/commands/filemanager/fetch.js
+++ b/packages/cli/commands/filemanager/fetch.js
@@ -15,7 +15,7 @@ const { i18n } = require('../../lib/lang');
 
 const i18nKey = 'cli.commands.filemanager.subcommands.fetch';
 const { EXIT_CODES } = require('../../lib/enums/exitCodes');
-const { logErrorInstance } = require('@hubspot/cli-lib/errorHandlers');
+const { logErrorInstance } = require('../../lib/errorHandlers/standardErrors');
 
 const downloadLogCallbacks = buildLogCallbacks({
   skippedExisting: `${i18nKey}.downloadLogCallbacks.skippedExisting`,

--- a/packages/cli/lib/errorHandlers/standardErrors.js
+++ b/packages/cli/lib/errorHandlers/standardErrors.js
@@ -2,7 +2,7 @@ const util = require('util');
 const {
   HubSpotAuthError,
 } = require('@hubspot/local-dev-lib/models/HubSpotAuthError');
-const { logger } = require('@hubspot/local-dev-lib/logger');
+const { logger } = require('@hubspot/cli-lib/logger');
 const { i18n } = require('../lang');
 
 const i18nKey = 'cli.lib.errorHandlers.standardErrors';

--- a/packages/cli/lib/errorHandlers/standardErrors.js
+++ b/packages/cli/lib/errorHandlers/standardErrors.js
@@ -1,6 +1,8 @@
 const util = require('util');
-const { HubSpotAuthError } = require('@hubspot/cli-lib/lib/models/Errors');
-const { logger } = require('@hubspot/cli-lib/logger');
+const {
+  HubSpotAuthError,
+} = require('@hubspot/local-dev-lib/models/HubSpotAuthError');
+const { logger } = require('@hubspot/local-dev-lib/logger');
 const { i18n } = require('../lang');
 
 const i18nKey = 'cli.lib.errorHandlers.standardErrors';


### PR DESCRIPTION
## Description and Context
This catches the few places that were still using cli-lib for `logErrorInstance`. With this PR in, there will be no more usage of cli-lib config outside of API modules

## Who to Notify
@brandenrodgers 
