### PR TITLE
Port api modules 1

### DIFF
--- a/packages/cli/commands/cms/lighthouseScore.js
+++ b/packages/cli/commands/cms/lighthouseScore.js
@@ -18,7 +18,7 @@ const {
   requestLighthouseScore,
   getLighthouseScoreStatus,
   getLighthouseScore,
-} = require('@hubspot/cli-lib/api/lighthouseScore');
+} = require('@hubspot/local-dev-lib/api/lighthouseScore');
 const {
   HUBSPOT_FOLDER,
   MARKETPLACE_FOLDER,

--- a/packages/cli/commands/cms/lighthouseScore.js
+++ b/packages/cli/commands/cms/lighthouseScore.js
@@ -13,7 +13,7 @@ const {
 const { loadAndValidateOptions } = require('../../lib/validation');
 const { promptUser } = require('../../lib/prompts/promptUtils');
 const { i18n } = require('../../lib/lang');
-const { fetchThemes } = require('@hubspot/cli-lib/api/designManager');
+const { fetchThemes } = require('@hubspot/local-dev-lib/api/designManager');
 const {
   requestLighthouseScore,
   getLighthouseScoreStatus,

--- a/packages/cli/commands/logs.js
+++ b/packages/cli/commands/logs.js
@@ -10,7 +10,7 @@ const { outputLogs } = require('@hubspot/cli-lib/lib/logs');
 const {
   getFunctionLogs,
   getLatestFunctionLog,
-} = require('@hubspot/cli-lib/api/results');
+} = require('@hubspot/local-dev-lib/api/functions');
 const { tailLogs } = require('../lib/serverlessLogs');
 const { loadAndValidateOptions } = require('../lib/validation');
 const { i18n } = require('../lib/lang');

--- a/packages/cli/commands/logs.js
+++ b/packages/cli/commands/logs.js
@@ -14,11 +14,12 @@ const {
 const { tailLogs } = require('../lib/serverlessLogs');
 const { loadAndValidateOptions } = require('../lib/validation');
 const { i18n } = require('../lib/lang');
+const { EXIT_CODES } = require('../lib/enums/exitCodes');
 
 const i18nKey = 'cli.commands.logs';
 
 const handleLogsError = (e, accountId, functionPath) => {
-  if (e.statusCode === 404) {
+  if (e.response.status === 404 || e.response.status == 400) {
     logger.error(
       i18n(`${i18nKey}.errors.noLogsFound`, {
         accountId,
@@ -63,12 +64,14 @@ const endpointLog = async (accountId, options) => {
       logsResp = await getLatestFunctionLog(accountId, functionPath);
     } catch (e) {
       handleLogsError(e, accountId, functionPath);
+      process.exit(EXIT_CODES.ERROR);
     }
   } else {
     try {
       logsResp = await getFunctionLogs(accountId, functionPath, options);
     } catch (e) {
       handleLogsError(e, accountId, functionPath);
+      process.exit(EXIT_CODES.ERROR);
     }
   }
 

--- a/packages/cli/commands/project/logs.js
+++ b/packages/cli/commands/project/logs.js
@@ -21,15 +21,14 @@ const {
 // const {
 //   getProjectAppFunctionLogs,
 //   getLatestProjectAppFunctionLog,
+//   getFunctionLogs,
+//   getLatestFunctionLog,
 // } = require('@hubspot/cli-lib/api/functions');
 // const {
 //   logApiErrorInstance,
 //   ApiErrorContext,
 // } = require('../../lib/errorHandlers/apiErrors');
-// const {
-//   getFunctionLogs,
-//   getLatestFunctionLog,
-// } = require('@hubspot/cli-lib/api/results');
+
 const { ensureProjectExists } = require('../../lib/projects');
 const { loadAndValidateOptions } = require('../../lib/validation');
 const { uiBetaTag, uiLine, uiLink } = require('../../lib/ui');


### PR DESCRIPTION
## Description and Context
This swaps out 
* `@hubspot/cli-lib/api/results`
* `@hubspot/cli-lib/api/designManager`
* `@hubspot/cli-lib/api/lighthouseScore`

in favor of their local dev lib equivalents

## Who to Notify
@brandenrodgers 
