### PR TITLE
Fix sandbox automatic PAK save

### DIFF
--- a/packages/cli/lib/sandboxes.js
+++ b/packages/cli/lib/sandboxes.js
@@ -237,7 +237,7 @@ const validateSandboxUsageLimits = async (accountConfig, sandboxType, env) => {
  */
 const saveSandboxToConfig = async (env, result, force = false) => {
   let personalAccessKey = result.personalAccessKey;
-  if (personalAccessKey) {
+  if (!personalAccessKey) {
     const configData = await personalAccessKeyPrompt({
       env,
       account: result.sandbox.sandboxHubId,


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->

This PR fixes an issue where PAKs were not being saved automatically when creating sandboxes. I tracked it down to an older PR here where a negate expression was missed: https://github.com/HubSpot/hubspot-cli/pull/964/files#diff-1571027f94f3fbe8d93b2e70d16ab063244781cd29fee699c8b8783e9eb163a4L237-L240

## Screenshots
<!-- Provide images of the before and after functionality -->
n/a

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->
n/a

## Who to Notify
<!-- /cc those you wish to know about the PR -->
