### PR TITLE
Cleanup ignore tasks for sandbox sync

### DIFF
--- a/packages/cli/lib/lang.js
+++ b/packages/cli/lib/lang.js
@@ -52,7 +52,7 @@ const getTextValue = lookupDotNotation => {
       previouslyCheckedProp = prop;
     });
   } catch (e) {
-    logger.error(
+    logger.debug(
       `Unable to access language property: ${lookupProps.join(
         '.'
       )}. Failed to access prop "${previouslyCheckedProp}".`
@@ -92,4 +92,5 @@ const setLangData = (newLocale, newLangObj) => {
 module.exports = {
   i18n,
   setLangData,
+  MISSING_LANGUAGE_DATA_PREFIX,
 };

--- a/packages/cli/lib/lang.js
+++ b/packages/cli/lib/lang.js
@@ -57,6 +57,7 @@ const getTextValue = lookupDotNotation => {
         '.'
       )}. Failed to access prop "${previouslyCheckedProp}".`
     );
+    logger.error('Unable to access language property.');
     return missingTextData;
   }
 

--- a/packages/cli/lib/sandboxes.js
+++ b/packages/cli/lib/sandboxes.js
@@ -332,7 +332,6 @@ function pollSyncTaskStatus(
   const mergeTasks = {
     'lead-flows': 'forms', // lead-flows are a subset of forms. We combine these in the UI as a single item, so we want to merge here for consistency.
   };
-  const ignoreTasks = ['gates'];
   let progressCounter = {};
   let pollInterval;
   // Handle manual exit for return key and ctrl+c
@@ -369,11 +368,7 @@ function pollSyncTaskStatus(
         for (const task of taskResult.tasks) {
           // For each sync task, show a progress bar and increment bar each time we run this interval until status is 'COMPLETE'
           const taskType = task.type;
-          if (
-            !progressBar.get(taskType) &&
-            !mergeTasks[taskType] &&
-            !ignoreTasks.includes(taskType)
-          ) {
+          if (!progressBar.get(taskType) && !mergeTasks[taskType]) {
             // skip creation of lead-flows bar because we're combining lead-flows into the forms bar, otherwise create a bar instance for the type
             progressCounter[taskType] = 0;
             progressBar.create(taskType, 100, 0, {

--- a/packages/cli/lib/sandboxes.js
+++ b/packages/cli/lib/sandboxes.js
@@ -1,5 +1,5 @@
 const chalk = require('chalk');
-const { i18n } = require('./lang');
+const { i18n, MISSING_LANGUAGE_DATA_PREFIX } = require('./lang');
 const { handleExit, handleKeypress } = require('./process');
 const { logger } = require('@hubspot/cli-lib/logger');
 const {
@@ -367,12 +367,16 @@ function pollSyncTaskStatus(
         // Array of sync tasks, eg: workflows, pipelines, object-schemas, etc. with each task containing a status of 'PENDING', 'IN_PROGRESS', 'COMPLETE', and 'FAILURE'
         for (const task of taskResult.tasks) {
           // For each sync task, show a progress bar and increment bar each time we run this interval until status is 'COMPLETE'
-          const taskType = task.type;
+          let taskType = task.type;
+          const taskTypeLabel = i18n(`${i18nKey}.${taskType}.label`);
+          if (taskTypeLabel.startsWith(MISSING_LANGUAGE_DATA_PREFIX)) {
+            continue;
+          }
           if (!progressBar.get(taskType) && !mergeTasks[taskType]) {
             // skip creation of lead-flows bar because we're combining lead-flows into the forms bar, otherwise create a bar instance for the type
             progressCounter[taskType] = 0;
             progressBar.create(taskType, 100, 0, {
-              label: i18n(`${i18nKey}.${taskType}.label`),
+              label: taskTypeLabel,
             });
           } else if (mergeTasks[taskType]) {
             // It's a lead-flow here, merge status into the forms progress bar
@@ -403,7 +407,7 @@ function pollSyncTaskStatus(
           }
           if (progressBar.get(taskType) && task.status === 'COMPLETE') {
             progressBar.update(taskType, 100, {
-              label: i18n(`${i18nKey}.${taskType}.label`),
+              label: taskTypeLabel,
             });
           } else if (
             // Do not start incrementing for tasks still in PENDING state
@@ -416,7 +420,7 @@ function pollSyncTaskStatus(
               taskType === syncTypes.OBJECT_RECORDS ? 2 : 3 // slower progress for object-records, sync can take up to a few minutes
             );
             progressBar.update(taskType, progressCounter[taskType], {
-              label: i18n(`${i18nKey}.${taskType}.label`),
+              label: taskTypeLabel,
             });
           }
         }


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
Sandboxes introduced a bug where an extra sync type was being returned. This resulted in a very ugly sync progress display as shown below in the screenshots section.

We've hidden that sync type from our side so I'm removing the ignore code that was added as a hotfix for this issue here: https://github.com/HubSpot/hubspot-cli/pull/979/files#diff-1571027f94f3fbe8d93b2e70d16ab063244781cd29fee699c8b8783e9eb163a4R335

This PR also adds an additional check to make sure if this happens again, we don't show the user that missing translation error and just hide it. 

## Screenshots
<!-- Provide images of the before and after functionality -->
Before:
![Screenshot 2024-01-23 at 4 21 04 PM](https://github.com/HubSpot/hubspot-cli/assets/16788677/c7d5fe41-7e32-42e0-a4d9-a08503e8eb49)


Expected view:
<img width="665" alt="Screenshot 2024-02-07 at 11 12 22" src="https://github.com/HubSpot/hubspot-cli/assets/16788677/26da7fcc-1c19-4cb7-b658-0c55a968911a">

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
