### PR TITLE
Port api modules 2

### DIFF
--- a/packages/cli/commands/customObject/create.js
+++ b/packages/cli/commands/customObject/create.js
@@ -1,15 +1,15 @@
 const { logger } = require('@hubspot/cli-lib/logger');
-const { logErrorInstance } = require('../../lib/errorHandlers/standardErrors');
+const { logApiErrorInstance } = require('../../lib/errorHandlers/apiErrors');
 const { getAbsoluteFilePath } = require('@hubspot/local-dev-lib/path');
 const {
-  isFileValidJSON,
+  checkAndConvertToJson,
   loadAndValidateOptions,
 } = require('../../lib/validation');
 const { trackCommandUsage } = require('../../lib/usageTracking');
 const { getAccountId } = require('../../lib/commonOpts');
 const {
   batchCreateObjects,
-} = require('@hubspot/local-dev-lib/api/customObject');
+} = require('@hubspot/local-dev-lib/api/customObjects');
 const { i18n } = require('../../lib/lang');
 
 const i18nKey = 'cli.commands.customObject.subcommands.create';
@@ -28,15 +28,17 @@ exports.handler = async options => {
   trackCommandUsage('custom-object-batch-create', null, accountId);
 
   const filePath = getAbsoluteFilePath(definition);
-  if (!isFileValidJSON(filePath)) {
+  const objectJson = checkAndConvertToJson(filePath);
+
+  if (!objectJson) {
     process.exit(EXIT_CODES.ERROR);
   }
 
   try {
-    await batchCreateObjects(accountId, name, filePath);
+    await batchCreateObjects(accountId, name, objectJson);
     logger.success(i18n(`${i18nKey}.success.objectsCreated`));
   } catch (e) {
-    logErrorInstance(e, { accountId });
+    logApiErrorInstance(e, { accountId });
     logger.error(
       i18n(`${i18nKey}.errors.creationFailed`, {
         definition,

--- a/packages/cli/commands/customObject/create.js
+++ b/packages/cli/commands/customObject/create.js
@@ -7,7 +7,9 @@ const {
 } = require('../../lib/validation');
 const { trackCommandUsage } = require('../../lib/usageTracking');
 const { getAccountId } = require('../../lib/commonOpts');
-const { batchCreateObjects } = require('@hubspot/cli-lib/api/customObject');
+const {
+  batchCreateObjects,
+} = require('@hubspot/local-dev-lib/api/customObject');
 const { i18n } = require('../../lib/lang');
 
 const i18nKey = 'cli.commands.customObject.subcommands.create';

--- a/packages/cli/commands/customObject/schema/create.js
+++ b/packages/cli/commands/customObject/schema/create.js
@@ -17,7 +17,7 @@ const { ENVIRONMENTS, ConfigFlags } = require('@hubspot/cli-lib/lib/constants');
 const { createSchema } = require('@hubspot/cli-lib/api/schema');
 const {
   createSchema: createSchemaFromHubFile,
-} = require('@hubspot/cli-lib/api/fileTransport');
+} = require('@hubspot/local-dev-lib/api/fileTransport');
 const { getHubSpotWebsiteOrigin } = require('@hubspot/local-dev-lib/urls');
 const { i18n } = require('../../../lib/lang');
 

--- a/packages/cli/commands/customObject/schema/create.js
+++ b/packages/cli/commands/customObject/schema/create.js
@@ -4,7 +4,7 @@ const {
 } = require('../../../lib/errorHandlers/standardErrors');
 const { getAbsoluteFilePath } = require('@hubspot/local-dev-lib/path');
 const {
-  isFileValidJSON,
+  checkAndConvertToJson,
   loadAndValidateOptions,
 } = require('../../../lib/validation');
 const { trackCommandUsage } = require('../../../lib/usageTracking');
@@ -38,7 +38,7 @@ exports.handler = async options => {
   trackCommandUsage('custom-object-schema-create', null, accountId);
 
   const filePath = getAbsoluteFilePath(definition);
-  if (!isFileValidJSON(filePath)) {
+  if (!checkAndConvertToJson(filePath)) {
     process.exit(EXIT_CODES.ERROR);
   }
 

--- a/packages/cli/commands/customObject/schema/delete.js
+++ b/packages/cli/commands/customObject/schema/delete.js
@@ -6,7 +6,9 @@ const {
 const { loadAndValidateOptions } = require('../../../lib/validation');
 const { trackCommandUsage } = require('../../../lib/usageTracking');
 const { getAccountId } = require('../../../lib/commonOpts');
-const { deleteSchema } = require('@hubspot/cli-lib/api/schema');
+const {
+  deleteObjectSchema,
+} = require('@hubspot/local-dev-lib/api/customObjects');
 const { i18n } = require('../../../lib/lang');
 
 const i18nKey =
@@ -25,7 +27,7 @@ exports.handler = async options => {
   trackCommandUsage('custom-object-schema-delete', null, accountId);
 
   try {
-    await deleteSchema(accountId, name);
+    await deleteObjectSchema(accountId, name);
     logger.success(
       i18n(`${i18nKey}.success.delete`, {
         name,

--- a/packages/cli/commands/customObject/schema/delete.js
+++ b/packages/cli/commands/customObject/schema/delete.js
@@ -1,7 +1,5 @@
 const { logger } = require('@hubspot/cli-lib/logger');
-const {
-  logErrorInstance,
-} = require('../../../lib/errorHandlers/standardErrors');
+const { logApiErrorInstance } = require('../../../lib/errorHandlers/apiErrors');
 
 const { loadAndValidateOptions } = require('../../../lib/validation');
 const { trackCommandUsage } = require('../../../lib/usageTracking');
@@ -34,7 +32,7 @@ exports.handler = async options => {
       })
     );
   } catch (e) {
-    logErrorInstance(e);
+    logApiErrorInstance(e);
     logger.error(
       i18n(`${i18nKey}.errors.delete`, {
         name,

--- a/packages/cli/commands/customObject/schema/fetch.js
+++ b/packages/cli/commands/customObject/schema/fetch.js
@@ -9,7 +9,7 @@ const {
   downloadSchema,
   getResolvedPath,
 } = require('@hubspot/local-dev-lib/customObjects');
-const { fetchSchema } = require('@hubspot/cli-lib/api/fileTransport');
+const { fetchSchema } = require('@hubspot/local-dev-lib/api/fileTransport');
 const { getCwd } = require('@hubspot/local-dev-lib/path');
 
 const { loadAndValidateOptions } = require('../../../lib/validation');

--- a/packages/cli/commands/customObject/schema/update.js
+++ b/packages/cli/commands/customObject/schema/update.js
@@ -4,7 +4,7 @@ const {
 } = require('../../../lib/errorHandlers/standardErrors');
 const { getAbsoluteFilePath } = require('@hubspot/local-dev-lib/path');
 const {
-  isFileValidJSON,
+  checkAndConvertToJson,
   loadAndValidateOptions,
 } = require('../../../lib/validation');
 const { trackCommandUsage } = require('../../../lib/usageTracking');
@@ -38,7 +38,7 @@ exports.handler = async options => {
   trackCommandUsage('custom-object-schema-update', null, accountId);
 
   const filePath = getAbsoluteFilePath(definition);
-  if (!isFileValidJSON(filePath)) {
+  if (!checkAndConvertToJson(filePath)) {
     process.exit(EXIT_CODES.ERROR);
   }
 

--- a/packages/cli/commands/customObject/schema/update.js
+++ b/packages/cli/commands/customObject/schema/update.js
@@ -17,7 +17,7 @@ const {
 const { updateSchema } = require('@hubspot/cli-lib/api/schema');
 const {
   updateSchema: updateSchemaFromHubFile,
-} = require('@hubspot/cli-lib/api/fileTransport');
+} = require('@hubspot/local-dev-lib/api/fileTransport');
 const { getHubSpotWebsiteOrigin } = require('@hubspot/local-dev-lib/urls');
 const { i18n } = require('../../../lib/lang');
 

--- a/packages/cli/commands/customObject/schema/update.js
+++ b/packages/cli/commands/customObject/schema/update.js
@@ -62,7 +62,6 @@ exports.handler = async options => {
       );
     }
   } catch (e) {
-    console.log(e);
     logApiErrorInstance(e, { accountId });
     logger.error(
       i18n(`${i18nKey}.errors.update`, {

--- a/packages/cli/commands/hubdb/create.js
+++ b/packages/cli/commands/hubdb/create.js
@@ -6,7 +6,7 @@ const { getCwd } = require('@hubspot/local-dev-lib/path');
 const { createHubDbTable } = require('@hubspot/cli-lib/hubdb');
 
 const {
-  isFileValidJSON,
+  checkAndConvertToJson,
   loadAndValidateOptions,
 } = require('../../lib/validation');
 const { trackCommandUsage } = require('../../lib/usageTracking');
@@ -35,7 +35,7 @@ exports.handler = async options => {
 
   try {
     const filePath = path.resolve(getCwd(), src);
-    if (!isFileValidJSON(filePath)) {
+    if (!checkAndConvertToJson(filePath)) {
       process.exit(EXIT_CODES.ERROR);
     }
 

--- a/packages/cli/lib/schema.js
+++ b/packages/cli/lib/schema.js
@@ -1,7 +1,9 @@
 const chalk = require('chalk');
 const { logger } = require('@hubspot/cli-lib/logger');
 const { table, getBorderCharacters } = require('table');
-const { fetchSchemas } = require('@hubspot/cli-lib/api/schema');
+const {
+  fetchObjectSchemas,
+} = require('@hubspot/local-dev-lib/api/customObjects');
 
 const logSchemas = schemas => {
   const data = schemas
@@ -22,7 +24,7 @@ const logSchemas = schemas => {
 };
 
 const listSchemas = async accountId => {
-  const response = await fetchSchemas(accountId);
+  const response = await fetchObjectSchemas(accountId);
   logSchemas(response.results);
 };
 

--- a/packages/cli/lib/validation.js
+++ b/packages/cli/lib/validation.js
@@ -206,29 +206,31 @@ const fileExists = _path => {
   return true;
 };
 
-const isFileValidJSON = _path => {
+const checkAndConvertToJson = _path => {
   const filePath = getAbsoluteFilePath(_path);
   if (!fileExists(filePath)) return false;
 
   if (getExt(_path) !== 'json') {
     logger.error(`The file "${_path}" must be a valid JSON file`);
-    return false;
+    return null;
   }
+
+  let result;
 
   try {
-    JSON.parse(fs.readFileSync(filePath));
+    result = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
   } catch (e) {
     logger.error(`The file "${_path}" contains invalid JSON`);
-    return false;
+    result = null;
   }
 
-  return true;
+  return result;
 };
 
 module.exports = {
   validateMode,
   validateAccount,
-  isFileValidJSON,
+  checkAndConvertToJson,
   fileExists,
   loadAndValidateOptions,
 };

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@hubspot/cli-lib": "^9.0.0",
-    "@hubspot/local-dev-lib": "^0.3.0",
+    "@hubspot/local-dev-lib": "^0.3.1",
     "@hubspot/serverless-dev-runtime": "5.1.3",
     "@hubspot/ui-extensions-dev-server": "0.8.9",
     "archiver": "^5.3.0",

--- a/packages/serverless-dev-runtime/package.json
+++ b/packages/serverless-dev-runtime/package.json
@@ -7,7 +7,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@hubspot/cli-lib": "^9.0.0",
-    "@hubspot/local-dev-lib": "^0.3.0",
+    "@hubspot/local-dev-lib": "^0.3.1",
     "body-parser": "^1.19.0",
     "chalk": "^4.1.0",
     "chokidar": "^3.4.3",

--- a/packages/webpack-cms-plugins/package.json
+++ b/packages/webpack-cms-plugins/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@hubspot/cli-lib": "^9.0.0",
-    "@hubspot/local-dev-lib": "^0.3.0"
+    "@hubspot/local-dev-lib": "^0.3.1"
   },
   "gitHead": "0659fd19cabc3645af431b177c11d0c1b089e0f8"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -513,10 +513,10 @@
     table "^6.6.0"
     unixify "1.0.0"
 
-"@hubspot/cli-lib@^8.0.2":
-  version "8.0.2"
-  resolved "https://registry.yarnpkg.com/@hubspot/cli-lib/-/cli-lib-8.0.2.tgz#68ebe595049c3f2cb7bf77b31e933c19a3013ed2"
-  integrity sha512-dnUqzWvOcS+x7sy49Rkbfsq5dDDabsBlMwLf/NlrEQW6CwIFHWKcQNW6mVUMhbJNzpUl2O6+R+oV//sKzApI1A==
+"@hubspot/cli-lib@^9.0.0":
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/@hubspot/cli-lib/-/cli-lib-9.0.0.tgz#b1da703cb3ffb931f56e8eb6bb25b2726a99b844"
+  integrity sha512-gN4gFLTe0c2gdqajEY0TpcK9t8HVnTXoypd/OPsrekVLYtZWeoq9OnH2IuiKg2CFca7bVqD2Te8KYFwUCcZtDg==
   dependencies:
     chalk "^2.4.2"
     chokidar "^3.0.1"
@@ -537,10 +537,10 @@
     table "^6.6.0"
     unixify "1.0.0"
 
-"@hubspot/local-dev-lib@^0.2.4":
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/@hubspot/local-dev-lib/-/local-dev-lib-0.2.4.tgz#af80a37283d08e55fa71ecff6a9832e01e459057"
-  integrity sha512-J/5cuPHqn5T2/Vh/yNe5UsPRROyfuujKI0KeRn+yd+A5ZCA0ei+GQaIsXrQbEAhcSJT+39o3umdeaEZZFACVeQ==
+"@hubspot/local-dev-lib@^0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@hubspot/local-dev-lib/-/local-dev-lib-0.3.1.tgz#2137d3d41be41c50193346d15b8f6a8a039adf1c"
+  integrity sha512-w3Wjiadw0sJw2akRYbU4PfDK9eXDmm9iEMPNgMN7NH43U68+l2BgDK+KFk5z9bOftHZg1IdF9JuQmSo45q4Ddg==
   dependencies:
     address "^2.0.1"
     axios "^1.3.5"


### PR DESCRIPTION
## Description and Context
This switches deps for the following api modules to use `local-dev-lib`
* `api/customObject`
* `api/schema` (consolidated with `customObject`)
* `api/fileTransport`

## Testing
The following commands need to be tested
* `hs custom-object create`
* `hs custom-object scheme create`
* `hs custom-object schema delete`
* `hs custom-object schema fetch`
* `hs custom-object scheme update`

## TODO
Need to merge this PR and release LDL https://github.com/HubSpot/hubspot-local-dev-lib/pull/99

## Who to Notify
@kemmerle @brandenrodgers 
