### PR TITLE
Use local-dev-lib for hubdb and api/hubdb

### DIFF
--- a/packages/cli/commands/hubdb/clear.js
+++ b/packages/cli/commands/hubdb/clear.js
@@ -1,6 +1,6 @@
 const { logger } = require('@hubspot/cli-lib/logger');
 const { logErrorInstance } = require('../../lib/errorHandlers/standardErrors');
-const { clearHubDbTableRows } = require('@hubspot/cli-lib/hubdb');
+const { clearHubDbTableRows } = require('@hubspot/local-dev-lib/hubdb');
 const { publishTable } = require('@hubspot/local-dev-lib/api/hubdb');
 
 const { loadAndValidateOptions } = require('../../lib/validation');

--- a/packages/cli/commands/hubdb/clear.js
+++ b/packages/cli/commands/hubdb/clear.js
@@ -1,7 +1,7 @@
 const { logger } = require('@hubspot/cli-lib/logger');
 const { logErrorInstance } = require('../../lib/errorHandlers/standardErrors');
 const { clearHubDbTableRows } = require('@hubspot/cli-lib/hubdb');
-const { publishTable } = require('@hubspot/cli-lib/api/hubdb');
+const { publishTable } = require('@hubspot/local-dev-lib/api/hubdb');
 
 const { loadAndValidateOptions } = require('../../lib/validation');
 const { trackCommandUsage } = require('../../lib/usageTracking');

--- a/packages/cli/commands/hubdb/clear.js
+++ b/packages/cli/commands/hubdb/clear.js
@@ -1,5 +1,5 @@
 const { logger } = require('@hubspot/cli-lib/logger');
-const { logErrorInstance } = require('../../lib/errorHandlers/standardErrors');
+const { logApiErrorInstance } = require('../../lib/errorHandlers/apiErrors');
 const { clearHubDbTableRows } = require('@hubspot/local-dev-lib/hubdb');
 const { publishTable } = require('@hubspot/local-dev-lib/api/hubdb');
 
@@ -52,7 +52,7 @@ exports.handler = async options => {
       );
     }
   } catch (e) {
-    logErrorInstance(e);
+    logApiErrorInstance(e);
   }
 };
 

--- a/packages/cli/commands/hubdb/create.js
+++ b/packages/cli/commands/hubdb/create.js
@@ -1,7 +1,7 @@
 const path = require('path');
 
 const { logger } = require('@hubspot/cli-lib/logger');
-const { logErrorInstance } = require('../../lib/errorHandlers/standardErrors');
+const { logApiErrorInstance } = require('../../lib/errorHandlers/apiErrors');
 const { getCwd } = require('@hubspot/local-dev-lib/path');
 const { createHubDbTable } = require('@hubspot/local-dev-lib/hubdb');
 
@@ -56,7 +56,7 @@ exports.handler = async options => {
         src,
       })
     );
-    logErrorInstance(e);
+    logApiErrorInstance(e);
   }
 };
 

--- a/packages/cli/commands/hubdb/create.js
+++ b/packages/cli/commands/hubdb/create.js
@@ -3,7 +3,7 @@ const path = require('path');
 const { logger } = require('@hubspot/cli-lib/logger');
 const { logErrorInstance } = require('../../lib/errorHandlers/standardErrors');
 const { getCwd } = require('@hubspot/local-dev-lib/path');
-const { createHubDbTable } = require('@hubspot/cli-lib/hubdb');
+const { createHubDbTable } = require('@hubspot/local-dev-lib/hubdb');
 
 const {
   checkAndConvertToJson,

--- a/packages/cli/commands/hubdb/delete.js
+++ b/packages/cli/commands/hubdb/delete.js
@@ -1,6 +1,6 @@
 const { logger } = require('@hubspot/cli-lib/logger');
 const { logErrorInstance } = require('../../lib/errorHandlers/standardErrors');
-const { deleteTable } = require('@hubspot/cli-lib/api/hubdb');
+const { deleteTable } = require('@hubspot/local-dev-lib/api/hubdb');
 const { loadAndValidateOptions } = require('../../lib/validation');
 const { trackCommandUsage } = require('../../lib/usageTracking');
 

--- a/packages/cli/commands/hubdb/delete.js
+++ b/packages/cli/commands/hubdb/delete.js
@@ -1,5 +1,5 @@
 const { logger } = require('@hubspot/cli-lib/logger');
-const { logErrorInstance } = require('../../lib/errorHandlers/standardErrors');
+const { logApiErrorInstance } = require('../../lib/errorHandlers/apiErrors');
 const { deleteTable } = require('@hubspot/local-dev-lib/api/hubdb');
 const { loadAndValidateOptions } = require('../../lib/validation');
 const { trackCommandUsage } = require('../../lib/usageTracking');
@@ -40,7 +40,7 @@ exports.handler = async options => {
         tableId,
       })
     );
-    logErrorInstance(e);
+    logApiErrorInstance(e);
   }
 };
 

--- a/packages/cli/commands/hubdb/fetch.js
+++ b/packages/cli/commands/hubdb/fetch.js
@@ -1,5 +1,5 @@
 const { logger } = require('@hubspot/cli-lib/logger');
-const { logErrorInstance } = require('../../lib/errorHandlers/standardErrors');
+const { logApiErrorInstance } = require('../../lib/errorHandlers/apiErrors');
 const { downloadHubDbTable } = require('@hubspot/local-dev-lib/hubdb');
 
 const { loadAndValidateOptions } = require('../../lib/validation');
@@ -37,7 +37,7 @@ exports.handler = async options => {
       })
     );
   } catch (e) {
-    logErrorInstance(e);
+    logApiErrorInstance(e);
   }
 };
 

--- a/packages/cli/commands/hubdb/fetch.js
+++ b/packages/cli/commands/hubdb/fetch.js
@@ -1,6 +1,6 @@
 const { logger } = require('@hubspot/cli-lib/logger');
 const { logErrorInstance } = require('../../lib/errorHandlers/standardErrors');
-const { downloadHubDbTable } = require('@hubspot/cli-lib/hubdb');
+const { downloadHubDbTable } = require('@hubspot/local-dev-lib/hubdb');
 
 const { loadAndValidateOptions } = require('../../lib/validation');
 const { trackCommandUsage } = require('../../lib/usageTracking');

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@hubspot/cli-lib": "^9.0.0",
-    "@hubspot/local-dev-lib": "^0.3.1",
+    "@hubspot/local-dev-lib": "^0.3.2",
     "@hubspot/serverless-dev-runtime": "5.1.3",
     "@hubspot/ui-extensions-dev-server": "0.8.9",
     "archiver": "^5.3.0",

--- a/packages/serverless-dev-runtime/package.json
+++ b/packages/serverless-dev-runtime/package.json
@@ -7,7 +7,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@hubspot/cli-lib": "^9.0.0",
-    "@hubspot/local-dev-lib": "^0.3.1",
+    "@hubspot/local-dev-lib": "^0.3.2",
     "body-parser": "^1.19.0",
     "chalk": "^4.1.0",
     "chokidar": "^3.4.3",

--- a/packages/webpack-cms-plugins/package.json
+++ b/packages/webpack-cms-plugins/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@hubspot/cli-lib": "^9.0.0",
-    "@hubspot/local-dev-lib": "^0.3.1"
+    "@hubspot/local-dev-lib": "^0.3.2"
   },
   "gitHead": "0659fd19cabc3645af431b177c11d0c1b089e0f8"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -537,10 +537,10 @@
     table "^6.6.0"
     unixify "1.0.0"
 
-"@hubspot/local-dev-lib@^0.3.1":
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/@hubspot/local-dev-lib/-/local-dev-lib-0.3.1.tgz#2137d3d41be41c50193346d15b8f6a8a039adf1c"
-  integrity sha512-w3Wjiadw0sJw2akRYbU4PfDK9eXDmm9iEMPNgMN7NH43U68+l2BgDK+KFk5z9bOftHZg1IdF9JuQmSo45q4Ddg==
+"@hubspot/local-dev-lib@^0.3.2":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@hubspot/local-dev-lib/-/local-dev-lib-0.3.2.tgz#5479bbf212b01742652cf57314b72bd61bf3d546"
+  integrity sha512-mH7RZLSjGWVcp3dwuiwbpGOmsL6MT6PBjRKMlXvYWrsaz/8K+gYNiOWh8zMSoTLxQ1F81In+/jBdhXMd3MsMAQ==
   dependencies:
     address "^2.0.1"
     axios "^1.3.5"


### PR DESCRIPTION
## Description and Context
This updates imports of `hubdb` and `api/hubdb` to use `local-dev-lib` rather than `cli-lib`

## Screenshots
<!-- Provide images of the before and after functionality -->

## TODO
Need to release changes here before merging https://github.com/HubSpot/hubspot-local-dev-lib/pull/103

## Who to Notify
@brandenrodgers @kemmerle 
