### PR TITLE
Include flags at the beginning of the upload prompt

### DIFF
--- a/packages/cli/commands/project/upload.js
+++ b/packages/cli/commands/project/upload.js
@@ -49,14 +49,10 @@ exports.handler = async options => {
 
   await showPlatformVersionWarning(accountId, projectConfig);
 
-  logger.log('');
-  logger.log(i18n(`${i18nKey}.describe`));
-  logger.log(
-    "$0 project upload myProjectFolder --forceCreate=true --message='Add a message when you upload your project'"
-  );
-  logger.log('');
-
-  await ensureProjectExists(accountId, projectConfig.name, { forceCreate });
+  await ensureProjectExists(accountId, projectConfig.name, {
+    forceCreate,
+    uploadCommand: true,
+  });
 
   try {
     const result = await handleProjectUpload(

--- a/packages/cli/commands/project/upload.js
+++ b/packages/cli/commands/project/upload.js
@@ -30,7 +30,7 @@ const { EXIT_CODES } = require('../../lib/enums/exitCodes');
 
 const i18nKey = 'cli.commands.project.subcommands.upload';
 
-exports.command = 'upload [path]';
+exports.command = 'upload [path] [--forceCreate] [--message]';
 exports.describe = uiBetaTag(i18n(`${i18nKey}.describe`), false);
 
 exports.handler = async options => {
@@ -48,6 +48,13 @@ exports.handler = async options => {
   validateProjectConfig(projectConfig, projectDir);
 
   await showPlatformVersionWarning(accountId, projectConfig);
+
+  logger.log('');
+  logger.log(i18n(`${i18nKey}.describe`));
+  logger.log(
+    "$0 project upload myProjectFolder --forceCreate=true --message='Add a message when you upload your project'"
+  );
+  logger.log('');
 
   await ensureProjectExists(accountId, projectConfig.name, { forceCreate });
 

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -933,6 +933,7 @@ en:
           fileFiltered: "Ignore rule triggered for \"{{ filename }}\""
         ensureProjectExists:
           createPrompt: "The project {{ projectName }} does not exist in {{ accountIdentifier }}. Would you like to create it?"
+          createPromptUpload: "[--forceCreate] The project {{ projectName }} does not exist in {{ accountIdentifier }}. Would you like to create it?"
           createSuccess: "New project {{#bold}}{{ projectName }}{{/bold}} successfully created in {{#bold}}{{ accountIdentifier }}{{/bold}}."
           notFound: "Your project {{#bold}}{{ projectName }}{{/bold}} could not be found in {{#bold}}{{ accountIdentifier }}{{/bold}}."
         pollFetchProject:

--- a/packages/cli/lib/projects.js
+++ b/packages/cli/lib/projects.js
@@ -238,6 +238,7 @@ const ensureProjectExists = async (
     allowCreate = true,
     noLogs = false,
     withPolling = false,
+    uploadCommand = false,
   } = {}
 ) => {
   const accountIdentifier = uiAccountDescription(accountId);
@@ -251,10 +252,11 @@ const ensureProjectExists = async (
       let shouldCreateProject = forceCreate;
 
       if (allowCreate && !shouldCreateProject) {
+        const promptKey = uploadCommand ? 'createPromptUpload' : 'createPrompt';
         const promptResult = await promptUser([
           {
             name: 'shouldCreateProject',
-            message: i18n(`${i18nKey}.ensureProjectExists.createPrompt`, {
+            message: i18n(`${i18nKey}.ensureProjectExists.${promptKey}`, {
               projectName,
               accountIdentifier,
             }),


### PR DESCRIPTION
## Description and Context
In a Slack thread, @brandenrodgers pointed out that it's difficult to discover the `--forceCreate` and `--message` flags in the `hs project upload` command. 

@brandenrodgers, you noted in Slack that the two flags weren't showing up in the help menu for the `create` command, but they only exist for the `upload` command, and they do appear in that help menu. 

I took your suggestion to include an example of the command with the `--forceCreate` command at the beginning of the upload flow. This isn't the usual pattern for us (the closest we come to it is in the `hs project add` command), so wanted to get your feedback. I know the message flag's message is a bit too long right now. 

## Screenshots
<!-- Provide images of the before and after functionality -->

<img width="1618" alt="Screenshot 2024-02-13 at 3 01 26 PM" src="https://github.com/HubSpot/hubspot-cli/assets/25392256/62718fbb-9280-4104-8029-dfe596532374">

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

- [ ] Address feedback (What should the message example read? Should it be included at all?) 

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@brandenrodgers @camden11 
