### PR TITLE
Remove project default platform version fetch

### DIFF
--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -964,8 +964,7 @@ en:
           feedbackMessage: "How are you liking the new projects and developer tools? \n > Run `{{#yellow}}hs feedback{{/yellow}}` to let us know what you think!\n"
         showPlatformVersionWarning:
           docsLink: "Projects platform versioning (BETA)"
-          noPlatformVersion: "No platformVersion found in hsproject.json. Falling back to version \"{{ defaultVersion }}\". Starting Mar 31, 2024, new project builds without a specified version will no longer be supported. To update your project to the latest version, see {{ docsLink }}."
-          noPlatformVersionAlt: "No platformVersion found in hsproject.json. Falling back to default version. Starting Mar 31, 2024, new project builds without a specified version will no longer be supported. To update your project to the latest version, see {{ docsLink }}."
+          noPlatformVersion: "No platformVersion found in hsproject.json. Falling back to default version. Starting Mar 31, 2024, new project builds without a specified version will no longer be supported. To update your project to the latest version, see {{ docsLink }}."
           deprecatedVersion: "Starting Mar 31, 2024, new project builds with platformVersion 2023.1 or unspecified versions will no longer be supported. It's recommended that you update your project to the latest version. For more info, see {{ docsLink }}."
       ui:
         betaTag: "{{#bold}}[BETA]{{/bold}}"

--- a/packages/cli/lib/projects.js
+++ b/packages/cli/lib/projects.js
@@ -18,9 +18,6 @@ const {
   SPINNER_STATUS,
 } = require('@hubspot/cli-lib/lib/constants');
 const {
-  fetchDefaultVersion,
-} = require('@hubspot/cli-lib/lib/projectPlatformVersion');
-const {
   createProject,
   getBuildStatus,
   getBuildStructure,
@@ -877,26 +874,13 @@ const showPlatformVersionWarning = async (accountId, projectConfig) => {
   );
 
   if (!platformVersion) {
-    try {
-      const defaultVersion = await fetchDefaultVersion(accountId);
-      logger.log('');
-      logger.warn(
-        i18n(`${i18nKey}.showPlatformVersionWarning.noPlatformVersion`, {
-          defaultVersion,
-          docsLink,
-        })
-      );
-      logger.log('');
-    } catch (e) {
-      logger.log('');
-      logger.warn(
-        i18n(`${i18nKey}.showPlatformVersionWarning.noPlatformVersionAlt`, {
-          docsLink,
-        })
-      );
-      logger.log('');
-      logger.debug(e.error);
-    }
+    logger.log('');
+    logger.warn(
+      i18n(`${i18nKey}.showPlatformVersionWarning.noPlatformVersion`, {
+        docsLink,
+      })
+    );
+    logger.log('');
   } else if (platformVersion === '2023.1') {
     logger.log('');
     logger.warn(


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
Removing the fetch for the default project platform version because we are removing the pattern where the BE falls back to the default version. Platform version will be a required field in the project config file starting at the end of March.

## Screenshots
<!-- Provide images of the before and after functionality -->

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->