### PR TITLE
Support public app config

### DIFF
--- a/packages/cli/lib/DevServerManager.js
+++ b/packages/cli/lib/DevServerManager.js
@@ -67,6 +67,7 @@ class DevServerManager {
   }
 
   async setup({ components, onUploadRequired, accountId }) {
+    console.log(components);
     this.componentsByType = this.arrangeComponentsByType(components);
     const { env } = getAccountConfig(accountId);
     await startPortManagerServer();

--- a/packages/cli/lib/DevServerManager.js
+++ b/packages/cli/lib/DevServerManager.js
@@ -1,5 +1,5 @@
 const { logger } = require('@hubspot/local-dev-lib/logger');
-const { COMPONENT_TYPES } = require('./projectStructure');
+const { COMPONENT_TYPE_MAP } = require('./projectStructure');
 const { i18n } = require('./lang');
 const { promptUser } = require('./prompts/promptUtils');
 const { DevModeInterface } = require('@hubspot/ui-extensions-dev-server');
@@ -30,7 +30,7 @@ class DevServerManager {
     this.path = null;
     this.devServers = {
       [SERVER_KEYS.app]: {
-        componentType: COMPONENT_TYPES.app,
+        componentType: COMPONENT_TYPE_MAP.app,
         serverInterface: DevModeInterface,
       },
     };

--- a/packages/cli/lib/DevServerManager.js
+++ b/packages/cli/lib/DevServerManager.js
@@ -18,7 +18,7 @@ const { getAccountConfig } = require('@hubspot/local-dev-lib/config');
 const i18nKey = 'cli.lib.DevServerManager';
 
 const SERVER_KEYS = {
-  app: 'app',
+  privateApp: 'privateApp',
   publicApp: 'publicApp',
 };
 
@@ -30,8 +30,8 @@ class DevServerManager {
     this.server = null;
     this.path = null;
     this.devServers = {
-      [SERVER_KEYS.app]: {
-        componentType: COMPONENT_TYPES.app,
+      [SERVER_KEYS.privateApp]: {
+        componentType: COMPONENT_TYPES.privateApp,
         serverInterface: DevModeInterface,
       },
       [SERVER_KEYS.publicApp]: {

--- a/packages/cli/lib/DevServerManager.js
+++ b/packages/cli/lib/DevServerManager.js
@@ -1,5 +1,5 @@
 const { logger } = require('@hubspot/local-dev-lib/logger');
-const { COMPONENT_TYPE_MAP } = require('./projectStructure');
+const { COMPONENT_TYPES } = require('./projectStructure');
 const { i18n } = require('./lang');
 const { promptUser } = require('./prompts/promptUtils');
 const { DevModeInterface } = require('@hubspot/ui-extensions-dev-server');
@@ -19,6 +19,7 @@ const i18nKey = 'cli.lib.DevServerManager';
 
 const SERVER_KEYS = {
   app: 'app',
+  publicApp: 'publicApp',
 };
 
 class DevServerManager {
@@ -30,7 +31,11 @@ class DevServerManager {
     this.path = null;
     this.devServers = {
       [SERVER_KEYS.app]: {
-        componentType: COMPONENT_TYPE_MAP.app,
+        componentType: COMPONENT_TYPES.app,
+        serverInterface: DevModeInterface,
+      },
+      [SERVER_KEYS.publicApp]: {
+        componentType: COMPONENT_TYPES.publicApp,
         serverInterface: DevModeInterface,
       },
     };

--- a/packages/cli/lib/DevServerManager.js
+++ b/packages/cli/lib/DevServerManager.js
@@ -72,7 +72,6 @@ class DevServerManager {
   }
 
   async setup({ components, onUploadRequired, accountId }) {
-    console.log(components);
     this.componentsByType = this.arrangeComponentsByType(components);
     const { env } = getAccountConfig(accountId);
     await startPortManagerServer();

--- a/packages/cli/lib/LocalDevManager.js
+++ b/packages/cli/lib/LocalDevManager.js
@@ -14,7 +14,7 @@ const DevServerManager = require('./DevServerManager');
 const { EXIT_CODES } = require('./enums/exitCodes');
 const { getProjectDetailUrl } = require('./projects');
 const {
-  CONFIG_TYPE_MAP,
+  CONFIG_FILES,
   COMPONENT_TYPES,
   findProjectComponents,
   getAppCardConfigs,
@@ -287,7 +287,7 @@ class LocalDevManager {
       .map(component => {
         const appConfigPath = path.join(
           component.path,
-          CONFIG_TYPE_MAP[component.type]
+          CONFIG_FILES[component.type]
         );
         return appConfigPath;
       });

--- a/packages/cli/lib/LocalDevManager.js
+++ b/packages/cli/lib/LocalDevManager.js
@@ -14,7 +14,7 @@ const DevServerManager = require('./DevServerManager');
 const { EXIT_CODES } = require('./enums/exitCodes');
 const { getProjectDetailUrl } = require('./projects');
 const {
-  APP_COMPONENT_CONFIG,
+  CONFIG_TYPE_MAP,
   COMPONENT_TYPES,
   findProjectComponents,
   getAppCardConfigs,
@@ -243,7 +243,7 @@ class LocalDevManager {
     let missingComponents = [];
 
     runnableComponents.forEach(({ type, config, path }) => {
-      if (type === COMPONENT_TYPES.app) {
+      if (Object.values(COMPONENT_TYPES).includes(type)) {
         const cardConfigs = getAppCardConfigs(config, path);
 
         if (!deployedComponentNames.includes(config.name)) {
@@ -283,9 +283,12 @@ class LocalDevManager {
     });
 
     const configPaths = runnableComponents
-      .filter(({ type }) => type === COMPONENT_TYPES.app)
+      .filter(({ type }) => Object.values(COMPONENT_TYPES).includes(type))
       .map(component => {
-        const appConfigPath = path.join(component.path, APP_COMPONENT_CONFIG);
+        const appConfigPath = path.join(
+          component.path,
+          CONFIG_TYPE_MAP[component.type]
+        );
         return appConfigPath;
       });
 

--- a/packages/cli/lib/projectStructure.js
+++ b/packages/cli/lib/projectStructure.js
@@ -103,14 +103,13 @@ async function findProjectComponents(projectSourceDir) {
       const parsedAppConfig = loadConfigFile(projectFile);
 
       if (parsedAppConfig && parsedAppConfig.name) {
-        const appPath = `${dir}/`;
-        const isLegacy = getIsLegacyApp(parsedAppConfig, appPath);
+        const isLegacy = getIsLegacyApp(parsedAppConfig, dir);
 
         components.push({
           type: getTypeFromConfigFile(base),
           config: parsedAppConfig,
           runnable: !isLegacy,
-          path: appPath,
+          path: dir,
         });
       }
     }

--- a/packages/cli/lib/projectStructure.js
+++ b/packages/cli/lib/projectStructure.js
@@ -9,15 +9,10 @@ const COMPONENT_TYPES = Object.freeze({
   publicApp: 'public-app',
 });
 
-const PRIVATE_APP_COMPONENT_CONFIG = 'app.json';
-const PUBLIC_APP_COMPONENT_CONFIG = 'public-app.json';
-
 const CONFIG_TYPE_MAP = {
-  [PRIVATE_APP_COMPONENT_CONFIG]: COMPONENT_TYPES.privateApp,
-  [PUBLIC_APP_COMPONENT_CONFIG]: COMPONENT_TYPES.publicApp,
+  'app.json': COMPONENT_TYPES.privateApp,
+  'public-app.json': COMPONENT_TYPES.publicApp,
 };
-
-const CONFIG_FILES = Object.keys(CONFIG_TYPE_MAP);
 
 function loadConfigFile(configPath) {
   if (configPath) {
@@ -95,7 +90,7 @@ async function findProjectComponents(projectSourceDir) {
     // Find app components
     const { base, dir } = path.parse(projectFile);
 
-    if (CONFIG_FILES.includes(base)) {
+    if (Object.keys(CONFIG_TYPE_MAP).includes(base)) {
       const parsedAppConfig = loadConfigFile(projectFile);
 
       if (parsedAppConfig && parsedAppConfig.name) {
@@ -116,7 +111,7 @@ async function findProjectComponents(projectSourceDir) {
 }
 
 module.exports = {
-  APP_COMPONENT_CONFIG,
+  CONFIG_TYPE_MAP,
   COMPONENT_TYPES,
   findProjectComponents,
   getAppCardConfigs,

--- a/packages/cli/lib/projectStructure.js
+++ b/packages/cli/lib/projectStructure.js
@@ -9,10 +9,19 @@ const COMPONENT_TYPES = Object.freeze({
   publicApp: 'public-app',
 });
 
-const CONFIG_TYPE_MAP = {
-  'app.json': COMPONENT_TYPES.privateApp,
-  'public-app.json': COMPONENT_TYPES.publicApp,
+const CONFIG_FILES = {
+  [COMPONENT_TYPES.privateApp]: 'app.json',
+  [COMPONENT_TYPES.publicApp]: 'public-app.json',
 };
+
+function getTypeFromConfigFile(configFile) {
+  for (let key in CONFIG_FILES) {
+    if (CONFIG_FILES[key] === configFile) {
+      return key;
+    }
+  }
+  return null;
+}
 
 function loadConfigFile(configPath) {
   if (configPath) {
@@ -90,7 +99,7 @@ async function findProjectComponents(projectSourceDir) {
     // Find app components
     const { base, dir } = path.parse(projectFile);
 
-    if (Object.keys(CONFIG_TYPE_MAP).includes(base)) {
+    if (Object.values(CONFIG_FILES).includes(base)) {
       const parsedAppConfig = loadConfigFile(projectFile);
 
       if (parsedAppConfig && parsedAppConfig.name) {
@@ -98,7 +107,7 @@ async function findProjectComponents(projectSourceDir) {
         const isLegacy = getIsLegacyApp(parsedAppConfig, appPath);
 
         components.push({
-          type: CONFIG_TYPE_MAP[base],
+          type: getTypeFromConfigFile(base),
           config: parsedAppConfig,
           runnable: !isLegacy,
           path: appPath,
@@ -111,7 +120,7 @@ async function findProjectComponents(projectSourceDir) {
 }
 
 module.exports = {
-  CONFIG_TYPE_MAP,
+  CONFIG_FILES,
   COMPONENT_TYPES,
   findProjectComponents,
   getAppCardConfigs,


### PR DESCRIPTION
## Description and Context
See https://git.hubteam.com/HubSpot/hubspot-cli-issues/issues/510
This makes a few behind-the-scenes changes to `hs project dev` to make parsing public app configs a bit cleaner and less error prone. Previously, `findProjectComponents` would look for any file _ending_ in `app.json`, which included `public-app.json`. Now it looks for specific config files, and then adds their corresponding `type` to the component object that gets passed into the dev servers. This also changes the `type` for private apps from `app` to `private-app`. From what I could tell, `type` isn't currently being used by the dev server, but will likely be useful when there are multiple types of components supported.

At this point, running `hs project dev` on a public app will still fail, since they're not supported by the UIE dev server yet. This PR shouldn't change the behavior of `hs project dev` at all - to test, make sure local development on private apps still works.

## Who to Notify
@brandenrodgers @kemmerle 
