### PR TITLE
Replace imports from cli-lib root

### DIFF
--- a/packages/cli/commands/config/set/defaultMode.js
+++ b/packages/cli/commands/config/set/defaultMode.js
@@ -1,6 +1,6 @@
 const { logger } = require('@hubspot/local-dev-lib/logger');
 const { updateDefaultMode } = require('@hubspot/local-dev-lib/config');
-const { Mode } = require('@hubspot/cli-lib');
+const { MODE } = require('@hubspot/local-dev-lib/constants/files');
 const { commaSeparatedValues } = require('@hubspot/local-dev-lib/text');
 const { trackCommandUsage } = require('../../../lib/usageTracking');
 const { promptUser } = require('../../../lib/prompts/promptUtils');
@@ -8,7 +8,7 @@ const { i18n } = require('../../../lib/lang');
 
 const i18nKey = 'cli.commands.config.subcommands.set.options.defaultMode';
 
-const ALL_MODES = Object.values(Mode);
+const ALL_MODES = Object.values(MODE);
 
 const selectMode = async () => {
   const { mode } = await promptUser([
@@ -19,7 +19,7 @@ const selectMode = async () => {
       pageSize: 20,
       message: i18n(`${i18nKey}.promptMessage`),
       choices: ALL_MODES,
-      default: Mode.publish,
+      default: MODE.publish,
     },
   ]);
 

--- a/packages/cli/commands/upload.js
+++ b/packages/cli/commands/upload.js
@@ -1,6 +1,9 @@
 const fs = require('fs');
 const path = require('path');
-const { uploadFolder, hasUploadErrors } = require('@hubspot/cli-lib');
+const {
+  uploadFolder,
+  hasUploadErrors,
+} = require('@hubspot/local-dev-lib/cms/uploadFolder');
 const {
   getFileMapperQueryValues,
 } = require('@hubspot/local-dev-lib/fileMapper');

--- a/packages/cli/commands/watch.js
+++ b/packages/cli/commands/watch.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 
-const { watch } = require('@hubspot/cli-lib');
+const { watch } = require('@hubspot/local-dev-lib/cms/watch');
 const { getCwd } = require('@hubspot/local-dev-lib/path');
 const { logger } = require('@hubspot/local-dev-lib/logger');
 

--- a/packages/cli/lib/__tests__/commonOpts.js
+++ b/packages/cli/lib/__tests__/commonOpts.js
@@ -10,7 +10,6 @@ const {
 } = require('@hubspot/local-dev-lib/config');
 const { getMode } = require('../commonOpts');
 
-jest.mock('@hubspot/local-dev-lib');
 jest.mock('@hubspot/local-dev-lib/config');
 
 describe('@hubspot/cli/lib/commonOpts', () => {

--- a/packages/cli/lib/__tests__/commonOpts.js
+++ b/packages/cli/lib/__tests__/commonOpts.js
@@ -1,4 +1,7 @@
-const { Mode, DEFAULT_MODE } = require('@hubspot/cli-lib');
+const {
+  MODE,
+  DEFAULT_MODE,
+} = require('@hubspot/local-dev-lib/constants/files');
 const {
   getAndLoadConfigIfNeeded,
   getAccountId,
@@ -7,7 +10,7 @@ const {
 } = require('@hubspot/local-dev-lib/config');
 const { getMode } = require('../commonOpts');
 
-jest.mock('@hubspot/cli-lib');
+jest.mock('@hubspot/local-dev-lib');
 jest.mock('@hubspot/local-dev-lib/config');
 
 describe('@hubspot/cli/lib/commonOpts', () => {
@@ -19,7 +22,7 @@ describe('@hubspot/cli/lib/commonOpts', () => {
     const devAccountConfig = {
       accountId: accounts.DEV,
       name: 'DEV',
-      defaultMode: Mode.draft,
+      defaultMode: MODE.draft,
     };
     const prodAccountConfig = {
       accountId: accounts.PROD,
@@ -31,7 +34,7 @@ describe('@hubspot/cli/lib/commonOpts', () => {
     };
     const configWithDefaultMode = {
       ...config,
-      defaultMode: Mode.draft,
+      defaultMode: MODE.draft,
     };
     afterEach(() => {
       getAndLoadConfigIfNeeded.mockReset();
@@ -44,8 +47,8 @@ describe('@hubspot/cli/lib/commonOpts', () => {
         it('should return the mode specified by the command option if present.', () => {
           getAndLoadConfigIfNeeded.mockReturnValue(configWithDefaultMode);
           getAccountConfig.mockReturnValue(devAccountConfig);
-          expect(getMode({ mode: Mode.draft })).toBe(Mode.draft);
-          expect(getMode({ mode: Mode.publish })).toBe(Mode.publish);
+          expect(getMode({ mode: MODE.draft })).toBe(MODE.draft);
+          expect(getMode({ mode: MODE.publish })).toBe(MODE.publish);
           expect(getMode({ mode: 'undefined-mode' })).toBe('undefined-mode');
         });
       });
@@ -55,7 +58,7 @@ describe('@hubspot/cli/lib/commonOpts', () => {
           getAccountId.mockReturnValue(accounts.DEV);
           getAccountConfig.mockReturnValue(devAccountConfig);
           loadConfigFromEnvironment.mockReturnValue(undefined);
-          expect(getMode({ account: accounts.DEV })).toBe(Mode.draft);
+          expect(getMode({ account: accounts.DEV })).toBe(MODE.draft);
         });
       });
       describe('3. hubspot.config.yml -> config.defaultMode', () => {
@@ -64,7 +67,7 @@ describe('@hubspot/cli/lib/commonOpts', () => {
           getAccountId.mockReturnValue(accounts.PROD);
           getAccountConfig.mockReturnValue(prodAccountConfig);
           loadConfigFromEnvironment.mockReturnValue(undefined);
-          expect(getMode({ account: accounts.PROD })).toBe(Mode.draft);
+          expect(getMode({ account: accounts.PROD })).toBe(MODE.draft);
         });
       });
       describe('4. DEFAULT_MODE', () => {

--- a/packages/cli/lib/__tests__/validation.js
+++ b/packages/cli/lib/__tests__/validation.js
@@ -7,7 +7,7 @@ const {
 const { getAccountId } = require('../commonOpts');
 const { validateAccount } = require('../validation');
 
-jest.mock('@hubspot/cli-lib');
+jest.mock('@hubspot/local-dev-lib');
 jest.mock('@hubspot/local-dev-lib/config');
 jest.mock('@hubspot/local-dev-lib/logger');
 jest.mock('@hubspot/local-dev-lib/oauth');

--- a/packages/cli/lib/__tests__/validation.js
+++ b/packages/cli/lib/__tests__/validation.js
@@ -7,7 +7,6 @@ const {
 const { getAccountId } = require('../commonOpts');
 const { validateAccount } = require('../validation');
 
-jest.mock('@hubspot/local-dev-lib');
 jest.mock('@hubspot/local-dev-lib/config');
 jest.mock('@hubspot/local-dev-lib/logger');
 jest.mock('@hubspot/local-dev-lib/oauth');

--- a/packages/cli/lib/commonOpts.js
+++ b/packages/cli/lib/commonOpts.js
@@ -2,7 +2,10 @@ const {
   LOG_LEVEL,
   setLogLevel: setLoggerLogLevel,
 } = require('@hubspot/local-dev-lib/logger');
-const { DEFAULT_MODE, Mode } = require('@hubspot/cli-lib');
+const {
+  DEFAULT_MODE,
+  MODE,
+} = require('@hubspot/local-dev-lib/constants/files');
 const {
   getAccountId: getAccountIdFromConfig,
   getAccountConfig,
@@ -35,7 +38,7 @@ const addOverwriteOptions = yargs =>
   });
 
 const addModeOptions = (yargs, { read, write }) => {
-  const modes = `<${Object.values(Mode).join(' | ')}>`;
+  const modes = `<${Object.values(MODE).join(' | ')}>`;
 
   return yargs.option('mode', {
     alias: 'm',


### PR DESCRIPTION
## Description and Context
There were a few places in the CLI that were importing `watch`, `uploadFolder`, and `MODE` directly from the `cli-lib` root. This swaps those out in favor of their `local-dev-lib` equivalents. This does _not_ change anything with `checkAndWarnGitInclusion`, which is also imported from the root, since we'll be moving that to this repo and removing it from `local-dev-lib`

See https://git.hubteam.com/HubSpot/hubspot-cli-issues/issues/477

#### Affected commands to test
* `hs upload`
* `hs watch`


## Who to Notify
@brandenrodgers @kemmerle 
