### PR TITLE
Remove cli-lib

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ When contributing to hubspot-cli, you may also need to make changes to cli-local
 1. Run `yarn local-dev` in `local-dev-lib`
 2. Run `yarn link @hubspot/local-dev-lib` in the hubspot-cli root and again in `packages/cli` to use the symlinked local package.
 
-To stop using your local `localpdev-lib`, you can follow a similar process with [yarn unlink](https://classic.yarnpkg.com/en/docs/cli/unlink).
+To stop using your local `local-dev-lib`, you can follow a similar process with [yarn unlink](https://classic.yarnpkg.com/en/docs/cli/unlink).
 
 ## Testing
 Ensure you are on the minimum version of Node supported by the CLI before running any tests, since that is the version of node that the build step uses. To find the minimum,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,12 +36,12 @@ cd /path/to/other-npm-package
 yarn link @hubspot/cli
 ```
 
-## Local development with cli-lib
-When contributing to hubspot-cli, you may also need to make changes to cli-lib. To use a local version of cli-lib as a dependancy, use [yarn link](https://classic.yarnpkg.com/lang/en/docs/cli/link/).
-1. Run `yarn link` in cli-lib to set up a symlink.
-2. Run `yarn link @hubspot/cli-lib` in hubspot-cli to use the symlinked local package.
+## Local development with local-dev-lib
+When contributing to hubspot-cli, you may also need to make changes to cli-local-dev-lib. To use a local version of local-dev-lib as a dependancy, use [yarn link](https://classic.yarnpkg.com/lang/en/docs/cli/link/).
+1. Run `yarn local-dev` in `local-dev-lib`
+2. Run `yarn link @hubspot/local-dev-lib` in the hubspot-cli root and again in `packages/cli` to use the symlinked local package.
 
-To stop using your local cli-lib, you can follow a similar process with [yarn unlink](https://classic.yarnpkg.com/en/docs/cli/unlink).
+To stop using your local `localpdev-lib`, you can follow a similar process with [yarn unlink](https://classic.yarnpkg.com/en/docs/cli/unlink).
 
 ## Testing
 Ensure you are on the minimum version of Node supported by the CLI before running any tests, since that is the version of node that the build step uses. To find the minimum,
@@ -49,10 +49,9 @@ see the `engine` entry in the [cli package.json](./packages/cli/package.json).
 
 Using [nvm](https://github.com/nvm-sh/nvm) to switch between versions will help speed up development.
 
-Tests on the CLI are located in three places:
+Tests on the CLI are located in two places:
 - `/acceptance-tests/tests`
 - `/packages/cli/lib/__tests__`
-- `/packages/cli-lib/lib/__tests__`
 
 The acceptance tests are run using `yarn test-cli`. You will need to do some configuration before being able to run the acceptance tests. See the [acceptance-tests folder](./acceptance-tests/README.md) for more information.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A CLI for HubSpot developers to enable local CMS development and automate their 
 
 See the `@hubspot/cli` [README](./packages/cli/README.md)
 
-See the node.js `cli-lib` library [README](https://github.com/HubSpot/cli-lib)
+See the node.js `local-dev-lib` library [README](https://github.com/HubSpot/hubspot-local-dev-lib)
 
 For information on the `hubspot.config.yml` file, see [HubspotConfigFile](./docs/HubspotConfigFile.md)
 

--- a/packages/cli/commands/accounts/use.js
+++ b/packages/cli/commands/accounts/use.js
@@ -4,7 +4,7 @@ const {
   getConfigPath,
   updateDefaultAccount,
   getAccountId: getAccountIdFromConfig,
-} = require('@hubspot/cli-lib/lib/config');
+} = require('@hubspot/local-dev-lib/config');
 
 const { trackCommandUsage } = require('../../lib/usageTracking');
 const { i18n } = require('../../lib/lang');

--- a/packages/cli/commands/theme/preview.js
+++ b/packages/cli/commands/theme/preview.js
@@ -14,7 +14,9 @@ const { trackCommandUsage } = require('../../lib/usageTracking');
 const { loadAndValidateOptions } = require('../../lib/validation');
 const { previewPrompt } = require('../../lib/prompts/previewPrompt');
 const { EXIT_CODES } = require('../../lib/enums/exitCodes');
-const { FileUploadResultType } = require('@hubspot/cli-lib/lib/uploadFolder');
+const {
+  FILE_UPLOAD_RESULT_TYPES,
+} = require('@hubspot/local-dev-lib/constants/files');
 const i18nKey = 'cli.commands.preview';
 const cliProgress = require('cli-progress');
 const {
@@ -121,7 +123,7 @@ exports.handler = async options => {
       });
       initialUploadProgressBar.stop();
       results.forEach(result => {
-        if (result.resultType == FileUploadResultType.FAILURE) {
+        if (result.resultType == FILE_UPLOAD_RESULT_TYPES.FAILURE) {
           logger.error('Uploading file "%s" to "%s" failed', result.file, dest);
           logApiUploadErrorInstance(
             result.error,

--- a/packages/cli/lib/commonOpts.js
+++ b/packages/cli/lib/commonOpts.js
@@ -3,9 +3,6 @@ const {
   setLogLevel: setLoggerLogLevel,
 } = require('@hubspot/local-dev-lib/logger');
 const {
-  setLogLevel: setCliLibLoggerLogLevel,
-} = require('@hubspot/cli-lib/logger');
-const {
   DEFAULT_MODE,
   MODE,
 } = require('@hubspot/local-dev-lib/constants/files');
@@ -74,14 +71,8 @@ const setLogLevel = (options = {}) => {
   const { debug } = options;
   if (debug) {
     setLoggerLogLevel(LOG_LEVEL.DEBUG);
-
-    // TODO remove this when we remove cli-lib as a dep
-    setCliLibLoggerLogLevel(LOG_LEVEL.DEBUG);
   } else {
     setLoggerLogLevel(LOG_LEVEL.LOG);
-
-    // TODO remove this when we remove cli-lib as a dep
-    setCliLibLoggerLogLevel(LOG_LEVEL.LOG);
   }
 };
 

--- a/packages/cli/lib/errorHandlers/apiErrors.js
+++ b/packages/cli/lib/errorHandlers/apiErrors.js
@@ -7,9 +7,7 @@ const {
   SCOPE_GROUPS,
   PERSONAL_ACCESS_KEY_AUTH_METHOD,
 } = require('@hubspot/local-dev-lib/constants/auth');
-const {
-  fetchScopeData,
-} = require('@hubspot/cli-lib/api/localDevAuth/authenticated');
+const { fetchScopeData } = require('@hubspot/local-dev-lib/api/localDevAuth/');
 const {
   debugErrorAndContext,
   logErrorInstance,

--- a/packages/cli/lib/errorHandlers/apiErrors.js
+++ b/packages/cli/lib/errorHandlers/apiErrors.js
@@ -7,7 +7,7 @@ const {
   SCOPE_GROUPS,
   PERSONAL_ACCESS_KEY_AUTH_METHOD,
 } = require('@hubspot/local-dev-lib/constants/auth');
-const { fetchScopeData } = require('@hubspot/local-dev-lib/api/localDevAuth/');
+const { fetchScopeData } = require('@hubspot/local-dev-lib/api/localDevAuth');
 const {
   debugErrorAndContext,
   logErrorInstance,

--- a/packages/cli/lib/process.js
+++ b/packages/cli/lib/process.js
@@ -4,7 +4,6 @@ const {
   setLogLevel,
   LOG_LEVEL,
 } = require('@hubspot/local-dev-lib/logger');
-const { setLogLevel: setCliLibLogLevel } = require('@hubspot/cli-lib/logger');
 const { i18n } = require('./lang');
 
 const i18nKey = 'cli.lib.process';
@@ -33,10 +32,6 @@ const handleExit = callback => {
         // Prevent logs when terminal closes
         if (isSIGHUP) {
           setLogLevel(LOG_LEVEL.NONE);
-
-          // Update the log level in cli-lib's instance of the logger
-          // We can remove this when we remove cli-lib as a dep
-          setCliLibLogLevel(LOG_LEVEL.NONE);
         }
 
         logger.debug(i18n(`${i18nKey}.exitDebug`, { signal }));

--- a/packages/cli/lib/projectsWatch.js
+++ b/packages/cli/lib/projectsWatch.js
@@ -6,7 +6,7 @@ const {
   logApiErrorInstance,
   ApiErrorContext,
 } = require('./errorHandlers/apiErrors');
-const { i18n } = require('@hubspot/cli-lib/lib/lang');
+const { i18n } = require('./lang');
 const { logger } = require('@hubspot/local-dev-lib/logger');
 const { isAllowedExtension } = require('@hubspot/local-dev-lib/path');
 const { shouldIgnoreFile } = require('@hubspot/local-dev-lib/ignoreRules');

--- a/packages/cli/lib/prompts/cmsFieldPrompt.js
+++ b/packages/cli/lib/prompts/cmsFieldPrompt.js
@@ -2,7 +2,7 @@ const path = require('path');
 const fs = require('fs');
 const { promptUser } = require('./promptUtils');
 const { i18n } = require('../lang');
-const escapeRegExp = require('@hubspot/cli-lib/lib/escapeRegExp');
+const escapeRegExp = require('@hubspot/local-dev-lib/escapeRegExp');
 const i18nKey = 'cli.lib.prompts.uploadPrompt';
 const FIELDS_FILES = ['fields.json', 'fields.js', 'fields.cjs', 'fields.mjs'];
 

--- a/packages/cli/lib/serverlessLogs.js
+++ b/packages/cli/lib/serverlessLogs.js
@@ -9,11 +9,19 @@ const {
   logApiErrorInstance,
   ApiErrorContext,
 } = require('./errorHandlers/apiErrors');
-const { base64EncodeString } = require('@hubspot/cli-lib/lib/encoding');
 
 const { EXIT_CODES } = require('../lib/enums/exitCodes');
 
 const TAIL_DELAY = 5000;
+
+const base64EncodeString = valueToEncode => {
+  if (typeof valueToEncode !== 'string') {
+    return valueToEncode;
+  }
+
+  const stringBuffer = Buffer.from(valueToEncode);
+  return encodeURIComponent(stringBuffer.toString('base64'));
+};
 
 const handleUserInput = () => {
   const onTerminate = async () => {

--- a/packages/cli/lib/validation.js
+++ b/packages/cli/lib/validation.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const { logger } = require('@hubspot/local-dev-lib/logger');
-const { Mode } = require('@hubspot/cli-lib');
+const { MODE } = require('@hubspot/local-dev-lib/constants/files');
 const {
   API_KEY_AUTH_METHOD,
   OAUTH_AUTH_METHOD,
@@ -175,10 +175,10 @@ async function validateAccount(options) {
  */
 function validateMode(options) {
   const mode = getMode(options);
-  if (Mode[mode]) {
+  if (MODE[mode]) {
     return true;
   }
-  const modesMessage = `Available modes are: ${Object.values(Mode).join(
+  const modesMessage = `Available modes are: ${Object.values(MODE).join(
     ', '
   )}.`;
   if (mode != null) {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,7 +8,6 @@
     "url": "https://github.com/HubSpot/hubspot-cms-tools"
   },
   "dependencies": {
-    "@hubspot/cli-lib": "^9.0.0",
     "@hubspot/local-dev-lib": "^0.3.10",
     "@hubspot/serverless-dev-runtime": "5.1.4-beta.4",
     "@hubspot/theme-preview-dev-server": "0.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -512,30 +512,6 @@
     table "^6.6.0"
     unixify "1.0.0"
 
-"@hubspot/cli-lib@^9.0.0":
-  version "9.0.0"
-  resolved "https://registry.npmjs.org/@hubspot/cli-lib/-/cli-lib-9.0.0.tgz"
-  integrity sha512-gN4gFLTe0c2gdqajEY0TpcK9t8HVnTXoypd/OPsrekVLYtZWeoq9OnH2IuiKg2CFca7bVqD2Te8KYFwUCcZtDg==
-  dependencies:
-    chalk "^2.4.2"
-    chokidar "^3.0.1"
-    content-disposition "^0.5.3"
-    debounce "^1.2.0"
-    extract-zip "^1.6.7"
-    findup-sync "^4.0.0"
-    fs-extra "^8.1.0"
-    ignore "^5.1.4"
-    jest "^29.5.0"
-    js-yaml "^4.1.0"
-    moment "^2.24.0"
-    p-queue "^6.0.2"
-    prettier "^1.19.1"
-    request "^2.87.0"
-    request-promise-native "^1.0.7"
-    semver "^6.3.0"
-    table "^6.6.0"
-    unixify "1.0.0"
-
 "@hubspot/local-dev-lib@^0.3.10":
   version "0.3.10"
   resolved "https://registry.yarnpkg.com/@hubspot/local-dev-lib/-/local-dev-lib-0.3.10.tgz#82861692ef69614920b5b5b6957d275be23003d1"


### PR DESCRIPTION
## Description and Context
This removes the remaining imports from cli-lib, removes the cli-lib dependancy, and updates the docs to remove references to cli-lib

## Testing
This touches a few files in `lib`, so it affects a wide range of commands. From what I can tell, these are the ones we should focus on testing.
* `hs accounts use`
* `hs theme preview`
* `hs projects watch`
* `hs upload`
* `hs logs`
* `hs project logs`
* `hs functions deploy`
* `hs fetch`
* `hs watch`

## Who to Notify
@kemmerle @brandenrodgers 
