### PR TITLE
Prevent same dev server from being run multiple times during hs project dev

### DIFF
--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -924,7 +924,7 @@ en:
       DevServerManager:
         portConflict: "The port {{ port }} is already in use."
         notInitialized: "The Dev Server Manager must be initialized before it is started."
-        noCompatibleComponents: "Skipping call to {{ serverKey }} because there are no compatible components in the project."
+        noCompatibleComponents: "Skipping call to {{ componentKey }} server because there are no compatible components in the project."
       LocalDevManager:
         failedToInitialize: "Missing required arguments to initialize Local Dev"
         noDeployedBuild: "There is no deployed build for this project in {{ accountIdentifier }}. Run {{ uploadCommand }} to upload and deploy your project."

--- a/packages/cli/lib/DevServerManager.js
+++ b/packages/cli/lib/DevServerManager.js
@@ -17,9 +17,13 @@ const { getAccountConfig } = require('@hubspot/local-dev-lib/config');
 
 const i18nKey = 'cli.lib.DevServerManager';
 
-const SERVER_KEYS = {
+const COMPONENT_KEYS = {
   privateApp: 'privateApp',
   publicApp: 'publicApp',
+};
+
+const SERVER_IDS = {
+  UIE_DEV_SERVER: 'UIE_DEV_SERVER',
 };
 
 class DevServerManager {
@@ -30,31 +34,40 @@ class DevServerManager {
     this.server = null;
     this.path = null;
     this.devServers = {
-      [SERVER_KEYS.privateApp]: {
+      [COMPONENT_KEYS.privateApp]: {
         componentType: COMPONENT_TYPES.privateApp,
         serverInterface: DevModeInterface,
+        id: SERVER_IDS.UIE_DEV_SERVER,
       },
-      [SERVER_KEYS.publicApp]: {
+      [COMPONENT_KEYS.publicApp]: {
         componentType: COMPONENT_TYPES.publicApp,
         serverInterface: DevModeInterface,
+        id: SERVER_IDS.UIE_DEV_SERVER,
       },
     };
   }
 
   async iterateDevServers(callback) {
-    const serverKeys = Object.keys(this.devServers);
+    const componentKeys = Object.keys(this.devServers);
+    const iteratedServerIds = [];
 
-    for (let i = 0; i < serverKeys.length; i++) {
-      const serverKey = serverKeys[i];
-      const devServer = this.devServers[serverKey];
+    for (let i = 0; i < componentKeys.length; i++) {
+      const componentKey = componentKeys[i];
+      const devServer = this.devServers[componentKey];
 
       const compatibleComponents =
         this.componentsByType[devServer.componentType] || {};
 
-      if (Object.keys(compatibleComponents).length) {
+      if (
+        Object.keys(compatibleComponents).length &&
+        !iteratedServerIds.includes(devServer.id)
+      ) {
+        iteratedServerIds.push(devServer.id);
         await callback(devServer.serverInterface, compatibleComponents);
       } else {
-        logger.debug(i18n(`${i18nKey}.noCompatibleComponents`, { serverKey }));
+        logger.debug(
+          i18n(`${i18nKey}.noCompatibleComponents`, { componentKey })
+        );
       }
     }
   }


### PR DESCRIPTION
## Description and Context
`hs project dev` is set up to iterate through multiple different servers that handle different component types, but wasn't handling the case of two different component types using the same server interface. This would cause it to call `setup` `start` etc on the UIE dev server multiple times in projects that contain both a private app and public app. This adds a check to make sure each server interface can only be iterated over once.

## Who to Notify
@brandenrodgers @kemmerle @joe-yeager 
