### PR TITLE
Log error instance correctly in project watch command (platformVersion warning fix)

### DIFF
--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -957,7 +957,6 @@ en:
           srcOutsideProjectDir: "Invalid value for 'srcDir' in {{ projectConfig }}: {{#bold}}srcDir: \"{{ srcDir }}\"{{/bold}}\n\t'srcDir' must be a relative path to a folder under the project root, such as \".\" or \"./src\""
         uploadProjectFiles:
           add: "Uploading {{#bold}}{{ projectName }}{{/bold}} project files to {{ accountIdentifier }}"
-          fail: "Failed to upload {{#bold}}{{ projectName }}{{/bold}} project files to {{ accountIdentifier }}"
           succeed: "Uploaded {{#bold}}{{ projectName }}{{/bold}} project files to {{ accountIdentifier }}"
           buildCreated: "Project \"{{ projectName }}\" uploaded and build #{{ buildId }} created"
         handleProjectUpload:

--- a/packages/cli/lib/projects.js
+++ b/packages/cli/lib/projects.js
@@ -380,12 +380,8 @@ const uploadProjectFiles = async (
       })
     );
   } catch (err) {
-    SpinniesManager.fail('upload', {
-      text: i18n(`${i18nKey}.uploadProjectFiles.fail`, {
-        accountIdentifier,
-        projectName,
-      }),
-    });
+    SpinniesManager.fail('upload');
+    logApiErrorInstance(err);
 
     error = err;
   }


### PR DESCRIPTION
## Description and Context
While testing out the new platformVersion warnings/errors in the CLI, Roger discussed that we were not displaying the correct error in the `hs project watch` command in two instances:

1) Running the `watch` command in projects with an empty platform version.
2) Running the `watch` command in projects with an unsupported platform version (ie. '2025.7').

## Screenshots
<!-- Provide images of the before and after functionality -->

Before:

<img width="1206" alt="Screenshot 2024-03-20 at 12 59 00 PM" src="https://github.com/HubSpot/hubspot-cli/assets/25392256/f4d0e37a-3c38-4e62-9d35-76d34a1fa5ec">

After:

<img width="1421" alt="Screenshot 2024-03-20 at 12 59 38 PM" src="https://github.com/HubSpot/hubspot-cli/assets/25392256/3c0991e5-6a8e-40ac-af29-750a8e892ad9">

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

- [x] Address any feedback

## Who to Notify
<!-- /cc those you wish to know about the PR -->

@brandenrodgers @camden11 
