### PR TITLE
Clean up error handling

### DIFF
--- a/packages/cli/commands/project/dev.js
+++ b/packages/cli/commands/project/dev.js
@@ -62,10 +62,10 @@ const { getHubSpotWebsiteOrigin } = require('@hubspot/local-dev-lib/urls');
 const {
   logApiErrorInstance,
   ApiErrorContext,
-  isSpecifiedError, // Migrate isSpecifiedError to local-dev-lib version only after uploadProject is migrated to local-dev-lib
 } = require('../../lib/errorHandlers/apiErrors');
 const {
   isMissingScopeError,
+  isSpecifiedError,
 } = require('@hubspot/local-dev-lib/errors/apiErrors');
 const { logErrorInstance } = require('../../lib/errorHandlers/standardErrors');
 const { isDeveloperTestAccount } = require('../../lib/developerTestAccounts');

--- a/packages/cli/commands/project/upload.js
+++ b/packages/cli/commands/project/upload.js
@@ -19,11 +19,11 @@ const {
 } = require('../../lib/projects');
 const { i18n } = require('../../lib/lang');
 const { getAccountConfig } = require('@hubspot/local-dev-lib/config');
+const { isSpecifiedError } = require('@hubspot/local-dev-lib/errors/apiErrors');
 const { PROJECT_ERROR_TYPES } = require('../../lib/constants');
 const {
   logApiErrorInstance,
   ApiErrorContext,
-  isSpecifiedError,
 } = require('../../lib/errorHandlers/apiErrors');
 const { EXIT_CODES } = require('../../lib/enums/exitCodes');
 

--- a/packages/cli/lib/errorHandlers/apiErrors.js
+++ b/packages/cli/lib/errorHandlers/apiErrors.js
@@ -39,11 +39,9 @@ class ApiErrorContext extends ErrorContext {
  */
 function logValidationErrors(error, context) {
   const { response = {} } = error;
-  const validationErrors = parseValidationErrors(response.body);
+  const validationErrors = parseValidationErrors(response.data);
   if (validationErrors.length) {
-    validationErrors.forEach(err => {
-      logger.error(err);
-    });
+    logger.error(validationErrors.join('\n- '));
   }
   debugErrorAndContext(error, context);
 }

--- a/packages/cli/lib/errorHandlers/apiErrors.js
+++ b/packages/cli/lib/errorHandlers/apiErrors.js
@@ -4,6 +4,7 @@ const {
   isMissingScopeError,
   isApiUploadValidationError,
   getAxiosErrorWithContext,
+  parseValidationErrors,
 } = require('@hubspot/local-dev-lib/errors/apiErrors');
 const {
   SCOPE_GROUPS,
@@ -21,29 +22,6 @@ const { overrideErrors } = require('./overrideErrors');
 const { i18n } = require('../lang');
 
 const i18nKey = 'cli.lib.errorHandlers.apiErrors';
-
-const parseValidationErrors = (responseBody = {}) => {
-  const errorMessages = [];
-
-  const { errors, message } = responseBody;
-
-  if (message) {
-    errorMessages.push(message);
-  }
-
-  if (errors) {
-    const specificErrors = errors.map(error => {
-      let errorMessage = error.message;
-      if (error.errorTokens && error.errorTokens.line) {
-        errorMessage = `line ${error.errorTokens.line}: ${errorMessage}`;
-      }
-      return errorMessage;
-    });
-    errorMessages.push(...specificErrors);
-  }
-
-  return errorMessages;
-};
 
 class ApiErrorContext extends ErrorContext {
   constructor(props = {}) {

--- a/packages/cli/lib/errorHandlers/apiErrors.js
+++ b/packages/cli/lib/errorHandlers/apiErrors.js
@@ -1,6 +1,8 @@
 const { logger } = require('@hubspot/local-dev-lib/logger');
 const { getAccountConfig } = require('@hubspot/local-dev-lib/config');
 const {
+  isMissingScopeError,
+  isApiUploadValidationError,
   getAxiosErrorWithContext,
 } = require('@hubspot/local-dev-lib/errors/apiErrors');
 const {
@@ -19,57 +21,6 @@ const { overrideErrors } = require('./overrideErrors');
 const { i18n } = require('../lang');
 
 const i18nKey = 'cli.lib.errorHandlers.apiErrors';
-
-const isApiStatusCodeError = err =>
-  err.name === 'StatusCodeError' ||
-  (err.statusCode >= 100 && err.statusCode < 600);
-
-const isApiUploadValidationError = err =>
-  !!(
-    err.statusCode === 400 &&
-    err.response &&
-    err.response.body &&
-    (err.response.body.message || err.response.body.errors)
-  );
-
-const isMissingScopeError = err =>
-  err.name === 'StatusCodeError' &&
-  err.statusCode === 403 &&
-  err.error &&
-  err.error.category === 'MISSING_SCOPES';
-
-const isGatingError = err =>
-  isSpecifiedError(err, { statusCode: 403, category: 'GATED' });
-
-const isSpecifiedError = (err, { statusCode, category, subCategory } = {}) => {
-  const statusCodeErr = !statusCode || err.statusCode === statusCode;
-  const categoryErr =
-    !category || (err.error && err.error.category === category);
-  const subCategoryErr =
-    !subCategory || (err.error && err.error.subCategory === subCategory);
-
-  return (
-    err.name === 'StatusCodeError' &&
-    statusCodeErr &&
-    categoryErr &&
-    subCategoryErr
-  );
-};
-
-const isSpecifiedHubSpotAuthError = (
-  err,
-  { statusCode, category, subCategory }
-) => {
-  const statusCodeErr = !statusCode || err.statusCode === statusCode;
-  const categoryErr = !category || err.category === category;
-  const subCategoryErr = !subCategory || err.subCategory === subCategory;
-  return (
-    err.name === 'HubSpotAuthError' &&
-    statusCodeErr &&
-    categoryErr &&
-    subCategoryErr
-  );
-};
 
 const parseValidationErrors = (responseBody = {}) => {
   const errorMessages = [];
@@ -122,150 +73,16 @@ function logValidationErrors(error, context) {
 }
 
 /**
- * Message segments for API messages.
- *
- * @enum {string}
- */
-const ApiMethodVerbs = {
-  DEFAULT: 'request',
-  DELETE: 'delete',
-  GET: 'request',
-  PATCH: 'update',
-  POST: 'post',
-  PUT: 'update',
-};
-
-/**
- * Message segments for API messages.
- *
- * @enum {string}
- */
-const ApiMethodPrepositions = {
-  DEFAULT: 'for',
-  DELETE: 'of',
-  GET: 'for',
-  PATCH: 'to',
-  POST: 'to',
-  PUT: 'to',
-};
-
-/**
- * Logs messages for an error instance resulting from API interaction.
- *
- * @param {StatusCodeError} error
- * @param {ApiErrorContext} context
- */
-function logApiStatusCodeError(error, context) {
-  const { statusCode } = error;
-  const { method } = error.options || {};
-  const { projectName } = context;
-  const isPutOrPost = method === 'PUT' || method === 'POST';
-  const action = ApiMethodVerbs[method] || ApiMethodVerbs.DEFAULT;
-  const preposition =
-    ApiMethodPrepositions[method] || ApiMethodPrepositions.DEFAULT;
-  let messageDetail = '';
-  {
-    const request = context.request
-      ? `${action} ${preposition} "${context.request}"`
-      : action;
-    messageDetail = `${request} in account ${context.accountId}`;
-  }
-  const errorMessage = [];
-  if (isPutOrPost && context.payload) {
-    errorMessage.push(`Unable to upload "${context.payload}".`);
-  }
-  const isProjectMissingScopeError = isMissingScopeError(error) && projectName;
-  const isProjectGatingError = isGatingError(error) && projectName;
-  switch (statusCode) {
-    case 400:
-      errorMessage.push(i18n(`${i18nKey}.codes.400`, { messageDetail }));
-      break;
-    case 401:
-      errorMessage.push(i18n(`${i18nKey}.codes.401`, { messageDetail }));
-      break;
-    case 403:
-      if (isProjectMissingScopeError) {
-        errorMessage.push(
-          i18n(`${i18nKey}.codes.403MissingScope`, {
-            accountId: context.accountId || '',
-          })
-        );
-      } else if (isProjectGatingError) {
-        errorMessage.push(
-          i18n(`${i18nKey}.codes.403Gating`, {
-            accountId: context.accountId || '',
-          })
-        );
-      } else {
-        errorMessage.push(i18n(`${i18nKey}.codes.403`, { messageDetail }));
-      }
-      break;
-    case 404:
-      if (context.request) {
-        errorMessage.push(
-          i18n(`${i18nKey}.codes.404Request`, {
-            action: action || 'request',
-            request: context.request,
-            account: context.accountId || '',
-          })
-        );
-      } else {
-        errorMessage.push(i18n(`${i18nKey}.codes.404`, { messageDetail }));
-      }
-      break;
-    case 429:
-      errorMessage.push(i18n(`${i18nKey}.codes.429`, { messageDetail }));
-      break;
-    case 503:
-      errorMessage.push(i18n(`${i18nKey}.codes.503`, { messageDetail }));
-      break;
-    default:
-      if (statusCode >= 500 && statusCode < 600) {
-        errorMessage.push(
-          i18n(`${i18nKey}.codes.500Generic`, { messageDetail })
-        );
-      } else if (statusCode >= 400 && statusCode < 500) {
-        i18n(`${i18nKey}.codes.400Generic`, { messageDetail });
-      } else {
-        errorMessage.push(i18n(`${i18nKey}.codes.generic`, { messageDetail }));
-      }
-      break;
-  }
-  if (
-    error.error &&
-    error.error.message &&
-    !isProjectMissingScopeError &&
-    !isProjectGatingError
-  ) {
-    errorMessage.push(error.error.message);
-  }
-  if (error.error && error.error.errors) {
-    error.error.errors.forEach(err => {
-      errorMessage.push('\n- ' + err.message);
-    });
-  }
-  logger.error(errorMessage.join(' '));
-  debugErrorAndContext(error, context);
-}
-
-/**
  * Logs a message for an error instance resulting from API interaction.
  *
  * @param {Error|SystemError|Object} error
  * @param {ApiErrorContext}          context
  */
 function logApiErrorInstance(error, context) {
-  // Use the new local-dev-lib error handler
-  // NOTE: This will eventually replace the logic in logApiStatusCodeError
   if (error.isAxiosError) {
     if (overrideErrors(error)) return;
     const errorWithContext = getAxiosErrorWithContext(error, context);
     logger.error(errorWithContext.message);
-    return;
-  }
-  // StatusCodeError
-  if (isApiStatusCodeError(error)) {
-    logApiStatusCodeError(error, context);
     return;
   }
   logErrorInstance(error, context);
@@ -344,12 +161,7 @@ async function logServerlessFunctionApiErrorInstance(
     return;
   }
 
-  // StatusCodeError
-  if (isApiStatusCodeError(error)) {
-    logApiStatusCodeError(error, context);
-    return;
-  }
-  logErrorInstance(error, context);
+  logApiErrorInstance(error, context);
 }
 
 module.exports = {
@@ -358,7 +170,4 @@ module.exports = {
   logApiErrorInstance,
   logApiUploadErrorInstance,
   logServerlessFunctionApiErrorInstance,
-  isMissingScopeError,
-  isSpecifiedError,
-  isSpecifiedHubSpotAuthError,
 };

--- a/packages/cli/lib/errorHandlers/fileSystemErrors.js
+++ b/packages/cli/lib/errorHandlers/fileSystemErrors.js
@@ -1,24 +1,7 @@
-const { logger } = require('@hubspot/local-dev-lib/logger');
 const {
-  ErrorContext,
-  isSystemError,
-  debugErrorAndContext,
-} = require('./standardErrors');
-const { i18n } = require('../lang');
-
-const i18nKey = 'cli.lib.errorHandlers.fileSystemErrors';
-
-class FileSystemErrorContext extends ErrorContext {
-  constructor(props = {}) {
-    super(props);
-    /** @type {string} */
-    this.filepath = props.filepath || '';
-    /** @type {boolean} */
-    this.read = !!props.read;
-    /** @type {boolean} */
-    this.write = !!props.write;
-  }
-}
+  getFileSystemError,
+} = require('@hubspot/local-dev-lib/errors/fileSystemErrors');
+const { debugErrorAndContext, logErrorInstance } = require('./standardErrors');
 
 /**
  * Logs a message for an error instance resulting from filesystem interaction.
@@ -27,29 +10,11 @@ class FileSystemErrorContext extends ErrorContext {
  * @param {FileSystemErrorContext}   context
  */
 function logFileSystemErrorInstance(error, context) {
-  let fileAction = '';
-  if (context.read) {
-    fileAction = 'reading from';
-  } else if (context.write) {
-    fileAction = 'writing to';
-  } else {
-    fileAction = 'accessing';
-  }
-  const filepath = context.filepath
-    ? `"${context.filepath}"`
-    : 'a file or folder';
-  const message = [i18n(`${i18nKey}.errorOccurred`, { fileAction, filepath })];
-  // Many `fs` errors will be `SystemError`s
-  if (isSystemError(error)) {
-    message.push(
-      i18n(`${i18nKey}.errorExplanation`, { errorMessage: error.message })
-    );
-  }
-  logger.error(message.join(' '));
+  const fileSystemError = getFileSystemError(error, context);
+  logErrorInstance(fileSystemError.message, context);
   debugErrorAndContext(error, context);
 }
 
 module.exports = {
-  FileSystemErrorContext,
   logFileSystemErrorInstance,
 };

--- a/packages/cli/lib/errorHandlers/standardErrors.js
+++ b/packages/cli/lib/errorHandlers/standardErrors.js
@@ -1,15 +1,11 @@
 const util = require('util');
-const {
-  HubSpotAuthError,
-} = require('@hubspot/local-dev-lib/models/HubSpotAuthError');
 const { logger } = require('@hubspot/local-dev-lib/logger');
+const {
+  isSystemError,
+} = require('@hubspot/local-dev-lib/errors/standardErrors');
 const { i18n } = require('../lang');
 
 const i18nKey = 'cli.lib.errorHandlers.standardErrors';
-
-const isSystemError = err =>
-  err.errno != null && err.code != null && err.syscall != null;
-const isFatalError = err => err instanceof HubSpotAuthError;
 
 // TODO: Make these TS interfaces
 class ErrorContext {
@@ -103,7 +99,5 @@ function logErrorInstance(error, context) {
 module.exports = {
   debugErrorAndContext,
   ErrorContext,
-  isFatalError,
-  isSystemError,
   logErrorInstance,
 };

--- a/packages/cli/lib/projects.js
+++ b/packages/cli/lib/projects.js
@@ -27,7 +27,10 @@ const {
   fetchProject,
   uploadProject,
 } = require('@hubspot/local-dev-lib/api/projects');
-const { isSpecifiedError } = require('@hubspot/local-dev-lib/errors/apiErrors');
+const {
+  isSpecifiedError,
+  isSpecifiedHubSpotAuthError,
+} = require('@hubspot/local-dev-lib/errors/apiErrors');
 const { shouldIgnoreFile } = require('@hubspot/local-dev-lib/ignoreRules');
 const { getCwd, getAbsoluteFilePath } = require('@hubspot/local-dev-lib/path');
 const { downloadGithubRepoContents } = require('@hubspot/local-dev-lib/github');
@@ -39,7 +42,6 @@ const SpinniesManager = require('./ui/SpinniesManager');
 const {
   logApiErrorInstance,
   ApiErrorContext,
-  isSpecifiedHubSpotAuthError,
 } = require('./errorHandlers/apiErrors');
 const { HUBSPOT_PROJECT_COMPONENTS_GITHUB_PATH } = require('./constants');
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/HubSpot/hubspot-cms-tools"
   },
   "dependencies": {
-    "@hubspot/local-dev-lib": "^0.3.11",
+    "@hubspot/local-dev-lib": "^0.3.13",
     "@hubspot/serverless-dev-runtime": "5.1.4-beta.6",
     "@hubspot/theme-preview-dev-server": "0.0.4",
     "@hubspot/ui-extensions-dev-server": "0.8.11",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@hubspot/cli-lib": "^9.0.0",
-    "@hubspot/local-dev-lib": "^0.3.10",
+    "@hubspot/local-dev-lib": "^0.3.11",
     "@hubspot/serverless-dev-runtime": "5.1.4-beta.4",
     "@hubspot/theme-preview-dev-server": "0.0.4",
     "@hubspot/ui-extensions-dev-server": "0.8.11",

--- a/packages/serverless-dev-runtime/package.json
+++ b/packages/serverless-dev-runtime/package.json
@@ -6,7 +6,7 @@
   "repository": "https://github.com/HubSpot/hubspot-cli",
   "license": "Apache-2.0",
   "dependencies": {
-    "@hubspot/local-dev-lib": "^0.3.10",
+    "@hubspot/local-dev-lib": "^0.3.11",
     "body-parser": "^1.19.0",
     "chalk": "^4.1.0",
     "chokidar": "^3.4.3",

--- a/packages/serverless-dev-runtime/package.json
+++ b/packages/serverless-dev-runtime/package.json
@@ -6,7 +6,7 @@
   "repository": "https://github.com/HubSpot/hubspot-cli",
   "license": "Apache-2.0",
   "dependencies": {
-    "@hubspot/local-dev-lib": "^0.3.11",
+    "@hubspot/local-dev-lib": "^0.3.13",
     "body-parser": "^1.19.0",
     "chalk": "^4.1.0",
     "chokidar": "^3.4.3",

--- a/packages/webpack-cms-plugins/package.json
+++ b/packages/webpack-cms-plugins/package.json
@@ -17,7 +17,7 @@
     "test": "echo \"Error: run tests from root\" && exit 1"
   },
   "dependencies": {
-    "@hubspot/local-dev-lib": "^0.3.10"
+    "@hubspot/local-dev-lib": "^0.3.11"
   },
   "gitHead": "0659fd19cabc3645af431b177c11d0c1b089e0f8"
 }

--- a/packages/webpack-cms-plugins/package.json
+++ b/packages/webpack-cms-plugins/package.json
@@ -17,7 +17,7 @@
     "test": "echo \"Error: run tests from root\" && exit 1"
   },
   "dependencies": {
-    "@hubspot/local-dev-lib": "^0.3.11"
+    "@hubspot/local-dev-lib": "^0.3.13"
   },
   "gitHead": "0659fd19cabc3645af431b177c11d0c1b089e0f8"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -536,10 +536,10 @@
     table "^6.6.0"
     unixify "1.0.0"
 
-"@hubspot/local-dev-lib@^0.3.10":
-  version "0.3.10"
-  resolved "https://registry.yarnpkg.com/@hubspot/local-dev-lib/-/local-dev-lib-0.3.10.tgz#82861692ef69614920b5b5b6957d275be23003d1"
-  integrity sha512-EKaMnM9KXRB8F4mGuLZg6yWoCRJggTJ4xU+Wl3sb9MUkGqJTxNLQ7bc3w+tlJNOXW8tog7+7iIC9VxAxAicvbQ==
+"@hubspot/local-dev-lib@^0.3.11":
+  version "0.3.11"
+  resolved "https://registry.yarnpkg.com/@hubspot/local-dev-lib/-/local-dev-lib-0.3.11.tgz#c2f7300d9ec9b41662bada0fc533d45842f86dc2"
+  integrity sha512-aEQQYvzE8UqL65RvBxVefCSRB1+ixy+HAXZrP5M+t1C5K6klpPr+n2WLZkXwL8V5ptozCCOZDeaKNAWiQ8Au4w==
   dependencies:
     address "^2.0.1"
     axios "^1.3.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -513,10 +513,10 @@
     table "^6.6.0"
     unixify "1.0.0"
 
-"@hubspot/local-dev-lib@^0.3.11":
-  version "0.3.11"
-  resolved "https://registry.yarnpkg.com/@hubspot/local-dev-lib/-/local-dev-lib-0.3.11.tgz#c2f7300d9ec9b41662bada0fc533d45842f86dc2"
-  integrity sha512-aEQQYvzE8UqL65RvBxVefCSRB1+ixy+HAXZrP5M+t1C5K6klpPr+n2WLZkXwL8V5ptozCCOZDeaKNAWiQ8Au4w==
+"@hubspot/local-dev-lib@^0.3.13":
+  version "0.3.13"
+  resolved "https://registry.yarnpkg.com/@hubspot/local-dev-lib/-/local-dev-lib-0.3.13.tgz#fdae7bd62a984fe8151efc529b41ace092c59f3c"
+  integrity sha512-s+NJNRluymkXoMV6LlQGpS0hirpKg6t83UlaPp1MqArEVz5uIu7WWm/juyw6n+AIp4/3aZ+BvxihZq4CiyRzlQ==
   dependencies:
     address "^2.0.1"
     axios "^1.3.5"


### PR DESCRIPTION
## Description and Context
Now that `cli-lib` is (soon to be) out of this repo, we can get rid of all the CLI specific error handlers and try to reduce repetition of error handling code as much as possible. This PR takes a few steps towards that, though there may be more to good.
* Remove `isSpecifiedError` and use the local-dev-lib version
* Remove `isSpecifiedHubSpotAuthError` and use the local-dev-lib version
* Remove `isMissingScopeError` and use the local-dev-lib version
* Remove `isSystemError` and use the local-dev-lib version
* Remove `isFatalError`
* Remove `parseValidationErrors` and use the local-dev-lib version
* Remove `logApiStatusCodeError` since we can now safely use `getAxiosErrorWithContext` for all API errors
* Remove remaining reference to `StatusCodeError`s
* Remove `logFileSystemErrorInstance` logic in favor of `getFileSystemError` from local-dev-lib

## Testing
This is going to be a tricky one to test - it touches a lot of different commands and a lot of errors can be tricky to reproduce. Not sure what the best move is there, but whenever this goes out it we should give it plenty of time in beta

## TODO
* Merge [this PR ](https://github.com/HubSpot/hubspot-local-dev-lib/pull/120)and release LDL

## Who to Notify
@brandenrodgers @kemmerle 
