### PR TITLE
Handle upload error in watch command (Platform version work)

### DIFF
--- a/packages/cli/commands/project/watch.js
+++ b/packages/cli/commands/project/watch.js
@@ -125,12 +125,33 @@ exports.handler = async options => {
 
     // Upload all files if no build exists for this project yet
     if (initialUpload || hasNoBuilds) {
-      await handleProjectUpload(
+      const result = await handleProjectUpload(
         accountId,
         projectConfig,
         projectDir,
         startWatching
       );
+
+      if (result.uploadError) {
+        if (
+          isSpecifiedError(result.uploadError, {
+            subCategory: PROJECT_ERROR_TYPES.PROJECT_LOCKED,
+          })
+        ) {
+          logger.log();
+          logger.error(i18n(`${i18nKey}.errors.projectLockedError`));
+          logger.log();
+        } else {
+          logApiErrorInstance(
+            result.uploadError,
+            new ApiErrorContext({
+              accountId,
+              projectName: projectConfig.name,
+            })
+          );
+        }
+        process.exit(EXIT_CODES.ERROR);
+      }
     } else {
       await startWatching();
     }

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -957,6 +957,7 @@ en:
           srcOutsideProjectDir: "Invalid value for 'srcDir' in {{ projectConfig }}: {{#bold}}srcDir: \"{{ srcDir }}\"{{/bold}}\n\t'srcDir' must be a relative path to a folder under the project root, such as \".\" or \"./src\""
         uploadProjectFiles:
           add: "Uploading {{#bold}}{{ projectName }}{{/bold}} project files to {{ accountIdentifier }}"
+          fail: "Failed to upload {{#bold}}{{ projectName }}{{/bold}} project files to {{ accountIdentifier }}"
           succeed: "Uploaded {{#bold}}{{ projectName }}{{/bold}} project files to {{ accountIdentifier }}"
           buildCreated: "Project \"{{ projectName }}\" uploaded and build #{{ buildId }} created"
         handleProjectUpload:

--- a/packages/cli/lib/projects.js
+++ b/packages/cli/lib/projects.js
@@ -380,8 +380,12 @@ const uploadProjectFiles = async (
       })
     );
   } catch (err) {
-    SpinniesManager.fail('upload');
-    logApiErrorInstance(err);
+    SpinniesManager.fail('upload', {
+      text: i18n(`${i18nKey}.uploadProjectFiles.fail`, {
+        accountIdentifier,
+        projectName,
+      }),
+    });
 
     error = err;
   }


### PR DESCRIPTION
## Description and Context
This is a followup PR to https://github.com/HubSpot/hubspot-cli/pull/1022, which in retrospect I merged too hastily.  I introduced a bug with that PR, in which platform version errors were being displayed twice when running project commands. 

This PR *actually* addresses the issue, which was that we were not handling upload errors correctly in the watch command itself. I have tested this out for all scenarios listed in Roger's [testing document](https://docs.google.com/document/d/18pzgXnfio-ZOISJD74yA_uHWvn_lhhDc1YpVhbE-K2M/edit#heading=h.8to4vurx9ens), so I am fully confident in this fix. 

## Screenshots
<!-- Provide images of the before and after functionality -->

BEFORE (With double error message):

<img width="1388" alt="Screenshot 2024-03-21 at 5 16 22 PM" src="https://github.com/HubSpot/hubspot-cli/assets/25392256/e8ca35c8-ac7c-4dfd-8ed6-a1ff0a33b6d4">

AFTER (Fixed!):

<img width="1530" alt="Screenshot 2024-03-21 at 5 17 39 PM" src="https://github.com/HubSpot/hubspot-cli/assets/25392256/03acc528-0a00-482b-8698-f5e64b52f59a">


## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

- [x] Address any feedback

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@brandenrodgers @camden11 
