### PR TITLE
Fix import for handleFieldsJS

### DIFF
--- a/packages/cli/commands/cms/convertFields.js
+++ b/packages/cli/commands/cms/convertFields.js
@@ -9,7 +9,7 @@ const { i18n } = require('../../lib/lang');
 const {
   FieldsJs,
   isConvertableFieldJs,
-} = require('@hubspot/local-dev-lib/cms/handleFieldsJs');
+} = require('@hubspot/local-dev-lib/cms/handleFieldsJS');
 
 const { trackConvertFieldsUsage } = require('../../lib/usageTracking');
 const { logErrorInstance } = require('../../lib/errorHandlers/standardErrors');


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->

In the code for the `hs cms convert-fields` command, the import for `handleFieldsJS` had incorrect casing. I also checked in other files where this is imported, and the casing is correct in them. Many thanks to @riskygit for pointing this out. 

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

- [ ] Address any feedback

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@brandenrodgers @camden11 
