### PR TITLE
Public App Init Flow First Pass + Clean up dev command

### DIFF
--- a/packages/cli/commands/accounts/list.js
+++ b/packages/cli/commands/accounts/list.js
@@ -9,11 +9,13 @@ const {
 } = require('../../lib/commonOpts');
 const { trackCommandUsage } = require('../../lib/usageTracking');
 const { loadAndValidateOptions } = require('../../lib/validation');
-const { isSandbox, getSandboxName } = require('../../lib/sandboxes');
+const { getSandboxName } = require('../../lib/sandboxes');
 const {
+  isSandbox,
   isDeveloperTestAccount,
   isAppDeveloperAccount,
-} = require('../../lib/developerTestAccounts');
+} = require('../../lib/accountTypes');
+
 const { i18n } = require('../../lib/lang');
 const {
   HUBSPOT_ACCOUNT_TYPES,

--- a/packages/cli/commands/project/dev.js
+++ b/packages/cli/commands/project/dev.js
@@ -146,15 +146,13 @@ exports.handler = async options => {
   SpinniesManager.init();
 
   if (!projectExists) {
-    createNewProjectForLocalDev(
+    await createNewProjectForLocalDev(
       projectConfig,
       targetAccountId,
       createNewSandbox
     );
-  }
 
-  if (!projectExists) {
-    deployedBuild = createInitialBuildForNewProject(
+    deployedBuild = await createInitialBuildForNewProject(
       projectConfig,
       projectDir,
       targetAccountId

--- a/packages/cli/commands/project/dev.js
+++ b/packages/cli/commands/project/dev.js
@@ -36,7 +36,7 @@ const {
 const {
   confirmDefaultAccountIsTarget,
   suggestRecommendedNestedAccount,
-  checkCorrectParentAccountType,
+  checkIfAppDeveloperAccount,
   createSandboxForLocalDev,
   createDeveloperTestAccountForLocalDev,
   createNewProjectForLocalDev,
@@ -79,9 +79,8 @@ exports.handler = async options => {
 
   const accounts = getConfigAccounts();
 
-  const defaultAccountIsRecommendedType = hasPublicApps
-    ? isDeveloperTestAccount(accountConfig)
-    : isSandbox(accountConfig);
+  const defaultAccountIsRecommendedType =
+    isDeveloperTestAccount || (!hasPublicApps && isSandbox(accountConfig));
 
   let targetAccountId = options.account ? accountId : null;
   let createNewSandbox = false;
@@ -90,8 +89,8 @@ exports.handler = async options => {
   if (!targetAccountId && defaultAccountIsRecommendedType) {
     await confirmDefaultAccountIsTarget(accountConfig, hasPublicApps);
     targetAccountId = hasPublicApps ? accountConfig.parentAccountId : accountId;
-  } else if (!targetAccountId) {
-    checkCorrectParentAccountType(accountConfig, hasPublicApps);
+  } else if (!targetAccountId && hasPublicApps) {
+    checkIfAppDeveloperAccount(accountConfig);
   }
 
   if (!targetAccountId) {

--- a/packages/cli/commands/project/dev.js
+++ b/packages/cli/commands/project/dev.js
@@ -38,7 +38,8 @@ const {
 } = require('../../lib/ui');
 const { confirmPrompt } = require('../../lib/prompts/promptUtils');
 const {
-  selectTargetAccountPrompt,
+  selectSandboxTargetAccountPrompt,
+  selectDeveloperTestTargetAccountPrompt,
   confirmDefaultAccountPrompt,
 } = require('../../lib/prompts/projectDevTargetAccountPrompt');
 const SpinniesManager = require('../../lib/ui/SpinniesManager');
@@ -165,15 +166,18 @@ exports.handler = async options => {
     uiLine();
     logger.log();
 
+    const targetAccountPrompt = hasPublicApps
+      ? selectDeveloperTestTargetAccountPrompt
+      : selectSandboxTargetAccountPrompt;
+
     const {
       targetAccountId: promptTargetAccountId,
-      createNewSandbox: promptCreateNewSandbox,
-      createNewDeveloperTestAccount: promptCreateNewDeveloperTestAccount,
-    } = await selectTargetAccountPrompt(accounts, accountConfig);
+      createNestedAccount,
+    } = await targetAccountPrompt(accounts, accountConfig, hasPublicApps);
 
     targetAccountId = promptTargetAccountId;
-    createNewSandbox = promptCreateNewSandbox;
-    createNewDeveloperTestAccount = promptCreateNewDeveloperTestAccount;
+    createNewSandbox = !hasPublicApps && createNestedAccount;
+    createNewDeveloperTestAccount = hasPublicApps && createNestedAccount;
   }
 
   if (createNewSandbox) {

--- a/packages/cli/commands/project/dev.js
+++ b/packages/cli/commands/project/dev.js
@@ -25,7 +25,12 @@ const { EXIT_CODES } = require('../../lib/enums/exitCodes');
 const { uiBetaTag } = require('../../lib/ui');
 const SpinniesManager = require('../../lib/ui/SpinniesManager');
 const LocalDevManager = require('../../lib/LocalDevManager');
-const { isSandbox, isDeveloperTestAccount } = require('../../lib/accountTypes');
+const {
+  isSandbox,
+  isDeveloperTestAccount,
+  isStandardAccount,
+  isAppDeveloperAccount,
+} = require('../../lib/accountTypes');
 const { getValidEnv } = require('@hubspot/local-dev-lib/environment');
 
 const {
@@ -80,7 +85,8 @@ exports.handler = async options => {
   const accounts = getConfigAccounts();
 
   const defaultAccountIsRecommendedType =
-    isDeveloperTestAccount || (!hasPublicApps && isSandbox(accountConfig));
+    isDeveloperTestAccount(accountConfig) ||
+    (!hasPublicApps && isSandbox(accountConfig));
 
   let targetAccountId = options.account ? accountId : null;
   let createNewSandbox = false;
@@ -105,8 +111,9 @@ exports.handler = async options => {
     );
 
     targetAccountId = hasPublicApps ? parentAccountId : selectedTargetAccountId;
-    createNewSandbox = !hasPublicApps && createNestedAccount;
-    createNewDeveloperTestAccount = hasPublicApps && createNestedAccount;
+    createNewSandbox = isStandardAccount(accountConfig) && createNestedAccount;
+    createNewDeveloperTestAccount =
+      isAppDeveloperAccount(accountConfig) && createNestedAccount;
   }
 
   if (createNewSandbox) {

--- a/packages/cli/commands/project/dev.js
+++ b/packages/cli/commands/project/dev.js
@@ -69,6 +69,7 @@ const {
 } = require('@hubspot/local-dev-lib/errors/apiErrors');
 const { logErrorInstance } = require('../../lib/errorHandlers/standardErrors');
 const { isDeveloperTestAccount } = require('../../lib/developerTestAccounts');
+const { findProjectComponents } = require('../../lib/projectStructure');
 const {
   HUBSPOT_ACCOUNT_TYPES,
   HUBSPOT_ACCOUNT_TYPE_STRINGS,
@@ -97,6 +98,8 @@ exports.handler = async options => {
   }
 
   validateProjectConfig(projectConfig, projectDir);
+
+  const components = await findProjectComponents(projectDir);
 
   const accounts = getConfigAccounts();
   let targetAccountId = options.account ? accountId : null;
@@ -357,6 +360,7 @@ exports.handler = async options => {
     projectDir,
     targetAccountId,
     isGithubLinked,
+    components,
   });
 
   await LocalDev.start();

--- a/packages/cli/commands/project/dev.js
+++ b/packages/cli/commands/project/dev.js
@@ -44,7 +44,8 @@ const {
 } = require('../../lib/prompts/projectDevTargetAccountPrompt');
 const SpinniesManager = require('../../lib/ui/SpinniesManager');
 const LocalDevManager = require('../../lib/LocalDevManager');
-const { isSandbox, getSandboxTypeAsString } = require('../../lib/sandboxes');
+const { isSandbox, isDeveloperTestAccount } = require('../../lib/accountTypes');
+const { getSandboxTypeAsString } = require('../../lib/sandboxes');
 const { sandboxNamePrompt } = require('../../lib/prompts/sandboxesPrompt');
 const {
   validateSandboxUsageLimits,
@@ -75,7 +76,6 @@ const {
   COMPONENT_TYPES,
 } = require('../../lib/projectStructure');
 const {
-  isDeveloperTestAccount,
   validateDevTestAccountUsageLimits,
 } = require('../../lib/developerTestAccounts');
 const {
@@ -154,6 +154,9 @@ exports.handler = async options => {
       process.exit(EXIT_CODES.SUCCESS);
     }
   }
+
+  // TODO: Somewhere around here we need to make sure user has a developer test account
+  // We also may need to make sure user
 
   if (!targetAccountId) {
     logger.log();

--- a/packages/cli/commands/sandbox/sync.js
+++ b/packages/cli/commands/sandbox/sync.js
@@ -15,11 +15,13 @@ const { getHubSpotWebsiteOrigin } = require('@hubspot/local-dev-lib/urls');
 const { promptUser } = require('../../lib/prompts/promptUtils');
 const { uiLine, uiAccountDescription } = require('../../lib/ui');
 const {
+  isSandbox,
+  isStandardSandbox,
+  isDevelopmentSandbox,
+} = require('../../lib/accountTypes');
+const {
   getAvailableSyncTypes,
   getSyncTypesWithContactRecordsPrompt,
-  isDevelopmentSandbox,
-  isStandardSandbox,
-  isSandbox,
 } = require('../../lib/sandboxes');
 const { syncSandbox } = require('../../lib/sandboxSync');
 const { getValidEnv } = require('@hubspot/local-dev-lib/environment');

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -492,6 +492,8 @@ en:
               noProjectConfig: "No project detected. Please run this command again from a project directory."
               projectLockedError: "Your project is locked. This may mean that another user is running the {{#bold}}`hs project watch`{{/bold}} command for this project. If this is you, unlock the project in Projects UI."
               invalidProjectComponents: "Projects cannot contain both private and public apps. Move your apps to separate projects before attempting local development."
+              standardAccountNotSupported: "This project contains a public app. Local development of public apps is only supported on developer accounts and developer test accounts. Change your default account using {{#bold}}`hs accounts use`{{/bold}}, or link a new account with {{#bold}}`hs auth`{{/bold}}."
+              appDeveloperAccountNotSupported: "Your current default account is a Developer Account. To develop this project locally, switch to a standard account using using {{#bold}}`hs accounts use`{{/bold}}, or link a new account with {{#bold}}`hs auth`{{/bold}}."
             examples:
               default: "Start local dev for the current project"
           create:

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -946,10 +946,10 @@ en:
           declineDefaultAccountExplanation: "To develop on a different account, run {{ useCommand }} to change your default account, then re-run {{ devCommand }}."
         checkCorrectParentAccountType:
           standardAccountNotSupported: "This project contains a public app. Local development of public apps is only supported on developer accounts and developer test accounts. Change your default account using {{#bold}}`hs accounts use`{{/bold}}, or link a new account with {{#bold}}`hs auth`{{/bold}}."
-          appDeveloperAccountNotSupported: "Your current default account is a Developer Account. To develop this project locally, switch to a standard account using using {{#bold}}`hs accounts use`{{/bold}}, or link a new account with {{#bold}}`hs auth`{{/bold}}."
         suggestRecommendedNestedAccount:
           nonSandboxWarning: "Testing in a sandbox is strongly recommended. To switch the target account, select an option below or run {{#bold}}`hs accounts use`{{/bold}} before running the command again."
-          nonDeveloperTestAccountWarning: "Local development of public apps is only supported in {{#bold}}developer test accounts{{/bold}}."
+          publicAppNonDeveloperTestAccountWarning: "Local development of public apps is only supported in {{#bold}}developer test accounts{{/bold}}."
+          privateAppNonDeveloperTestAccountWarning: "Local development of private apps is only supported in {{#bold}}developer test accounts{{/bold}}"
         createNewProjectForLocalDev:
           projectMustExistExplanation: "The project {{ projectName }} does not exist in the target account {{ accountIdentifier}}. This command requires the project to exist in the target account."
           createProject: "Create new project {{ projectName}} in {{#bold}}[{{ accountIdentifier }}]{{/bold}}?"

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -491,6 +491,7 @@ en:
             errors:
               noProjectConfig: "No project detected. Please run this command again from a project directory."
               projectLockedError: "Your project is locked. This may mean that another user is running the {{#bold}}`hs project watch`{{/bold}} command for this project. If this is you, unlock the project in Projects UI."
+              invalidProjectComponents: "Projects cannot contain both private and public apps. Move your apps to separate projects before attempting local development."
             examples:
               default: "Start local dev for the current project"
           create:

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -475,25 +475,10 @@ en:
             describe: "Start local dev for the current project"
             logs:
               betaMessage: "HubSpot projects local development"
-              nonSandboxWarning: "Testing in a sandbox is strongly recommended. To switch the target account, select an option below or run {{#bold}}`hs accounts use`{{/bold}} before running the command again."
-              nonDeveloperTestAccountWarning: "Local development of public apps is only supported in {{#bold}}developer test accounts{{/bold}}."
               placeholderAccountSelection: "Using default account as target account (for now)"
-              projectMustExistExplanation: "The project {{ projectName }} does not exist in the target account {{ accountIdentifier}}. This command requires the project to exist in the target account."
-              choseNotToCreateProject: "Exiting because this command requires the project to exist in the target account."
-              initialUploadMessage: "HubSpot Local Dev Server Startup"
-              declineDefaultAccountExplanation: "To develop on a different account, run {{ useCommand }} to change your default account, then re-run {{ devCommand }}."
-            status:
-              creatingProject: "Creating project {{ projectName }} in {{ accountIdentifier }}"
-              createdProject: "Created project {{ projectName }} in {{ accountIdentifier }}"
-              failedToCreateProject: "Failed to create project in the target account."
-            prompt:
-              createProject: "Create new project {{ projectName}} in {{#bold}}[{{ accountIdentifier }}]{{/bold}}?"
             errors:
               noProjectConfig: "No project detected. Please run this command again from a project directory."
-              projectLockedError: "Your project is locked. This may mean that another user is running the {{#bold}}`hs project watch`{{/bold}} command for this project. If this is you, unlock the project in Projects UI."
               invalidProjectComponents: "Projects cannot contain both private and public apps. Move your apps to separate projects before attempting local development."
-              standardAccountNotSupported: "This project contains a public app. Local development of public apps is only supported on developer accounts and developer test accounts. Change your default account using {{#bold}}`hs accounts use`{{/bold}}, or link a new account with {{#bold}}`hs auth`{{/bold}}."
-              appDeveloperAccountNotSupported: "Your current default account is a Developer Account. To develop this project locally, switch to a standard account using using {{#bold}}`hs accounts use`{{/bold}}, or link a new account with {{#bold}}`hs auth`{{/bold}}."
             examples:
               default: "Start local dev for the current project"
           create:
@@ -956,6 +941,25 @@ en:
           setupError: "Failed to setup local dev server: {{ message }}"
           startError: "Failed to start local dev server: {{ message }}"
           fileChangeError: "Failed to notify local dev server of file change: {{ message }}"
+      localDev:
+        confirmDefaultAccountIsTarget:
+          declineDefaultAccountExplanation: "To develop on a different account, run {{ useCommand }} to change your default account, then re-run {{ devCommand }}."
+        checkCorrectParentAccountType:
+          standardAccountNotSupported: "This project contains a public app. Local development of public apps is only supported on developer accounts and developer test accounts. Change your default account using {{#bold}}`hs accounts use`{{/bold}}, or link a new account with {{#bold}}`hs auth`{{/bold}}."
+          appDeveloperAccountNotSupported: "Your current default account is a Developer Account. To develop this project locally, switch to a standard account using using {{#bold}}`hs accounts use`{{/bold}}, or link a new account with {{#bold}}`hs auth`{{/bold}}."
+        suggestRecommendedNestedAccount:
+          nonSandboxWarning: "Testing in a sandbox is strongly recommended. To switch the target account, select an option below or run {{#bold}}`hs accounts use`{{/bold}} before running the command again."
+          nonDeveloperTestAccountWarning: "Local development of public apps is only supported in {{#bold}}developer test accounts{{/bold}}."
+        createNewProjectForLocalDev:
+          projectMustExistExplanation: "The project {{ projectName }} does not exist in the target account {{ accountIdentifier}}. This command requires the project to exist in the target account."
+          createProject: "Create new project {{ projectName}} in {{#bold}}[{{ accountIdentifier }}]{{/bold}}?"
+          choseNotToCreateProject: "Exiting because this command requires the project to exist in the target account."
+          creatingProject: "Creating project {{ projectName }} in {{ accountIdentifier }}"
+          createdProject: "Created project {{ projectName }} in {{ accountIdentifier }}"
+          failedToCreateProject: "Failed to create project in the target account."
+        createInitialBuildForNewProject:
+          initialUploadMessage: "HubSpot Local Dev Server Startup"
+          projectLockedError: "Your project is locked. This may mean that another user is running the {{#bold}}`hs project watch`{{/bold}} command for this project. If this is you, unlock the project in Projects UI."
       projects:
         config:
           srcOutsideProjectDir: "Invalid value for 'srcDir' in {{ projectConfig }}: {{#bold}}srcDir: \"{{ srcDir }}\"{{/bold}}\n\t'srcDir' must be a relative path to a folder under the project root, such as \".\" or \"./src\""

--- a/packages/cli/lib/accountTypes.js
+++ b/packages/cli/lib/accountTypes.js
@@ -1,0 +1,34 @@
+const {
+  HUBSPOT_ACCOUNT_TYPES,
+} = require('@hubspot/local-dev-lib/constants/config');
+
+const isAccountType = (config, accountType) =>
+  config.accountType && config.accountType === accountType;
+
+const isStandardAccount = config =>
+  isAccountType(config, HUBSPOT_ACCOUNT_TYPES.STANDARD);
+
+const isSandbox = config =>
+  isAccountType(config, HUBSPOT_ACCOUNT_TYPES.STANDARD_SANDBOX) ||
+  isAccountType(config, HUBSPOT_ACCOUNT_TYPES.DEVELOPMENT_SANDBOX);
+
+const isStandardSandbox = config =>
+  isAccountType(config, HUBSPOT_ACCOUNT_TYPES.STANDARD_SANDBOX);
+
+const isDevelopmentSandbox = config =>
+  isAccountType(config, HUBSPOT_ACCOUNT_TYPES.DEVELOPMENT_SANDBOX);
+
+const isDeveloperTestAccount = config =>
+  isAccountType(config, HUBSPOT_ACCOUNT_TYPES.DEVELOPER_TEST);
+
+const isAppDeveloperAccount = config =>
+  isAccountType(config, HUBSPOT_ACCOUNT_TYPES.APP_DEVELOPER);
+
+module.exports = {
+  isStandardAccount,
+  isSandbox,
+  isStandardSandbox,
+  isDevelopmentSandbox,
+  isDeveloperTestAccount,
+  isAppDeveloperAccount,
+};

--- a/packages/cli/lib/developerTestAccounts.js
+++ b/packages/cli/lib/developerTestAccounts.js
@@ -7,14 +7,6 @@ const {
   fetchDeveloperTestAccounts,
 } = require('@hubspot/local-dev-lib/developerTestAccounts');
 
-const isDeveloperTestAccount = config =>
-  config.accountType &&
-  config.accountType === HUBSPOT_ACCOUNT_TYPES.DEVELOPER_TEST;
-
-const isAppDeveloperAccount = config =>
-  config.accountType &&
-  config.accountType === HUBSPOT_ACCOUNT_TYPES.APP_DEVELOPER;
-
 const getHasDevTestAccounts = appDeveloperAccountConfig => {
   const config = getConfig();
   const parentPortalId = getAccountId(appDeveloperAccountConfig.portalId);
@@ -61,7 +53,5 @@ const validateDevTestAccountUsageLimits = async accountConfig => {
   return null;
 };
 module.exports = {
-  isDeveloperTestAccount,
-  isAppDeveloperAccount,
   validateDevTestAccountUsageLimits,
 };

--- a/packages/cli/lib/localDev.js
+++ b/packages/cli/lib/localDev.js
@@ -33,7 +33,7 @@ const { logErrorInstance } = require('./errorHandlers/standardErrors');
 const { uiCommandReference, uiLine } = require('./ui');
 const { i18n } = require('./lang');
 const { EXIT_CODES } = require('./enums/exitCodes');
-const { trackCommandMetadataUsage } = require('./lib/usageTracking');
+const { trackCommandMetadataUsage } = require('./usageTracking');
 const { isAppDeveloperAccount } = require('./accountTypes');
 
 // TODO: Maybe give these to their own lang key
@@ -63,7 +63,7 @@ const confirmDefaultAccountIsTarget = async (accountConfig, hasPublicApps) => {
 
 // Confirm the default account supports the creation of the recommended nested account type
 // Exit if not
-const checkCorrectParentAccountType = async (accountConfig, hasPublicApps) => {
+const checkCorrectParentAccountType = (accountConfig, hasPublicApps) => {
   if (hasPublicApps && !isAppDeveloperAccount(accountConfig)) {
     logger.error(i18n(`${i18nKey}.errors.standardAccountNotSupported`));
     process.exit(EXIT_CODES.SUCCESS);

--- a/packages/cli/lib/localDev.js
+++ b/packages/cli/lib/localDev.js
@@ -80,21 +80,12 @@ const confirmDefaultAccountIsTarget = async (accountConfig, hasPublicApps) => {
   }
 };
 
-// Confirm the default account supports the creation of the recommended nested account type
-// Exit if not
-const checkCorrectParentAccountType = (accountConfig, hasPublicApps) => {
-  if (hasPublicApps && !isAppDeveloperAccount(accountConfig)) {
+// Confirm the default account is a developer account if developing public apps
+const checkIfAppDeveloperAccount = accountConfig => {
+  if (!isAppDeveloperAccount(accountConfig)) {
     logger.error(
       i18n(
         `${i18nKey}.checkCorrectParentAccountType.standardAccountNotSupported`
-      )
-    );
-    process.exit(EXIT_CODES.SUCCESS);
-  }
-  if (!hasPublicApps && isAppDeveloperAccount(accountConfig)) {
-    logger.error(
-      i18n(
-        `${i18nKey}.checkCorrectParentAccountType.appDeveloperAccountNotSupported`
       )
     );
     process.exit(EXIT_CODES.SUCCESS);
@@ -112,7 +103,13 @@ const suggestRecommendedNestedAccount = async (
   if (hasPublicApps) {
     logger.warn(
       i18n(
-        `${i18nKey}.suggestRecommendedNestedAccount.nonDeveloperTestAccountWarning`
+        `${i18nKey}.suggestRecommendedNestedAccount.publicAppNonDeveloperTestAccountWarning`
+      )
+    );
+  } else if (isAppDeveloperAccount(accountConfig)) {
+    logger.warn(
+      i18n(
+        `${i18nKey}.suggestRecommendedNestedAccount.publicAppNonDeveloperTestAccountWarning`
       )
     );
   } else {
@@ -123,7 +120,7 @@ const suggestRecommendedNestedAccount = async (
   uiLine();
   logger.log();
 
-  const targetAccountPrompt = hasPublicApps
+  const targetAccountPrompt = isAppDeveloperAccount(accountConfig)
     ? selectDeveloperTestTargetAccountPrompt
     : selectSandboxTargetAccountPrompt;
 
@@ -392,7 +389,7 @@ const createInitialBuildForNewProject = async (
 
 module.exports = {
   confirmDefaultAccountIsTarget,
-  checkCorrectParentAccountType,
+  checkIfAppDeveloperAccount,
   suggestRecommendedNestedAccount,
   createSandboxForLocalDev,
   createDeveloperTestAccountForLocalDev,

--- a/packages/cli/lib/localDev.js
+++ b/packages/cli/lib/localDev.js
@@ -38,7 +38,10 @@ const SpinniesManager = require('./ui/SpinniesManager');
 const { i18n } = require('./lang');
 const { EXIT_CODES } = require('./enums/exitCodes');
 const { trackCommandMetadataUsage } = require('./usageTracking');
-const { isAppDeveloperAccount } = require('./accountTypes');
+const {
+  isAppDeveloperAccount,
+  isDeveloperTestAccount,
+} = require('./accountTypes');
 const {
   handleProjectUpload,
   pollProjectBuildAndDeploy,
@@ -57,11 +60,11 @@ const i18nKey = 'cli.lib.localDev';
 
 // If the user passed in the --account flag, confirm they want to use that account as
 // their target account, otherwise exit
-const confirmDefaultAccountIsTarget = async (accountConfig, hasPublicApps) => {
+const confirmDefaultAccountIsTarget = async accountConfig => {
   logger.log();
   const useDefaultAccount = await confirmDefaultAccountPrompt(
     accountConfig.name,
-    hasPublicApps
+    isDeveloperTestAccount(accountConfig)
       ? HUBSPOT_ACCOUNT_TYPE_STRINGS[HUBSPOT_ACCOUNT_TYPES.DEVELOPER_TEST]
       : `${getSandboxTypeAsString(accountConfig.accountType)} sandbox`
   );

--- a/packages/cli/lib/localDev.js
+++ b/packages/cli/lib/localDev.js
@@ -1,0 +1,151 @@
+const { logger } = require('@hubspot/local-dev-lib/logger');
+const {
+  HUBSPOT_ACCOUNT_TYPES,
+  HUBSPOT_ACCOUNT_TYPE_STRINGS,
+} = require('@hubspot/local-dev-lib/constants/config');
+const {
+  isMissingScopeError,
+} = require('@hubspot/local-dev-lib/errors/apiErrors');
+const { getHubSpotWebsiteOrigin } = require('@hubspot/local-dev-lib/urls');
+const { getAccountConfig } = require('@hubspot/local-dev-lib/config');
+
+const {
+  confirmDefaultAccountPrompt,
+  selectSandboxTargetAccountPrompt,
+  selectDeveloperTestTargetAccountPrompt,
+} = require('./prompts/projectDevTargetAccountPrompt');
+const { sandboxNamePrompt } = require('./prompts/sandboxesPrompt');
+const {
+  validateSandboxUsageLimits,
+  getSandboxTypeAsString,
+  getAvailableSyncTypes,
+} = require('./sandboxes');
+const { buildSandbox } = require('./lib/sandboxCreate');
+const { syncSandbox } = require('./lib/sandboxSync');
+const { logErrorInstance } = require('./errorHandlers/standardErrors');
+const { uiCommandReference, uiLine } = require('./ui');
+const { i18n } = require('./lang');
+const { EXIT_CODES } = require('./enums/exitCodes');
+const { trackCommandMetadataUsage } = require('./lib/usageTracking');
+
+// TODO: Maybe give these to their own lang key
+const i18nKey = 'cli.commands.project.subcommands.dev';
+
+// If the user passed in the --account flag, confirm they want to use that account as
+// their target account, otherwise exit
+const confirmDefaultAccountIsTarget = async (accountConfig, hasPublicApps) => {
+  logger.log();
+  const useDefaultAccount = await confirmDefaultAccountPrompt(
+    accountConfig.name,
+    hasPublicApps
+      ? HUBSPOT_ACCOUNT_TYPE_STRINGS[HUBSPOT_ACCOUNT_TYPES.DEVELOPER_TEST]
+      : `${getSandboxTypeAsString(accountConfig.accountType)} sandbox`
+  );
+
+  if (!useDefaultAccount) {
+    logger.log(
+      i18n(`${i18nKey}.logs.declineDefaultAccountExplanation`, {
+        useCommand: uiCommandReference('hs accounts use'),
+        devCommand: uiCommandReference('hs project dev'),
+      })
+    );
+    process.exit(EXIT_CODES.SUCCESS);
+  }
+};
+
+// If the user isn't using the recommended account type, prompt them to use or create one
+const suggestRecommendedNestedAccount = async (
+  accounts,
+  accountConfig,
+  hasPublicApps
+) => {
+  logger.log();
+  uiLine();
+  if (hasPublicApps) {
+    logger.warn(i18n(`${i18nKey}.logs.nonDeveloperTestAccountWarning`));
+  } else {
+    logger.warn(i18n(`${i18nKey}.logs.nonSandboxWarning`));
+  }
+  uiLine();
+  logger.log();
+
+  const targetAccountPrompt = hasPublicApps
+    ? selectDeveloperTestTargetAccountPrompt
+    : selectSandboxTargetAccountPrompt;
+
+  return targetAccountPrompt(accounts, accountConfig, hasPublicApps);
+};
+
+// Create a new sandbox and return its accountId
+const createSandboxForLocalDev = async (accountId, accountConfig, env) => {
+  try {
+    await validateSandboxUsageLimits(
+      accountConfig,
+      HUBSPOT_ACCOUNT_TYPES.DEVELOPMENT_SANDBOX,
+      env
+    );
+  } catch (err) {
+    if (isMissingScopeError(err)) {
+      logger.error(
+        i18n('cli.lib.sandbox.create.failure.scopes.message', {
+          accountName: accountConfig.name || accountId,
+        })
+      );
+      const websiteOrigin = getHubSpotWebsiteOrigin(env);
+      const url = `${websiteOrigin}/personal-access-key/${accountId}`;
+      logger.info(
+        i18n('cli.lib.sandbox.create.failure.scopes.instructions', {
+          accountName: accountConfig.name || accountId,
+          url,
+        })
+      );
+    } else {
+      logErrorInstance(err);
+    }
+    process.exit(EXIT_CODES.ERROR);
+  }
+  try {
+    const { name } = await sandboxNamePrompt(
+      HUBSPOT_ACCOUNT_TYPES.DEVELOPMENT_SANDBOX
+    );
+
+    trackCommandMetadataUsage(
+      'sandbox-create',
+      { step: 'project-dev' },
+      accountId
+    );
+
+    const { result } = await buildSandbox({
+      name,
+      type: HUBSPOT_ACCOUNT_TYPES.DEVELOPMENT_SANDBOX,
+      accountConfig,
+      env,
+    });
+
+    const targetAccountId = result.sandbox.sandboxHubId;
+
+    const sandboxAccountConfig = getAccountConfig(result.sandbox.sandboxHubId);
+    const syncTasks = await getAvailableSyncTypes(
+      accountConfig,
+      sandboxAccountConfig
+    );
+    await syncSandbox({
+      accountConfig: sandboxAccountConfig,
+      parentAccountConfig: accountConfig,
+      env,
+      syncTasks,
+      allowEarlyTermination: false, // Don't let user terminate early in this flow
+      skipPolling: true, // Skip polling, sync will run and complete in the background
+    });
+    return targetAccountId;
+  } catch (err) {
+    logErrorInstance(err);
+    process.exit(EXIT_CODES.ERROR);
+  }
+};
+
+module.exports = {
+  confirmDefaultAccountIsTarget,
+  suggestRecommendedNestedAccount,
+  createSandboxForLocalDev,
+};

--- a/packages/cli/lib/localDev.js
+++ b/packages/cli/lib/localDev.js
@@ -53,8 +53,7 @@ const {
   ApiErrorContext,
 } = require('./errorHandlers/apiErrors');
 
-// TODO: Maybe give these to their own lang key
-const i18nKey = 'cli.commands.project.subcommands.dev';
+const i18nKey = 'cli.lib.localDev';
 
 // If the user passed in the --account flag, confirm they want to use that account as
 // their target account, otherwise exit
@@ -69,10 +68,13 @@ const confirmDefaultAccountIsTarget = async (accountConfig, hasPublicApps) => {
 
   if (!useDefaultAccount) {
     logger.log(
-      i18n(`${i18nKey}.logs.declineDefaultAccountExplanation`, {
-        useCommand: uiCommandReference('hs accounts use'),
-        devCommand: uiCommandReference('hs project dev'),
-      })
+      i18n(
+        `${i18nKey}.confirmDefaultAccountIsTarget.declineDefaultAccountExplanation`,
+        {
+          useCommand: uiCommandReference('hs accounts use'),
+          devCommand: uiCommandReference('hs project dev'),
+        }
+      )
     );
     process.exit(EXIT_CODES.SUCCESS);
   }
@@ -82,11 +84,19 @@ const confirmDefaultAccountIsTarget = async (accountConfig, hasPublicApps) => {
 // Exit if not
 const checkCorrectParentAccountType = (accountConfig, hasPublicApps) => {
   if (hasPublicApps && !isAppDeveloperAccount(accountConfig)) {
-    logger.error(i18n(`${i18nKey}.errors.standardAccountNotSupported`));
+    logger.error(
+      i18n(
+        `${i18nKey}.checkCorrectParentAccountType.standardAccountNotSupported`
+      )
+    );
     process.exit(EXIT_CODES.SUCCESS);
   }
   if (!hasPublicApps && isAppDeveloperAccount(accountConfig)) {
-    logger.error(i18n(`${i18nKey}.errors.appDeveloperAccountNotSupported`));
+    logger.error(
+      i18n(
+        `${i18nKey}.checkCorrectParentAccountType.appDeveloperAccountNotSupported`
+      )
+    );
     process.exit(EXIT_CODES.SUCCESS);
   }
 };
@@ -100,9 +110,15 @@ const suggestRecommendedNestedAccount = async (
   logger.log();
   uiLine();
   if (hasPublicApps) {
-    logger.warn(i18n(`${i18nKey}.logs.nonDeveloperTestAccountWarning`));
+    logger.warn(
+      i18n(
+        `${i18nKey}.suggestRecommendedNestedAccount.nonDeveloperTestAccountWarning`
+      )
+    );
   } else {
-    logger.warn(i18n(`${i18nKey}.logs.nonSandboxWarning`));
+    logger.warn(
+      i18n(`${i18nKey}.suggestRecommendedNestedAccount.nonSandboxWarning`)
+    );
   }
   uiLine();
   logger.log();
@@ -259,15 +275,18 @@ const createNewProjectForLocalDev = async (
     logger.log();
     uiLine();
     logger.warn(
-      i18n(`${i18nKey}.logs.projectMustExistExplanation`, {
-        accountIdentifier: uiAccountDescription(targetAccountId),
-        projectName: projectConfig.name,
-      })
+      i18n(
+        `${i18nKey}.createNewProjectForLocalDev.projectMustExistExplanation`,
+        {
+          accountIdentifier: uiAccountDescription(targetAccountId),
+          projectName: projectConfig.name,
+        }
+      )
     );
     uiLine();
 
     shouldCreateProject = await confirmPrompt(
-      i18n(`${i18nKey}.prompt.createProject`, {
+      i18n(`${i18nKey}.createNewProjectForLocalDev.createProject`, {
         accountIdentifier: uiAccountDescription(targetAccountId),
         projectName: projectConfig.name,
       })
@@ -276,7 +295,7 @@ const createNewProjectForLocalDev = async (
 
   if (shouldCreateProject) {
     SpinniesManager.add('createProject', {
-      text: i18n(`${i18nKey}.status.creatingProject`, {
+      text: i18n(`${i18nKey}.createNewProjectForLocalDev.creatingProject`, {
         accountIdentifier: uiAccountDescription(targetAccountId),
         projectName: projectConfig.name,
       }),
@@ -285,7 +304,7 @@ const createNewProjectForLocalDev = async (
     try {
       await createProject(targetAccountId, projectConfig.name);
       SpinniesManager.succeed('createProject', {
-        text: i18n(`${i18nKey}.status.createdProject`, {
+        text: i18n(`${i18nKey}.createNewProjectForLocalDev.createdProject`, {
           accountIdentifier: uiAccountDescription(targetAccountId),
           projectName: projectConfig.name,
         }),
@@ -293,13 +312,17 @@ const createNewProjectForLocalDev = async (
       });
     } catch (err) {
       SpinniesManager.fail('createProject');
-      logger.log(i18n(`${i18nKey}.status.failedToCreateProject`));
+      logger.log(
+        i18n(`${i18nKey}.createNewProjectForLocalDev.failedToCreateProject`)
+      );
       process.exit(EXIT_CODES.ERROR);
     }
   } else {
     // We cannot continue if the project does not exist in the target account
     logger.log();
-    logger.log(i18n(`${i18nKey}.logs.choseNotToCreateProject`));
+    logger.log(
+      i18n(`${i18nKey}.createNewProjectForLocalDev.choseNotToCreateProject`)
+    );
     process.exit(EXIT_CODES.SUCCESS);
   }
 };
@@ -316,7 +339,7 @@ const createInitialBuildForNewProject = async (
     projectConfig,
     projectDir,
     (...args) => pollProjectBuildAndDeploy(...args, true),
-    i18n(`${i18nKey}.logs.initialUploadMessage`)
+    i18n(`${i18nKey}.createInitialBuildForNewProject.initialUploadMessage`)
   );
 
   if (initialUploadResult.uploadError) {
@@ -326,7 +349,9 @@ const createInitialBuildForNewProject = async (
       })
     ) {
       logger.log();
-      logger.error(i18n(`${i18nKey}.errors.projectLockedError`));
+      logger.error(
+        i18n(`${i18nKey}.createInitialBuildForNewProject.projectLockedError`)
+      );
       logger.log();
     } else {
       logApiErrorInstance(

--- a/packages/cli/lib/projectStructure.js
+++ b/packages/cli/lib/projectStructure.js
@@ -118,9 +118,16 @@ async function findProjectComponents(projectSourceDir) {
   return components;
 }
 
+function getProjectComponentTypes(components) {
+  const projectContents = {};
+  components.forEach(({ type }) => (projectContents[type] = true));
+  return projectContents;
+}
+
 module.exports = {
   CONFIG_FILES,
   COMPONENT_TYPES,
   findProjectComponents,
   getAppCardConfigs,
+  getProjectComponentTypes,
 };

--- a/packages/cli/lib/prompts/projectDevTargetAccountPrompt.js
+++ b/packages/cli/lib/prompts/projectDevTargetAccountPrompt.js
@@ -12,10 +12,7 @@ const { logger } = require('@hubspot/local-dev-lib/logger');
 const {
   fetchDeveloperTestAccounts,
 } = require('@hubspot/local-dev-lib/developerTestAccounts');
-const {
-  isAppDeveloperAccount,
-  isDeveloperTestAccount,
-} = require('../developerTestAccounts');
+const { isDeveloperTestAccount } = require('../developerTestAccounts');
 
 const i18nKey = 'cli.lib.prompts.projectDevTargetAccountPrompt';
 
@@ -23,122 +20,136 @@ const mapNestedAccount = accountConfig => ({
   name: uiAccountDescription(accountConfig.portalId, false),
   value: {
     targetAccountId: getAccountId(accountConfig.name),
-    createNewSandbox: false,
+    createNestedAccount: false,
   },
 });
 
-const selectTargetAccountPrompt = async (accounts, defaultAccountConfig) => {
+const selectSandboxTargetAccountPrompt = async (
+  accounts,
+  defaultAccountConfig
+) => {
   const defaultAccountId = getAccountId(defaultAccountConfig.name);
   let choices = [];
-
-  if (isAppDeveloperAccount(defaultAccountConfig)) {
-    let devTestAccountUsage = undefined;
-    try {
-      devTestAccountUsage = await fetchDeveloperTestAccounts(defaultAccountId);
-    } catch (err) {
-      logger.debug(
-        'Unable to fetch developer test account usage limits: ',
-        err
-      );
-    }
-
-    const devTestAccounts = accounts
-      .reverse()
-      .filter(
-        config =>
-          isDeveloperTestAccount(config) &&
-          config.parentAccountId === defaultAccountId
-      );
-    let disabledMessage = false;
-    if (
-      devTestAccountUsage &&
-      devTestAccountUsage.results.length >= devTestAccountUsage.maxTestPortals
-    ) {
-      disabledMessage = i18n(`${i18nKey}.developerTestAccountLimit`, {
-        authCommand: uiCommandReference('hs auth'),
-        limit: devTestAccountUsage.maxTestPortals,
-      });
-    }
-
-    choices = [
-      ...devTestAccounts.map(mapNestedAccount),
-      {
-        name: i18n(`${i18nKey}.createNewDeveloperTestAccountOption`),
-        value: {
-          targetAccountId: null,
-          createNewDeveloperTestAccount: true,
-        },
-        disabled: disabledMessage,
-      },
-    ];
-  } else {
-    let sandboxUsage = {};
-    try {
-      sandboxUsage = await getSandboxUsageLimits(defaultAccountId);
-    } catch (err) {
-      logger.debug('Unable to fetch sandbox usage limits: ', err);
-    }
-
-    const sandboxAccounts = accounts
-      .reverse()
-      .filter(
-        config =>
-          isSandbox(config) && config.parentAccountId === defaultAccountId
-      );
-    let disabledMessage = false;
-
-    if (
-      sandboxUsage['DEVELOPER'] &&
-      sandboxUsage['DEVELOPER'].available === 0
-    ) {
-      if (sandboxAccounts.length < sandboxUsage['DEVELOPER'].limit) {
-        disabledMessage = i18n(`${i18nKey}.sandboxLimitWithSuggestion`, {
-          authCommand: uiCommandReference('hs auth'),
-          limit: sandboxUsage['DEVELOPER'].limit,
-        });
-      } else {
-        disabledMessage = i18n(`${i18nKey}.sandboxLimit`, {
-          limit: sandboxUsage['DEVELOPER'].limit,
-        });
-      }
-    }
-    // Order choices by Developer Sandbox -> Standard Sandbox
-    choices = [
-      ...sandboxAccounts
-        .filter(
-          a => a.accountType === HUBSPOT_ACCOUNT_TYPES.DEVELOPMENT_SANDBOX
-        )
-        .map(mapNestedAccount),
-      ...sandboxAccounts
-        .filter(a => a.accountType === HUBSPOT_ACCOUNT_TYPES.STANDARD_SANDBOX)
-        .map(mapNestedAccount),
-      {
-        name: i18n(`${i18nKey}.createNewSandboxOption`),
-        value: {
-          targetAccountId: null,
-          createNewSandbox: true,
-        },
-        disabled: disabledMessage,
-      },
-      {
-        name: i18n(`${i18nKey}.chooseDefaultAccountOption`),
-        value: {
-          targetAccountId: defaultAccountId,
-          createNewSandbox: false,
-        },
-      },
-    ];
+  let sandboxUsage = {};
+  try {
+    sandboxUsage = await getSandboxUsageLimits(defaultAccountId);
+  } catch (err) {
+    logger.debug('Unable to fetch sandbox usage limits: ', err);
   }
 
+  const sandboxAccounts = accounts
+    .reverse()
+    .filter(
+      config => isSandbox(config) && config.parentAccountId === defaultAccountId
+    );
+  let disabledMessage = false;
+
+  if (sandboxUsage['DEVELOPER'] && sandboxUsage['DEVELOPER'].available === 0) {
+    if (sandboxAccounts.length < sandboxUsage['DEVELOPER'].limit) {
+      disabledMessage = i18n(`${i18nKey}.sandboxLimitWithSuggestion`, {
+        authCommand: uiCommandReference('hs auth'),
+        limit: sandboxUsage['DEVELOPER'].limit,
+      });
+    } else {
+      disabledMessage = i18n(`${i18nKey}.sandboxLimit`, {
+        limit: sandboxUsage['DEVELOPER'].limit,
+      });
+    }
+  }
+  // Order choices by Developer Sandbox -> Standard Sandbox
+  choices = [
+    ...sandboxAccounts
+      .filter(a => a.accountType === HUBSPOT_ACCOUNT_TYPES.DEVELOPMENT_SANDBOX)
+      .map(mapNestedAccount),
+    ...sandboxAccounts
+      .filter(a => a.accountType === HUBSPOT_ACCOUNT_TYPES.STANDARD_SANDBOX)
+      .map(mapNestedAccount),
+    {
+      name: i18n(`${i18nKey}.createNewSandboxOption`),
+      value: {
+        targetAccountId: null,
+        createNestedAccount: true,
+      },
+      disabled: disabledMessage,
+    },
+    {
+      name: i18n(`${i18nKey}.chooseDefaultAccountOption`),
+      value: {
+        targetAccountId: defaultAccountId,
+        createNestedAccount: false,
+      },
+    },
+  ];
+
+  return selectTargetAccountPrompt(
+    defaultAccountId,
+    'sandbox account',
+    choices
+  );
+};
+
+const selectDeveloperTestTargetAccountPrompt = async (
+  accounts,
+  defaultAccountConfig
+) => {
+  const defaultAccountId = getAccountId(defaultAccountConfig.name);
+  let choices = [];
+  let devTestAccountUsage = undefined;
+  try {
+    devTestAccountUsage = await fetchDeveloperTestAccounts(defaultAccountId);
+  } catch (err) {
+    logger.debug('Unable to fetch developer test account usage limits: ', err);
+  }
+
+  const devTestAccounts = accounts
+    .reverse()
+    .filter(
+      config =>
+        isDeveloperTestAccount(config) &&
+        config.parentAccountId === defaultAccountId
+    );
+  let disabledMessage = false;
+  if (
+    devTestAccountUsage &&
+    devTestAccountUsage.results.length >= devTestAccountUsage.maxTestPortals
+  ) {
+    disabledMessage = i18n(`${i18nKey}.developerTestAccountLimit`, {
+      authCommand: uiCommandReference('hs auth'),
+      limit: devTestAccountUsage.maxTestPortals,
+    });
+  }
+
+  choices = [
+    ...devTestAccounts.map(mapNestedAccount),
+    {
+      name: i18n(`${i18nKey}.createNewDeveloperTestAccountOption`),
+      value: {
+        targetAccountId: null,
+        createNestedAccount: true,
+      },
+      disabled: disabledMessage,
+    },
+  ];
+
+  return selectTargetAccountPrompt(
+    defaultAccountId,
+    HUBSPOT_ACCOUNT_TYPE_STRINGS[HUBSPOT_ACCOUNT_TYPES.DEVELOPER_TEST],
+    choices
+  );
+};
+
+const selectTargetAccountPrompt = async (
+  defaultAccountId,
+  accountType,
+  choices
+) => {
   const { targetAccountInfo } = await promptUser([
     {
       name: 'targetAccountInfo',
       type: 'list',
       message: i18n(`${i18nKey}.promptMessage`, {
         accountIdentifier: uiAccountDescription(defaultAccountId),
-        accountType: isAppDeveloperAccount(defaultAccountConfig)
-          ? HUBSPOT_ACCOUNT_TYPE_STRINGS[HUBSPOT_ACCOUNT_TYPES.DEVELOPER_TEST]
-          : 'sandbox account',
+        accountType,
       }),
       choices,
     },
@@ -162,6 +173,7 @@ const confirmDefaultAccountPrompt = async (accountName, accountType) => {
 };
 
 module.exports = {
-  selectTargetAccountPrompt,
+  selectSandboxTargetAccountPrompt,
+  selectDeveloperTestTargetAccountPrompt,
   confirmDefaultAccountPrompt,
 };

--- a/packages/cli/lib/prompts/projectDevTargetAccountPrompt.js
+++ b/packages/cli/lib/prompts/projectDevTargetAccountPrompt.js
@@ -1,7 +1,7 @@
 const { promptUser } = require('./promptUtils');
 const { i18n } = require('../lang');
 const { uiAccountDescription, uiCommandReference } = require('../ui');
-const { isSandbox } = require('../accountTypes');
+const { isSandbox, isDeveloperTestAccount } = require('../accountTypes');
 const { getAccountId } = require('@hubspot/local-dev-lib/config');
 const { getSandboxUsageLimits } = require('@hubspot/local-dev-lib/sandboxes');
 const {
@@ -12,7 +12,6 @@ const { logger } = require('@hubspot/local-dev-lib/logger');
 const {
   fetchDeveloperTestAccounts,
 } = require('@hubspot/local-dev-lib/developerTestAccounts');
-const { isDeveloperTestAccount } = require('../accountTypes');
 
 const i18nKey = 'cli.lib.prompts.projectDevTargetAccountPrompt';
 

--- a/packages/cli/lib/prompts/projectDevTargetAccountPrompt.js
+++ b/packages/cli/lib/prompts/projectDevTargetAccountPrompt.js
@@ -21,6 +21,7 @@ const mapNestedAccount = accountConfig => ({
   value: {
     targetAccountId: getAccountId(accountConfig.name),
     createNestedAccount: false,
+    parentAccountId: accountConfig.parentAccountId,
   },
 });
 

--- a/packages/cli/lib/prompts/projectDevTargetAccountPrompt.js
+++ b/packages/cli/lib/prompts/projectDevTargetAccountPrompt.js
@@ -1,7 +1,7 @@
 const { promptUser } = require('./promptUtils');
 const { i18n } = require('../lang');
 const { uiAccountDescription, uiCommandReference } = require('../ui');
-const { isSandbox } = require('../sandboxes');
+const { isSandbox } = require('../accountTypes');
 const { getAccountId } = require('@hubspot/local-dev-lib/config');
 const { getSandboxUsageLimits } = require('@hubspot/local-dev-lib/sandboxes');
 const {
@@ -12,7 +12,7 @@ const { logger } = require('@hubspot/local-dev-lib/logger');
 const {
   fetchDeveloperTestAccounts,
 } = require('@hubspot/local-dev-lib/developerTestAccounts');
-const { isDeveloperTestAccount } = require('../developerTestAccounts');
+const { isDeveloperTestAccount } = require('../accountTypes');
 
 const i18nKey = 'cli.lib.prompts.projectDevTargetAccountPrompt';
 

--- a/packages/cli/lib/prompts/sandboxesPrompt.js
+++ b/packages/cli/lib/prompts/sandboxesPrompt.js
@@ -5,7 +5,7 @@ const { uiAccountDescription } = require('../ui');
 const {
   HUBSPOT_ACCOUNT_TYPES,
 } = require('@hubspot/local-dev-lib/constants/config');
-const { isSandbox } = require('../sandboxes');
+const { isSandbox } = require('../accountTypes');
 
 const i18nKey = 'cli.lib.prompts.sandboxesPrompt';
 

--- a/packages/cli/lib/sandboxSync.js
+++ b/packages/cli/lib/sandboxSync.js
@@ -2,11 +2,11 @@ const SpinniesManager = require('./ui/SpinniesManager');
 const { getHubSpotWebsiteOrigin } = require('@hubspot/local-dev-lib/urls');
 const { logger } = require('@hubspot/local-dev-lib/logger');
 const { i18n } = require('./lang');
+const { isDevelopmentSandbox } = require('./accountTypes');
 const {
   getAvailableSyncTypes,
   pollSyncTaskStatus,
   syncTypes,
-  isDevelopmentSandbox,
 } = require('./sandboxes');
 const { initiateSync } = require('@hubspot/local-dev-lib/sandboxes');
 const {

--- a/packages/cli/lib/sandboxes.js
+++ b/packages/cli/lib/sandboxes.js
@@ -10,6 +10,7 @@ const {
 const { getConfig, getAccountId } = require('@hubspot/local-dev-lib/config');
 const CliProgressMultibarManager = require('./ui/CliProgressMultibarManager');
 const { promptUser } = require('./prompts/promptUtils');
+const { isDevelopmentSandbox } = require('./accountTypes');
 const { getHubSpotWebsiteOrigin } = require('@hubspot/local-dev-lib/urls');
 const {
   HUBSPOT_ACCOUNT_TYPES,
@@ -40,19 +41,6 @@ const getSandboxTypeAsString = accountType => {
 
 const getSandboxName = config =>
   `[${getSandboxTypeAsString(config.accountType)} sandbox] `;
-
-const isSandbox = config =>
-  config.accountType &&
-  (config.accountType === HUBSPOT_ACCOUNT_TYPES.STANDARD_SANDBOX ||
-    config.accountType === HUBSPOT_ACCOUNT_TYPES.DEVELOPMENT_SANDBOX);
-
-const isStandardSandbox = config =>
-  config.accountType &&
-  config.accountType === HUBSPOT_ACCOUNT_TYPES.STANDARD_SANDBOX;
-
-const isDevelopmentSandbox = config =>
-  config.accountType &&
-  config.accountType === HUBSPOT_ACCOUNT_TYPES.DEVELOPMENT_SANDBOX;
 
 function getHasSandboxesByType(parentAccountConfig, type) {
   const config = getConfig();
@@ -356,9 +344,6 @@ module.exports = {
   sandboxTypeMap,
   sandboxApiTypeMap,
   syncTypes,
-  isSandbox,
-  isStandardSandbox,
-  isDevelopmentSandbox,
   getSandboxName,
   getSandboxTypeAsString,
   getHasSandboxesByType,

--- a/packages/cli/lib/ui/index.js
+++ b/packages/cli/lib/ui/index.js
@@ -3,11 +3,12 @@ const { getAccountConfig } = require('@hubspot/local-dev-lib/config');
 const { logger } = require('@hubspot/local-dev-lib/logger');
 const supportsHyperlinks = require('./supportHyperlinks');
 const supportsColor = require('./supportsColor');
-const { isSandbox, getSandboxName } = require('../sandboxes');
 const {
+  isSandbox,
   isDeveloperTestAccount,
   isAppDeveloperAccount,
-} = require('../developerTestAccounts');
+} = require('../accountTypes');
+const { getSandboxName } = require('../sandboxes');
 const { i18n } = require('../lang');
 
 const {


### PR DESCRIPTION
## Description and Context
This PR does the following

#### Sets up _most_ of the public app local dev init flow
* Determine what components are in the project before determining what kind of account the user should use
* Error if the project contains both public apps and private apps (not supported)
* Error if the user is not using a supported account type - for example trying to develop a private app with a developer test account
* Set the target ID for project upload to the parent account if developing a public app

#### Cleans up code for dev command
`dev.js` was over 400 lines long and just its imports previously took up my entire screen. While I was going through and trying to figure out exactly what was going on, I tried to make the code more readable by extracting each discrete step of the dev flow into its own function. These functions now live in `lib/localDev.js`. I also tried to reconcile some of the shared logic between sandboxes and test accounts and clean things up there.

## Testing
From what I can tell, this PR doesn't break the existing private app flow, and gets the public app flow to the point where things are passed off to the UIE dev server (which errors). A lot has changed here though, and there are a lot of different permutations, so should try to test all of them thoroughly.

Off the top of my head, here are some of them
* Developing a private app with a production account
* Developing a private app with an existing sandbox
* Developing a private app with a new sandbox
* Developing a private app with a developer account (should error in a clear way)
* Developing a private app with a developer test account (should error in a clear way)
* Developing a public app with a non-developer account (should error in a clear way)
* Developing a public app with a developer account and creating a new test account
* Developing a public app with developer account and using an existing test account
* Developing a public app with a developer test account

## TODO
This PR includes most of the updates we'll need for the init flow, but still need to add the check to see if the public app is installed in the test account. Going to do this in a later PR.

## Who to Notify
@brandenrodgers @kemmerle @adamawang 
