### PR TITLE
Fixing init for accounts with no name

### DIFF
--- a/packages/cli/commands/init.js
+++ b/packages/cli/commands/init.js
@@ -62,7 +62,7 @@ const personalAccessKeyConfigCreationFlow = async (env, account) => {
 
   try {
     const token = await getAccessToken(personalAccessKey, env);
-    const defaultName = toKebabCase(token.hubName);
+    const defaultName = token.hubName ? toKebabCase(token.hubName) : null;
     const { name } = await enterAccountNamePrompt(defaultName);
 
     updatedConfig = updateConfigWithAccessToken(


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
Our implementation of `hs init` relied on the accounts having a name. HubSpot accounts are not required to have names so we need to support that case.

## Screenshots
<!-- Provide images of the before and after functionality -->

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
