### PR TITLE
Fix bug with creating new developer test accounts

### DIFF
--- a/packages/cli/commands/project/dev.js
+++ b/packages/cli/commands/project/dev.js
@@ -139,6 +139,7 @@ exports.handler = async options => {
       accountConfig,
       env
     );
+    targetProjectAccountId = accountId;
   }
 
   const projectExists = await ensureProjectExists(


### PR DESCRIPTION
## Description and Context
Previously, `targetProjectAccountId` was never getting set when the user selected to create a new test account. This updates that flow to set `targetProjectAccountId` to the default account id, since developer test accounts are always created under the default app developer account.

## Who to Notify
@brandenrodgers @kemmerle @joe-yeager @adamawang 
