### PR TITLE
`hs project dev` supports developer test accounts not in config 

### DIFF
--- a/packages/cli/commands/project/dev.js
+++ b/packages/cli/commands/project/dev.js
@@ -128,6 +128,8 @@ exports.handler = async options => {
 
     targetProjectAccountId = hasPublicApps ? parentAccountId : targetAccountId;
     targetTestingAccountId = targetAccountId;
+
+    // Only used for developer test accounts that are not yet in the config
     if (notInConfigAccount) {
       const useExistingDevTestAcct = await confirmUseExistingDeveloperTestAccountPrompt(
         notInConfigAccount

--- a/packages/cli/commands/project/dev.js
+++ b/packages/cli/commands/project/dev.js
@@ -22,7 +22,7 @@ const {
   validateProjectConfig,
 } = require('../../lib/projects');
 const { EXIT_CODES } = require('../../lib/enums/exitCodes');
-const { uiBetaTag } = require('../../lib/ui');
+const { uiBetaTag, uiCommandReference } = require('../../lib/ui');
 const SpinniesManager = require('../../lib/ui/SpinniesManager');
 const LocalDevManager = require('../../lib/LocalDevManager');
 const {
@@ -47,6 +47,15 @@ const {
   createNewProjectForLocalDev,
   createInitialBuildForNewProject,
 } = require('../../lib/localDev');
+const {
+  confirmUseExistingDeveloperTestAccountPrompt,
+} = require('../../lib/prompts/projectDevTargetAccountPrompt');
+const {
+  saveDevTestAccountToConfig,
+} = require('../../lib/developerTestAccountCreate');
+const {
+  PERSONAL_ACCESS_KEY_AUTH_METHOD,
+} = require('@hubspot/local-dev-lib/constants/auth');
 
 const i18nKey = 'cli.commands.project.subcommands.dev';
 
@@ -110,6 +119,7 @@ exports.handler = async options => {
       targetAccountId,
       parentAccountId,
       createNestedAccount,
+      notInConfigAccount,
     } = await suggestRecommendedNestedAccount(
       accounts,
       accountConfig,
@@ -118,6 +128,35 @@ exports.handler = async options => {
 
     targetProjectAccountId = hasPublicApps ? parentAccountId : targetAccountId;
     targetTestingAccountId = targetAccountId;
+    if (notInConfigAccount) {
+      const useExistingDevTestAcct = await confirmUseExistingDeveloperTestAccountPrompt(
+        notInConfigAccount
+      );
+      if (!useExistingDevTestAcct) {
+        logger.log('');
+        logger.log(
+          i18n(
+            `cli.lib.localDev.confirmDefaultAccountIsTarget.declineDefaultAccountExplanation`,
+            {
+              useCommand: uiCommandReference('hs accounts use'),
+              devCommand: uiCommandReference('hs project dev'),
+            }
+          )
+        );
+        logger.log('');
+        process.exit(EXIT_CODES.SUCCESS);
+      }
+      const devTestAcctConfigName = await saveDevTestAccountToConfig(
+        env,
+        notInConfigAccount
+      );
+      logger.success(
+        i18n(`cli.lib.developerTestAccount.create.success.configFileUpdated`, {
+          accountName: devTestAcctConfigName,
+          authType: PERSONAL_ACCESS_KEY_AUTH_METHOD.name,
+        })
+      );
+    }
 
     createNewSandbox = isStandardAccount(accountConfig) && createNestedAccount;
     createNewDeveloperTestAccount =
@@ -139,6 +178,7 @@ exports.handler = async options => {
       accountConfig,
       env
     );
+    targetProjectAccountId = accountId;
   }
 
   const projectExists = await ensureProjectExists(

--- a/packages/cli/commands/project/dev.js
+++ b/packages/cli/commands/project/dev.js
@@ -22,7 +22,7 @@ const {
   validateProjectConfig,
 } = require('../../lib/projects');
 const { EXIT_CODES } = require('../../lib/enums/exitCodes');
-const { uiBetaTag, uiCommandReference } = require('../../lib/ui');
+const { uiBetaTag } = require('../../lib/ui');
 const SpinniesManager = require('../../lib/ui/SpinniesManager');
 const LocalDevManager = require('../../lib/LocalDevManager');
 const {
@@ -46,16 +46,8 @@ const {
   createDeveloperTestAccountForLocalDev,
   createNewProjectForLocalDev,
   createInitialBuildForNewProject,
+  useExistingDevTestAccount,
 } = require('../../lib/localDev');
-const {
-  confirmUseExistingDeveloperTestAccountPrompt,
-} = require('../../lib/prompts/projectDevTargetAccountPrompt');
-const {
-  saveDevTestAccountToConfig,
-} = require('../../lib/developerTestAccountCreate');
-const {
-  PERSONAL_ACCESS_KEY_AUTH_METHOD,
-} = require('@hubspot/local-dev-lib/constants/auth');
 
 const i18nKey = 'cli.commands.project.subcommands.dev';
 
@@ -131,33 +123,7 @@ exports.handler = async options => {
 
     // Only used for developer test accounts that are not yet in the config
     if (notInConfigAccount) {
-      const useExistingDevTestAcct = await confirmUseExistingDeveloperTestAccountPrompt(
-        notInConfigAccount
-      );
-      if (!useExistingDevTestAcct) {
-        logger.log('');
-        logger.log(
-          i18n(
-            `cli.lib.localDev.confirmDefaultAccountIsTarget.declineDefaultAccountExplanation`,
-            {
-              useCommand: uiCommandReference('hs accounts use'),
-              devCommand: uiCommandReference('hs project dev'),
-            }
-          )
-        );
-        logger.log('');
-        process.exit(EXIT_CODES.SUCCESS);
-      }
-      const devTestAcctConfigName = await saveDevTestAccountToConfig(
-        env,
-        notInConfigAccount
-      );
-      logger.success(
-        i18n(`cli.lib.developerTestAccount.create.success.configFileUpdated`, {
-          accountName: devTestAcctConfigName,
-          authType: PERSONAL_ACCESS_KEY_AUTH_METHOD.name,
-        })
-      );
+      await useExistingDevTestAccount(env, notInConfigAccount);
     }
 
     createNewSandbox = isStandardAccount(accountConfig) && createNestedAccount;

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -1080,6 +1080,7 @@ en:
           sandboxLimitWithSuggestion: "Your account reached the limit of {{ limit }} development sandboxes. Run {{ authCommand }} to add an existing one to the config."
           developerTestAccountLimit: "Your account reached the limit of {{ limit }} developer test accounts."
           confirmDefaultAccount: "Continue testing on {{#bold}}{{ accountName }} ({{ accountType }}){{/bold}}? (Y/n)"
+          confirmUseExistingDeveloperTestAccount: "Continue with {{ accountName }}? This account isn't currently connected to the HubSpot CLI. By continuing, you'll be prompted to generate a personal access key and connect it."
         projectLogsPrompt:
           projectName:
             message: "[--project] Enter the project name:"
@@ -1241,7 +1242,7 @@ en:
             fail: "Failed to create a developer test account {{#bold}}{{ accountName }}{{/bold}}."
             succeed: "Successfully created a developer test account {{#bold}}{{ name }}{{/bold}} with portalId {{#bold}}{{ accountId }}{{/bold}}."
           success:
-            configFileUpdated: "{{ configFilename }} updated with {{ authMethod }} for account {{ account }}."
+            configFileUpdated: "Account \"{{ accountName }}\" updated using \"{{ authType }}\""
           failure:
             invalidUser: "Couldn't create {{#bold}}{{ accountName }}{{/bold}} because your account has been removed from {{#bold}}{{ parentAccountName }}{{/bold}} or your permission set doesn't allow you to create the sandbox. To update your permissions, contact a super admin in {{#bold}}{{ parentAccountName }}{{/bold}}."
             limit: "{{#bold}}{{ accountName }}{{/bold}} reached the limit of {{ limit }} developer test accounts.
@@ -1264,8 +1265,6 @@ en:
               add: "Creating standard sandbox {{#bold}}{{ sandboxName }}{{/bold}}"
               fail: "Failed to create a standard sandbox {{#bold}}{{ sandboxName }}{{/bold}}."
               succeed: "Successfully created a standard sandbox {{#bold}}{{ name }}{{/bold}} with portalId {{#bold}}{{ sandboxHubId }}{{/bold}}."
-          success:
-            configFileUpdated: "{{ configFilename }} updated with {{ authMethod }} for account {{ account }}."
           failure:
             invalidUser: "Couldn't create {{#bold}}{{ accountName }}{{/bold}} because your account has been removed from {{#bold}}{{ parentAccountName }}{{/bold}} or your permission set doesn't allow you to create the sandbox. To update your permissions, contact a super admin in {{#bold}}{{ parentAccountName }}{{/bold}}."
             403Gating: "Couldn't create {{#bold}}{{ accountName }}{{/bold}} because {{#bold}}{{ parentAccountName }}{{/bold}} does not have access to development sandboxes. To opt in to the CRM Development Beta and use development sandboxes, visit https://app.hubspot.com/l/product-updates/in-beta?update=13899236."

--- a/packages/cli/lib/developerTestAccountCreate.js
+++ b/packages/cli/lib/developerTestAccountCreate.js
@@ -183,4 +183,5 @@ const buildDeveloperTestAccount = async ({
 
 module.exports = {
   buildDeveloperTestAccount,
+  saveDevTestAccountToConfig,
 };


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
Issue: https://git.hubteam.com/HubSpot/hubspot-cli-issues/issues/546

After feedback from last weeks bug bash, the expected behavior for `hs project dev` with an app developer account as default is to list all available developer test accounts including those that do not exist in the CLI config. 

In this PR, we fetch all dev test accounts for an app developer account and mix them into the choices available when prompted to select an account. We track that behind the scenes and if a user is to select an account not yet in the config, we prompt them to continue and have them manually generate/save a PAK. 

Confirmation message approved by Mark H: https://hubspot.slack.com/archives/C066MUYG1UH/p1713888899890209?thread_ts=1713886322.515959&cid=C066MUYG1UH

## Screenshots
<!-- Provide images of the before and after functionality -->
Declining the confirmation:
<img width="1256" alt="Screenshot 2024-04-23 at 13 28 28" src="https://github.com/HubSpot/hubspot-cli/assets/16788677/823cd13d-14f3-4413-b82b-68d3c2f0d762">

Full flow:
<img width="1257" alt="Screenshot 2024-04-23 at 13 29 10" src="https://github.com/HubSpot/hubspot-cli/assets/16788677/15f46fd7-ebc5-4207-83a6-5172b09ff25e">


## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->
It does look a bit long on screen but I'm not sure if theres any way to shorten it. 

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@shannon-lichtenwalter 
