### PR TITLE
Fix issues with account flag + add clarification to new project warning

### DIFF
--- a/packages/cli/commands/project/dev.js
+++ b/packages/cli/commands/project/dev.js
@@ -42,6 +42,7 @@ const {
   confirmDefaultAccountIsTarget,
   suggestRecommendedNestedAccount,
   checkIfAppDeveloperAccount,
+  checkIfDeveloperTestAccount,
   createSandboxForLocalDev,
   createDeveloperTestAccountForLocalDev,
   createNewProjectForLocalDev,
@@ -91,7 +92,13 @@ exports.handler = async options => {
   // The account that the project must exist in
   let targetProjectAccountId = options.account ? accountId : null;
   // The account that we are locally testing against
-  let targetTestingAccountId = targetProjectAccountId;
+  let targetTestingAccountId = options.account ? accountId : null;
+
+  if (options.account && hasPublicApps) {
+    checkIfDeveloperTestAccount(accountConfig);
+    targetProjectAccountId = accountConfig.parentAccountId;
+    targetTestingAccountId = accountId;
+  }
 
   let createNewSandbox = false;
   let createNewDeveloperTestAccount = false;
@@ -172,7 +179,8 @@ exports.handler = async options => {
     await createNewProjectForLocalDev(
       projectConfig,
       targetProjectAccountId,
-      createNewSandbox
+      createNewSandbox,
+      hasPublicApps
     );
 
     deployedBuild = await createInitialBuildForNewProject(

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -945,14 +945,15 @@ en:
       localDev:
         confirmDefaultAccountIsTarget:
           declineDefaultAccountExplanation: "To develop on a different account, run {{ useCommand }} to change your default account, then re-run {{ devCommand }}."
-        checkCorrectParentAccountType:
-          standardAccountNotSupported: "This project contains a public app. Local development of public apps is only supported on developer accounts and developer test accounts. Change your default account using {{#bold}}`hs accounts use`{{/bold}}, or link a new account with {{#bold}}`hs auth`{{/bold}}."
+        checkIfAppDevloperAccount: "This project contains a public app. Local development of public apps is only supported on developer accounts and developer test accounts. Change your default account using {{#bold}}`hs accounts use`{{/bold}}, or link a new account with {{#bold}}`hs auth`{{/bold}}."
+        checkIfDeveloperTestAccount: "This project contains a public app. The \"--account\" flag must point to a developer test account to develop this project locally. Alternatively, change your default account to an App Developer Account using {{#bold}}`hs accounts use`{{/bold}} and run {{#bold}}`hs project dev`{{/bold}} to set up a new Developer Test Account."
         suggestRecommendedNestedAccount:
           nonSandboxWarning: "Testing in a sandbox is strongly recommended. To switch the target account, select an option below or run {{#bold}}`hs accounts use`{{/bold}} before running the command again."
           publicAppNonDeveloperTestAccountWarning: "Local development of public apps is only supported in {{#bold}}developer test accounts{{/bold}}."
           privateAppNonDeveloperTestAccountWarning: "Local development of private apps is only supported in {{#bold}}developer test accounts{{/bold}}"
         createNewProjectForLocalDev:
           projectMustExistExplanation: "The project {{ projectName }} does not exist in the target account {{ accountIdentifier}}. This command requires the project to exist in the target account."
+          publicAppProjectMustExistExplanation: "The project {{ projectName }} does not exist in {{ accountIdentifier}}, the app developer account associated with your target account. This command requires the project to exist in this app developer account."
           createProject: "Create new project {{ projectName}} in {{#bold}}[{{ accountIdentifier }}]{{/bold}}?"
           choseNotToCreateProject: "Exiting because this command requires the project to exist in the target account."
           creatingProject: "Creating project {{ projectName }} in {{ accountIdentifier }}"

--- a/packages/cli/lib/localDev.js
+++ b/packages/cli/lib/localDev.js
@@ -86,11 +86,15 @@ const confirmDefaultAccountIsTarget = async accountConfig => {
 // Confirm the default account is a developer account if developing public apps
 const checkIfAppDeveloperAccount = accountConfig => {
   if (!isAppDeveloperAccount(accountConfig)) {
-    logger.error(
-      i18n(
-        `${i18nKey}.checkCorrectParentAccountType.standardAccountNotSupported`
-      )
-    );
+    logger.error(i18n(`${i18nKey}.checkIfAppDevloperAccount`));
+    process.exit(EXIT_CODES.SUCCESS);
+  }
+};
+
+// Confirm the default account is a developer account if developing public apps
+const checkIfDeveloperTestAccount = accountConfig => {
+  if (!isDeveloperTestAccount(accountConfig)) {
+    logger.error(i18n(`${i18nKey}.checkIfDeveloperTestAccount`));
     process.exit(EXIT_CODES.SUCCESS);
   }
 };
@@ -266,23 +270,25 @@ const createDeveloperTestAccountForLocalDev = async (
 const createNewProjectForLocalDev = async (
   projectConfig,
   targetAccountId,
-  shouldCreateWithoutConfirmation
+  shouldCreateWithoutConfirmation,
+  hasPublicApps
 ) => {
   // Create the project without prompting if this is a newly created sandbox
   let shouldCreateProject = shouldCreateWithoutConfirmation;
 
   if (!shouldCreateProject) {
+    const explanationString = i18n(
+      hasPublicApps
+        ? `${i18nKey}.createNewProjectForLocalDev.publicAppProjectMustExistExplanation`
+        : `${i18nKey}.createNewProjectForLocalDev.projectMustExistExplanation`,
+      {
+        accountIdentifier: uiAccountDescription(targetAccountId),
+        projectName: projectConfig.name,
+      }
+    );
     logger.log();
     uiLine();
-    logger.warn(
-      i18n(
-        `${i18nKey}.createNewProjectForLocalDev.projectMustExistExplanation`,
-        {
-          accountIdentifier: uiAccountDescription(targetAccountId),
-          projectName: projectConfig.name,
-        }
-      )
-    );
+    logger.warn(explanationString);
     uiLine();
 
     shouldCreateProject = await confirmPrompt(
@@ -393,6 +399,7 @@ const createInitialBuildForNewProject = async (
 module.exports = {
   confirmDefaultAccountIsTarget,
   checkIfAppDeveloperAccount,
+  checkIfDeveloperTestAccount,
   suggestRecommendedNestedAccount,
   createSandboxForLocalDev,
   createDeveloperTestAccountForLocalDev,


### PR DESCRIPTION
## Description and Context
See https://git.hubteam.com/HubSpot/hubspot-cli-issues/issues/549
This does a few small things
* Fixes the `account` flag on both private and public app projects
* Adds an error if running a public app project with an account other than a developer test account
* Adds some clarification to the warning message when uploading a public app project - previously it said it didn't exist in the target account. For public apps, it needs to exist in the _parent_ of the target account.

## Screenshots
`--account` flag error
<img width="783" alt="Screenshot 2024-04-23 at 4 48 38 PM" src="https://github.com/HubSpot/hubspot-cli/assets/10413161/c5c74d86-93b5-4763-8959-ccff99c47773">

Upload warning
<img width="780" alt="Screenshot 2024-04-23 at 4 48 22 PM" src="https://github.com/HubSpot/hubspot-cli/assets/10413161/18b43b36-8e8c-4e1b-ba9a-92648a18e6ae">


## Who to Notify
@brandenrodgers @kemmerle 