### PR TITLE
Fix project dev when recommended account is default

### DIFF
--- a/packages/cli/commands/project/dev.js
+++ b/packages/cli/commands/project/dev.js
@@ -109,6 +109,7 @@ exports.handler = async options => {
     targetProjectAccountId = hasPublicApps
       ? accountConfig.parentAccountId
       : accountId;
+    targetTestingAccountId = accountId;
   } else if (!targetProjectAccountId && hasPublicApps) {
     checkIfAppDeveloperAccount(accountConfig);
   }


### PR DESCRIPTION
## Description and Context
We weren't setting target test account if the user already had the recommended account type as their default

## Who to Notify
@brandenrodgers @kemmerle 
