### PR TITLE
Fix `hs accounts clean` 

### DIFF
--- a/packages/cli/commands/accounts/clean.js
+++ b/packages/cli/commands/accounts/clean.js
@@ -111,7 +111,7 @@ exports.handler = async options => {
         await deleteAccount(accountToRemove.name);
         logger.log(
           i18n(`${i18nKey}.removeSuccess`, {
-            accountName: uiAccountDescription(accountToRemove.portalId),
+            accountName: accountToRemove.name,
           })
         );
       }

--- a/packages/cli/commands/accounts/clean.js
+++ b/packages/cli/commands/accounts/clean.js
@@ -87,7 +87,7 @@ exports.handler = async options => {
     });
     logger.log(
       getTableContents(
-        accountsToRemove.map(p => [uiAccountDescription(p)]),
+        accountsToRemove.map(p => [uiAccountDescription(p.portalId)]),
         { border: { bodyLeft: '  ' } }
       )
     );
@@ -111,7 +111,7 @@ exports.handler = async options => {
         await deleteAccount(accountToRemove.name);
         logger.log(
           i18n(`${i18nKey}.removeSuccess`, {
-            accountName: uiAccountDescription(accountToRemove),
+            accountName: uiAccountDescription(accountToRemove.portalId),
           })
         );
       }


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
Related BE issue here: https://git.hubteam.com/HubSpotProtected/LocalDevAuth/pull/196

A fix went out for the `hs accounts clean` command recently but we discovered incorrect usage of `uiAccountDescription` where a config object was being passed instead of a portalId. This PR addresses that. 

## Screenshots
<!-- Provide images of the before and after functionality -->
Before: 
<img width="1292" alt="Screenshot 2024-04-24 at 12 16 15" src="https://github.com/HubSpot/hubspot-cli/assets/16788677/4d272dbe-0d18-471d-b289-877622d8f771">

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->
none

## Who to Notify
<!-- /cc those you wish to know about the PR -->
