### PR TITLE
Fixing account id references for public app local dev

### DIFF
--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -479,7 +479,7 @@ en:
             errors:
               noProjectConfig: "No project detected. Please run this command again from a project directory."
               invalidProjectComponents: "Projects cannot contain both private and public apps. Move your apps to separate projects before attempting local development."
-              parentAccountNotConfigured: "To locally develop your project on {{ accountIdentifier }} you must authenticate the CLI with the App Developer Account {{ accountId}}. Run {{ authCommand }} to authenticate the parent account."
+              parentAccountNotConfigured: "To develop this project locally, run {{ authCommand }} to authenticate the App Developer Account {{ accountId}} associated with {{ accountIdentifier }}."
             examples:
               default: "Start local dev for the current project"
           create:

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -479,6 +479,7 @@ en:
             errors:
               noProjectConfig: "No project detected. Please run this command again from a project directory."
               invalidProjectComponents: "Projects cannot contain both private and public apps. Move your apps to separate projects before attempting local development."
+              parentAccountNotConfigured: "To locally test your project on {{ accountIdentifier }} you must connect the CLI to its parent account. Run {{ authCommand }} to authenticate the parent account."
             examples:
               default: "Start local dev for the current project"
           create:

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -479,7 +479,7 @@ en:
             errors:
               noProjectConfig: "No project detected. Please run this command again from a project directory."
               invalidProjectComponents: "Projects cannot contain both private and public apps. Move your apps to separate projects before attempting local development."
-              parentAccountNotConfigured: "To develop this project locally, run {{ authCommand }} to authenticate the App Developer Account {{ accountId}} associated with {{ accountIdentifier }}."
+              parentAccountNotConfigured: "To develop this project locally, run {{ authCommand }} to authenticate the App Developer Account {{ accountId }} associated with {{ accountIdentifier }}."
             examples:
               default: "Start local dev for the current project"
           create:

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -479,7 +479,7 @@ en:
             errors:
               noProjectConfig: "No project detected. Please run this command again from a project directory."
               invalidProjectComponents: "Projects cannot contain both private and public apps. Move your apps to separate projects before attempting local development."
-              parentAccountNotConfigured: "To locally test your project on {{ accountIdentifier }} you must connect the CLI to its parent account. Run {{ authCommand }} to authenticate the parent account."
+              parentAccountNotConfigured: "To locally develop your project on {{ accountIdentifier }} you must authenticate the CLI with the App Developer Account {{ accountId}}. Run {{ authCommand }} to authenticate the parent account."
             examples:
               default: "Start local dev for the current project"
           create:
@@ -1393,8 +1393,8 @@ en:
           platformVersionErrors:
             header: "Platform version update required"
             unspecifiedPlatformVersion: "Projects with an {{#bold}}{{platformVersion}}{{/bold}} are no longer supported."
-            platformVersionRetired: "Projects with {{#bold}} platformVersion {{ platformVersion }}{{/bold}} are no longer supported."
-            nonExistentPlatformVersion: "Projects with {{#bold}} platformVersion {{ platformVersion }}{{/bold}} are not supported."
+            platformVersionRetired: "Projects with {{#bold}}platformVersion {{ platformVersion }}{{/bold}} are no longer supported."
+            nonExistentPlatformVersion: "Projects with {{#bold}}platformVersion {{ platformVersion }}{{/bold}} are not supported."
             updateProject: "Please update your project to the latest version and try again."
             docsLink: "Projects platform versioning (BETA)"
             betaLink: "For more info, see {{ docsLink }}."

--- a/packages/cli/lib/LocalDevManager.js
+++ b/packages/cli/lib/LocalDevManager.js
@@ -39,6 +39,9 @@ const i18nKey = 'cli.lib.LocalDevManager';
 class LocalDevManager {
   constructor(options) {
     this.targetAccountId = options.targetAccountId;
+    // The account that the project exists in. This is not always the targetAccountId
+    this.targetProjectAccountId = options.parentAccountId || options.accountId;
+
     this.projectConfig = options.projectConfig;
     this.projectDir = options.projectDir;
     this.debug = options.debug || false;
@@ -88,7 +91,7 @@ class LocalDevManager {
     if (!this.deployedBuild) {
       logger.error(
         i18n(`${i18nKey}.noDeployedBuild`, {
-          accountIdentifier: uiAccountDescription(this.targetAccountId),
+          accountIdentifier: uiAccountDescription(this.targetProjectAccountId),
           uploadCommand: this.getUploadCommand(),
         })
       );
@@ -117,7 +120,10 @@ class LocalDevManager {
     logger.log(
       uiLink(
         i18n(`${i18nKey}.viewInHubSpotLink`),
-        getProjectDetailUrl(this.projectConfig.name, this.targetAccountId)
+        getProjectDetailUrl(
+          this.projectConfig.name,
+          this.targetProjectAccountId
+        )
       )
     );
     logger.log();
@@ -177,9 +183,9 @@ class LocalDevManager {
   getUploadCommand() {
     const currentDefaultAccount = getConfigDefaultAccount();
 
-    return this.targetAccountId !== getAccountId(currentDefaultAccount)
+    return this.targetProjectAccountId !== getAccountId(currentDefaultAccount)
       ? uiCommandReference(
-          `hs project upload --account=${this.targetAccountId}`
+          `hs project upload --account=${this.targetProjectAccountId}`
         )
       : uiCommandReference('hs project upload');
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8091,7 +8091,16 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -8132,7 +8141,7 @@ stringify-object@^3.2.1, stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -8145,6 +8154,13 @@ strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -8831,7 +8847,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -8844,6 +8860,15 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
This fixes a few different small edge-case bugs, all related to local dev for public apps:
- We were showing the incorrect account id in the prompt when the user edits a configuration file while local dev is running
- We were showing the incorrect account to upload to when there is no deployed build for the project in the target account
  - This only shows when the project exists in the account, but there are no builds (repro by uploading a broken project)
- Fixing JS error when default account is a dev test account, and the parent dev account has not been configured in the CLI

## Screenshots
<!-- Provide images of the before and after functionality -->
WIP copy for the message to tell the user that they need to configure their Developer Account:
<img width="858" alt="image" src="https://github.com/HubSpot/hubspot-cli/assets/6654014/654d5be3-2081-4e5c-8f76-95986735d335">

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
cc/ @markhazlewood for input on copy