### PR TITLE
Public app install prompt setup

### DIFF
--- a/packages/cli/commands/project/dev.js
+++ b/packages/cli/commands/project/dev.js
@@ -166,13 +166,17 @@ exports.handler = async options => {
     }
   );
 
-  let deployedBuild = project.deployedBuild;
-  let isGithubLinked =
-    project.sourceIntegration && project.sourceIntegration.source === 'GITHUB';
+  let deployedBuild;
+  let isGithubLinked;
 
   SpinniesManager.init();
 
-  if (!projectExists) {
+  if (projectExists) {
+    deployedBuild = project.deployedBuild;
+    isGithubLinked =
+      project.sourceIntegration &&
+      project.sourceIntegration.source === 'GITHUB';
+  } else {
     await createNewProjectForLocalDev(
       projectConfig,
       targetProjectAccountId,

--- a/packages/cli/commands/project/dev.js
+++ b/packages/cli/commands/project/dev.js
@@ -47,6 +47,7 @@ const {
   createNewProjectForLocalDev,
   createInitialBuildForNewProject,
   useExistingDevTestAccount,
+  checkAndPromptPublicAppInstallation,
 } = require('../../lib/localDev');
 
 const i18nKey = 'cli.commands.project.subcommands.dev';
@@ -185,6 +186,10 @@ exports.handler = async options => {
       projectDir,
       targetProjectAccountId
     );
+  }
+
+  if (hasPublicApps) {
+    checkAndPromptPublicAppInstallation(targetTestingAccountId, project.id);
   }
 
   const LocalDev = new LocalDevManager({

--- a/packages/cli/commands/project/dev.js
+++ b/packages/cli/commands/project/dev.js
@@ -47,7 +47,6 @@ const {
   createNewProjectForLocalDev,
   createInitialBuildForNewProject,
   useExistingDevTestAccount,
-  checkAndPromptPublicAppInstallation,
 } = require('../../lib/localDev');
 
 const i18nKey = 'cli.commands.project.subcommands.dev';
@@ -186,10 +185,6 @@ exports.handler = async options => {
       projectDir,
       targetProjectAccountId
     );
-  }
-
-  if (hasPublicApps) {
-    checkAndPromptPublicAppInstallation(targetTestingAccountId, project.id);
   }
 
   const LocalDev = new LocalDevManager({

--- a/packages/cli/commands/project/dev.js
+++ b/packages/cli/commands/project/dev.js
@@ -15,7 +15,6 @@ const {
   getAccountConfig,
   getEnv,
 } = require('@hubspot/local-dev-lib/config');
-const { fetchProject } = require('@hubspot/local-dev-lib/api/projects');
 const {
   getProjectConfig,
   ensureProjectExists,
@@ -167,19 +166,9 @@ exports.handler = async options => {
     }
   );
 
-  let deployedBuild;
-  let isGithubLinked;
-
-  if (projectExists) {
-    const project = await fetchProject(
-      targetProjectAccountId,
-      projectConfig.name
-    );
-    deployedBuild = project.deployedBuild;
-    isGithubLinked =
-      project.sourceIntegration &&
-      project.sourceIntegration.source === 'GITHUB';
-  }
+  let deployedBuild = project.deployedBuild;
+  let isGithubLinked =
+    project.sourceIntegration && project.sourceIntegration.source === 'GITHUB';
 
   SpinniesManager.init();
 

--- a/packages/cli/commands/project/dev.js
+++ b/packages/cli/commands/project/dev.js
@@ -157,7 +157,7 @@ exports.handler = async options => {
     targetProjectAccountId = accountId;
   }
 
-  const projectExists = await ensureProjectExists(
+  const { projectExists, project } = await ensureProjectExists(
     targetProjectAccountId,
     projectConfig.name,
     {

--- a/packages/cli/commands/project/download.js
+++ b/packages/cli/commands/project/download.js
@@ -50,10 +50,14 @@ exports.handler = async options => {
   trackCommandUsage('project-download', null, accountId);
 
   try {
-    const projectExists = await ensureProjectExists(accountId, projectName, {
-      allowCreate: false,
-      noLogs: true,
-    });
+    const { projectExists } = await ensureProjectExists(
+      accountId,
+      projectName,
+      {
+        allowCreate: false,
+        noLogs: true,
+      }
+    );
 
     if (!projectExists) {
       logger.error(

--- a/packages/cli/commands/project/open.js
+++ b/packages/cli/commands/project/open.js
@@ -37,9 +37,13 @@ exports.handler = async options => {
   let projectName = project;
 
   if (projectName) {
-    const projectExists = await ensureProjectExists(accountId, projectName, {
-      allowCreate: false,
-    });
+    const { projectExists } = await ensureProjectExists(
+      accountId,
+      projectName,
+      {
+        allowCreate: false,
+      }
+    );
 
     if (!projectExists) {
       process.exit(EXIT_CODES.ERROR);

--- a/packages/cli/lib/DevServerManager.js
+++ b/packages/cli/lib/DevServerManager.js
@@ -71,7 +71,7 @@ class DevServerManager {
     }, {});
   }
 
-  async setup({ components, onUploadRequired, accountId, setActiveComponent }) {
+  async setup({ components, onUploadRequired, accountId, setActiveApp }) {
     this.componentsByType = this.arrangeComponentsByType(components);
     const { env } = getAccountConfig(accountId);
     await startPortManagerServer();
@@ -87,7 +87,7 @@ class DevServerManager {
               api: getHubSpotApiOrigin(env),
               web: getHubSpotWebsiteOrigin(env),
             },
-            setActiveComponent,
+            setActiveApp,
           });
         }
       }

--- a/packages/cli/lib/DevServerManager.js
+++ b/packages/cli/lib/DevServerManager.js
@@ -71,7 +71,7 @@ class DevServerManager {
     }, {});
   }
 
-  async setup({ components, onUploadRequired, accountId }) {
+  async setup({ components, onUploadRequired, accountId, setActiveComponent }) {
     this.componentsByType = this.arrangeComponentsByType(components);
     const { env } = getAccountConfig(accountId);
     await startPortManagerServer();
@@ -87,6 +87,7 @@ class DevServerManager {
               api: getHubSpotApiOrigin(env),
               web: getHubSpotWebsiteOrigin(env),
             },
+            setActiveComponent,
           });
         }
       }

--- a/packages/cli/lib/LocalDevManager.js
+++ b/packages/cli/lib/LocalDevManager.js
@@ -47,6 +47,7 @@ class LocalDevManager {
     this.watcher = null;
     this.uploadWarnings = {};
     this.runnableComponents = this.getRunnableComponents(options.components);
+    this.activeApp = null;
 
     this.projectSourceDir = path.join(
       this.projectDir,
@@ -78,6 +79,12 @@ class LocalDevManager {
 
   getRunnableComponents(components) {
     return components.filter(component => component.runnable);
+  }
+
+  async setActiveApp(app) {
+    this.activeApp = app;
+
+    // TODO: Show the install warnings the first time this gets set
   }
 
   async start() {
@@ -325,6 +332,7 @@ class LocalDevManager {
         components: this.runnableComponents,
         onUploadRequired: this.logUploadWarning.bind(this),
         accountId: this.targetAccountId,
+        setActiveApp: this.setActiveApp.bind(this),
       });
       return true;
     } catch (e) {

--- a/packages/cli/lib/localDev.js
+++ b/packages/cli/lib/localDev.js
@@ -11,10 +11,6 @@ const { getHubSpotWebsiteOrigin } = require('@hubspot/local-dev-lib/urls');
 const { getAccountConfig } = require('@hubspot/local-dev-lib/config');
 const { createProject } = require('@hubspot/local-dev-lib/api/projects');
 const {
-  fetchAppInstallationData,
-} = require('@hubspot/local-dev-lib/api/localDevAuth');
-
-const {
   confirmDefaultAccountPrompt,
   selectSandboxTargetAccountPrompt,
   selectDeveloperTestTargetAccountPrompt,
@@ -434,20 +430,6 @@ const createInitialBuildForNewProject = async (
   return initialUploadResult.buildResult;
 };
 
-const checkAndPromptPublicAppInstallation = async (
-  targetTestingAccountId,
-  projectId,
-  appUid,
-  requiredScopeGroups
-) => {
-  await fetchAppInstallationData(
-    targetTestingAccountId,
-    projectId,
-    appUid,
-    requiredScopeGroups
-  );
-};
-
 module.exports = {
   confirmDefaultAccountIsTarget,
   checkIfAppDeveloperAccount,
@@ -458,5 +440,4 @@ module.exports = {
   useExistingDevTestAccount,
   createNewProjectForLocalDev,
   createInitialBuildForNewProject,
-  checkAndPromptPublicAppInstallation,
 };

--- a/packages/cli/lib/localDev.js
+++ b/packages/cli/lib/localDev.js
@@ -10,6 +10,9 @@ const {
 const { getHubSpotWebsiteOrigin } = require('@hubspot/local-dev-lib/urls');
 const { getAccountConfig } = require('@hubspot/local-dev-lib/config');
 const { createProject } = require('@hubspot/local-dev-lib/api/projects');
+const {
+  fetchAppInstallationData,
+} = require('@hubspot/local-dev-lib/api/localDevAuth');
 
 const {
   confirmDefaultAccountPrompt,
@@ -431,6 +434,20 @@ const createInitialBuildForNewProject = async (
   return initialUploadResult.buildResult;
 };
 
+const checkAndPromptPublicAppInstallation = async (
+  targetTestingAccountId,
+  projectId,
+  appUid,
+  requiredScopeGroups
+) => {
+  await fetchAppInstallationData(
+    targetTestingAccountId,
+    projectId,
+    appUid,
+    requiredScopeGroups
+  );
+};
+
 module.exports = {
   confirmDefaultAccountIsTarget,
   checkIfAppDeveloperAccount,
@@ -441,4 +458,5 @@ module.exports = {
   useExistingDevTestAccount,
   createNewProjectForLocalDev,
   createInitialBuildForNewProject,
+  checkAndPromptPublicAppInstallation,
 };

--- a/packages/cli/lib/projects.js
+++ b/packages/cli/lib/projects.js
@@ -273,14 +273,14 @@ const ensureProjectExists = async (
 
       if (shouldCreateProject) {
         try {
-          await createProject(accountId, projectName);
+          const project = await createProject(accountId, projectName);
           logger.success(
             i18n(`${i18nKey}.ensureProjectExists.createSuccess`, {
               projectName,
               accountIdentifier,
             })
           );
-          return { projectExists: true };
+          return { projectExists: true, project };
         } catch (err) {
           return logApiErrorInstance(
             err,

--- a/packages/cli/lib/projects.js
+++ b/packages/cli/lib/projects.js
@@ -252,7 +252,7 @@ const ensureProjectExists = async (
     const project = withPolling
       ? await pollFetchProject(accountId, projectName)
       : await fetchProject(accountId, projectName);
-    return !!project;
+    return { projectExists: !!project, project };
   } catch (err) {
     if (isSpecifiedError(err, { statusCode: 404 })) {
       let shouldCreateProject = forceCreate;
@@ -280,7 +280,7 @@ const ensureProjectExists = async (
               accountIdentifier,
             })
           );
-          return true;
+          return { projectExists: true };
         } catch (err) {
           return logApiErrorInstance(
             err,
@@ -296,7 +296,7 @@ const ensureProjectExists = async (
             })
           );
         }
-        return false;
+        return { projectExists: false };
       }
     }
     if (

--- a/packages/cli/lib/prompts/projectNamePrompt.js
+++ b/packages/cli/lib/prompts/projectNamePrompt.js
@@ -14,7 +14,7 @@ const projectNamePrompt = (accountId, options = {}) => {
       if (typeof val !== 'string' || !val) {
         return i18n(`${i18nKey}.errors.invalidName`);
       }
-      const projectExists = await ensureProjectExists(accountId, val, {
+      const { projectExists } = await ensureProjectExists(accountId, val, {
         allowCreate: false,
         noLogs: true,
       });


### PR DESCRIPTION
## Description and Context
This is kind of a weird WIP PR, but it won't affect the local dev flow at all and will allow @joe-yeager to start handling the dev server side of this.

What this does
* Passed a `setActiveApp` callback to the dev server. Once the `LocalDevManager` has the active app, it'll be able to issue the relevant prompts and warnings
* Slightly tweaks `ensureProjectExists` to return the project - noticed when working on this that we were making a redundant call to `fetchProject`

## Screenshots
<!-- Provide images of the before and after functionality -->

## TODO
Once the dev server is setting the active app, we can handle the rest of the flow in the CLI

## Who to Notify
@brandenrodgers @kemmerle @joe-yeager 
