### PR TITLE
Public app install prompt

### DIFF
--- a/packages/cli/commands/project/dev.js
+++ b/packages/cli/commands/project/dev.js
@@ -223,6 +223,7 @@ exports.handler = async options => {
     projectDir,
     projectId: project.id,
     targetAccountId: targetTestingAccountId,
+    env,
   });
 
   await LocalDev.start();

--- a/packages/cli/commands/project/dev.js
+++ b/packages/cli/commands/project/dev.js
@@ -221,6 +221,7 @@ exports.handler = async options => {
     parentAccountId: targetProjectAccountId,
     projectConfig,
     projectDir,
+    projectId: project.id,
     targetAccountId: targetTestingAccountId,
   });
 

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -1231,6 +1231,10 @@ en:
           destRequired: "You must specify a destination directory."
       cleanUploadPrompt:
         message: "You are about to remove any remote files in \"{{ filePath }}\" on HubSpot account {{ accountId }} that don't exist locally. Are you sure you want to do this?"
+      installPublicAppPrompt:
+        explanation: "Local development requires this app to be installed in the target test account"
+        prompt: "Open hubspot.com to install this app?"
+        decline: "To continue local development of this app, install it in your target test account and re-run {{#bold}}`hs project dev`{{/bold}}"
     convertFields:
       positionals:
         src:

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -927,6 +927,7 @@ en:
       exitingStart: "Stopping local dev server ..."
       exitingSucceed: "Successfully exited"
       exitingFail: "Failed to cleanup before exiting"
+      missingUid: "Could not find a uid for the selected app. Confirm that the app config file contains the uid field and re-run {{#bold}}`hs project dev`{{/bold}}."
       uploadWarning:
         appLabel: "[App]"
         uiExtensionLabel: "[UI Extension]"

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -927,7 +927,7 @@ en:
       exitingStart: "Stopping local dev server ..."
       exitingSucceed: "Successfully exited"
       exitingFail: "Failed to cleanup before exiting"
-      missingUid: "Could not find a uid for the selected app. Confirm that the app config file contains the uid field and re-run {{#bold}}`hs project dev`{{/bold}}."
+      missingUid: "Could not find a uid for the selected app. Confirm that the app config file contains the uid field and re-run {{ devCommand }}."
       uploadWarning:
         appLabel: "[App]"
         uiExtensionLabel: "[UI Extension]"

--- a/packages/cli/lib/LocalDevManager.js
+++ b/packages/cli/lib/LocalDevManager.js
@@ -5,6 +5,9 @@ const { i18n } = require('./lang');
 const { handleKeypress } = require('./process');
 const { logger } = require('@hubspot/local-dev-lib/logger');
 const {
+  fetchAppInstallationData,
+} = require('@hubspot/local-dev-lib/api/localDevAuth');
+const {
   getAccountId,
   getConfigDefaultAccount,
 } = require('@hubspot/local-dev-lib/config');
@@ -44,6 +47,7 @@ class LocalDevManager {
 
     this.projectConfig = options.projectConfig;
     this.projectDir = options.projectDir;
+    this.projectId = options.projectId;
     this.debug = options.debug || false;
     this.deployedBuild = options.deployedBuild;
     this.isGithubLinked = options.isGithubLinked;
@@ -85,10 +89,12 @@ class LocalDevManager {
   }
 
   async setActiveApp(appUid) {
-    console.log(appUid, this.runnableComponents);
     this.activeApp = this.runnableComponents.find(component => {
       return component.config.uid === appUid;
     });
+
+    const installationData = await this.getActiveAppInstallationData();
+    console.log(installationData);
     // TODO: Show the install warnings the first time this gets set
   }
 
@@ -179,6 +185,16 @@ class LocalDevManager {
       });
     }
     process.exit(EXIT_CODES.SUCCESS);
+  }
+
+  getActiveAppInstallationData() {
+    return fetchAppInstallationData(
+      this.targetAccountId,
+      this.projectId,
+      this.activeApp.config.uid,
+      this.activeApp.config.auth.requiredScopes,
+      this.activeApp.config.auth.optionalScopes
+    );
   }
 
   updateKeypressListeners() {

--- a/packages/cli/lib/LocalDevManager.js
+++ b/packages/cli/lib/LocalDevManager.js
@@ -97,7 +97,11 @@ class LocalDevManager {
 
   async setActiveApp(appUid) {
     if (!appUid) {
-      logger.error(i18n(`${i18nKey}.missingUid`));
+      logger.error(
+        i18n(`${i18nKey}.missingUid`, {
+          devCommand: uiCommandReference('hs project dev'),
+        })
+      );
       process.exit(EXIT_CODES.ERROR);
     }
     this.activeApp = this.runnableComponents.find(component => {

--- a/packages/cli/lib/LocalDevManager.js
+++ b/packages/cli/lib/LocalDevManager.js
@@ -61,6 +61,7 @@ class LocalDevManager {
     this.runnableComponents = this.getRunnableComponents(options.components);
     this.activeApp = null;
     this.activePublicAppData = null;
+    this.env = options.env;
 
     this.projectSourceDir = path.join(
       this.projectDir,
@@ -234,7 +235,18 @@ class LocalDevManager {
     } = await this.getActiveAppInstallationData();
 
     if (!isInstalled) {
-      await installPublicAppPrompt();
+      const {
+        clientId,
+        requiredScopes,
+        redirectUrls,
+      } = this.activePublicAppData;
+
+      await installPublicAppPrompt(
+        this.env,
+        clientId,
+        requiredScopes,
+        redirectUrls
+      );
     }
   }
 

--- a/packages/cli/lib/LocalDevManager.js
+++ b/packages/cli/lib/LocalDevManager.js
@@ -97,8 +97,8 @@ class LocalDevManager {
 
   async setActiveApp(appUid) {
     if (!appUid) {
-      // TODO: What do we do here?
-      return;
+      logger.error(i18n(`${i18nKey}.missingUid`));
+      process.exit(EXIT_CODES.ERROR);
     }
     this.activeApp = this.runnableComponents.find(component => {
       return component.config.uid === appUid;

--- a/packages/cli/lib/LocalDevManager.js
+++ b/packages/cli/lib/LocalDevManager.js
@@ -84,9 +84,11 @@ class LocalDevManager {
     return components.filter(component => component.runnable);
   }
 
-  async setActiveApp(app) {
-    this.activeApp = app;
-
+  async setActiveApp(appUid) {
+    console.log(appUid, this.runnableComponents);
+    this.activeApp = this.runnableComponents.find(component => {
+      return component.config.uid === appUid;
+    });
     // TODO: Show the install warnings the first time this gets set
   }
 

--- a/packages/cli/lib/LocalDevManager.js
+++ b/packages/cli/lib/LocalDevManager.js
@@ -235,17 +235,12 @@ class LocalDevManager {
     } = await this.getActiveAppInstallationData();
 
     if (!isInstalled) {
-      const {
-        clientId,
-        requiredScopes,
-        redirectUrls,
-      } = this.activePublicAppData;
-
       await installPublicAppPrompt(
         this.env,
-        clientId,
-        requiredScopes,
-        redirectUrls
+        this.targetAccountId,
+        this.activePublicAppData.clientId,
+        this.activeApp.config.auth.requiredScopes,
+        this.activeApp.config.auth.redirectUrls
       );
     }
   }

--- a/packages/cli/lib/prompts/installPublicAppPrompt.js
+++ b/packages/cli/lib/prompts/installPublicAppPrompt.js
@@ -1,0 +1,9 @@
+const open = require('open');
+const { getHubSpotWebsiteOrigin } = require('@hubspot/local-dev-lib/urls');
+const { logger } = require('@hubspot/local-dev-lib/logger');
+const { promptUser } = require('./promptUtils');
+const { i18n } = require('../lang');
+const { uiInfoSection } = require('../ui');
+const { EXIT_CODES } = require('../enums/exitCodes');
+
+const i18nKey = 'lib.prompts.installPublicAppPrompt';

--- a/packages/cli/lib/prompts/installPublicAppPrompt.js
+++ b/packages/cli/lib/prompts/installPublicAppPrompt.js
@@ -14,6 +14,7 @@ const installPublicAppPrompt = async (
   scopes,
   redirectUrls
 ) => {
+  logger.log('');
   logger.log(i18n(`${i18nKey}.explanation`));
 
   const { shouldOpenBrowser } = await promptUser({

--- a/packages/cli/lib/prompts/installPublicAppPrompt.js
+++ b/packages/cli/lib/prompts/installPublicAppPrompt.js
@@ -7,3 +7,24 @@ const { uiInfoSection } = require('../ui');
 const { EXIT_CODES } = require('../enums/exitCodes');
 
 const i18nKey = 'lib.prompts.installPublicAppPrompt';
+
+const installPublicAppPrompt = async () => {
+  logger.log(i18n(`${i18nKey}.explanation`));
+
+  const { shouldOpenBrowser } = await promptUser({
+    name: 'shouldOpenBrowser',
+    type: 'confirm',
+    message: i18n(`${i18nKey}.prompt`),
+  });
+
+  if (!shouldOpenBrowser) {
+    logger.log(i18n(`${i18nKey}.decline`));
+    process.exit(EXIT_CODES.SUCCESS);
+  }
+
+  const url = '';
+
+  open(url);
+};
+
+module.exports = { installPublicAppPrompt };

--- a/packages/cli/lib/prompts/installPublicAppPrompt.js
+++ b/packages/cli/lib/prompts/installPublicAppPrompt.js
@@ -7,7 +7,13 @@ const { EXIT_CODES } = require('../enums/exitCodes');
 
 const i18nKey = 'lib.prompts.installPublicAppPrompt';
 
-const installPublicAppPrompt = async (env, clientId, scopes, redirectUrls) => {
+const installPublicAppPrompt = async (
+  env,
+  targetAccountId,
+  clientId,
+  scopes,
+  redirectUrls
+) => {
   logger.log(i18n(`${i18nKey}.explanation`));
 
   const { shouldOpenBrowser } = await promptUser({
@@ -24,7 +30,7 @@ const installPublicAppPrompt = async (env, clientId, scopes, redirectUrls) => {
   const websiteOrigin = getHubSpotWebsiteOrigin(env);
 
   const url =
-    `${websiteOrigin}/oauth/authorize` +
+    `${websiteOrigin}/oauth/${targetAccountId}/authorize` +
     `?client_id=${encodeURIComponent(clientId)}` +
     `&scope=${encodeURIComponent(scopes)}` +
     `&redirect_uri=${encodeURIComponent(redirectUrls)}`;

--- a/packages/cli/lib/prompts/installPublicAppPrompt.js
+++ b/packages/cli/lib/prompts/installPublicAppPrompt.js
@@ -3,12 +3,11 @@ const { getHubSpotWebsiteOrigin } = require('@hubspot/local-dev-lib/urls');
 const { logger } = require('@hubspot/local-dev-lib/logger');
 const { promptUser } = require('./promptUtils');
 const { i18n } = require('../lang');
-const { uiInfoSection } = require('../ui');
 const { EXIT_CODES } = require('../enums/exitCodes');
 
 const i18nKey = 'lib.prompts.installPublicAppPrompt';
 
-const installPublicAppPrompt = async () => {
+const installPublicAppPrompt = async (env, clientId, scopes, redirectUrls) => {
   logger.log(i18n(`${i18nKey}.explanation`));
 
   const { shouldOpenBrowser } = await promptUser({
@@ -22,7 +21,13 @@ const installPublicAppPrompt = async () => {
     process.exit(EXIT_CODES.SUCCESS);
   }
 
-  const url = '';
+  const websiteOrigin = getHubSpotWebsiteOrigin(env);
+
+  const url =
+    `${websiteOrigin}/oauth/authorize` +
+    `?client_id=${encodeURIComponent(clientId)}` +
+    `&scope=${encodeURIComponent(scopes)}` +
+    `&redirect_uri=${encodeURIComponent(redirectUrls)}`;
 
   open(url);
 };

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/HubSpot/hubspot-cms-tools"
   },
   "dependencies": {
-    "@hubspot/local-dev-lib": "1.0.1",
+    "@hubspot/local-dev-lib": "1.1.0",
     "@hubspot/serverless-dev-runtime": "5.2.1-beta.2",
     "@hubspot/theme-preview-dev-server": "0.0.5",
     "@hubspot/ui-extensions-dev-server": "0.8.16",

--- a/packages/serverless-dev-runtime/package.json
+++ b/packages/serverless-dev-runtime/package.json
@@ -6,7 +6,7 @@
   "repository": "https://github.com/HubSpot/hubspot-cli",
   "license": "Apache-2.0",
   "dependencies": {
-    "@hubspot/local-dev-lib": "1.0.1",
+    "@hubspot/local-dev-lib": "1.1.0",
     "body-parser": "^1.19.0",
     "chalk": "^4.1.0",
     "chokidar": "^3.4.3",

--- a/packages/webpack-cms-plugins/package.json
+++ b/packages/webpack-cms-plugins/package.json
@@ -17,7 +17,7 @@
     "test": "echo \"Error: run tests from root\" && exit 1"
   },
   "dependencies": {
-    "@hubspot/local-dev-lib": "1.0.1"
+    "@hubspot/local-dev-lib": "1.1.0"
   },
   "gitHead": "0659fd19cabc3645af431b177c11d0c1b089e0f8"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -475,10 +475,10 @@
     express "^4.18.2"
     uuid "^9.0.1"
 
-"@hubspot/local-dev-lib@1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@hubspot/local-dev-lib/-/local-dev-lib-1.0.1.tgz#a796e11d7b16cb445215dd403abb1090e4f906d5"
-  integrity sha512-x6DF8kXW62bdRXDINSPKmHvqNRWukbm/oOy7oxqGMY102JQLkQ1UpGziaCV9QRzLOi6HU9jQv4G2XzuGt93nag==
+"@hubspot/local-dev-lib@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@hubspot/local-dev-lib/-/local-dev-lib-1.1.0.tgz#6c6fd7cc94a2d7d74c822ea0623fb47ce94f6a27"
+  integrity sha512-vchW2L5atfBDYyiCEWVAZ15oiUwhInNIM+eQwFU5zDCQuOTAikPubwFdUCd4ydYduA8ZBpNrxiJOasRqk/9NBQ==
   dependencies:
     address "^2.0.1"
     axios "^1.3.5"


### PR DESCRIPTION
## Description and Context
See https://git.hubteam.com/HubSpot/hubspot-cli-issues/issues/523
This adds a few checks to `hs project dev` to ensure development of public apps goes smoothly. Now, the CLI will check to see if the public app is installed on the target developer test account, and prompt you to open your browser and install if it's not. This also fetches information about app installs, which sets us up to do the active install warning in a future PR (see https://git.hubteam.com/HubSpot/hubspot-cli-issues/issues/522)

## Screenshots
<img width="708" alt="Screenshot 2024-05-02 at 4 36 16 PM" src="https://github.com/HubSpot/hubspot-cli/assets/10413161/aa60da39-5804-495a-b2ba-f9b835f90399">


## TODO / Questions / Etc
* ~I'm having some trouble getting my backend to work properly on QA, so I haven't gotten all the way through the flow yet. I'm 90% sure it all works though~ Tested and works on QA!
* Right now, all this does is open the install page for the user. We don't have any way to confirm if they actually install the app, so we continue with local dev once they open the page. Is that OK for now or should there be another check of some kind?
* Need to release local-dev-lib and update dependancy

## Who to Notify
@brandenrodgers @kemmerle @joe-yeager @markhazlewood 
