### PR TITLE
Stop linking to old feedback form

### DIFF
--- a/packages/cli/commands/feedback.js
+++ b/packages/cli/commands/feedback.js
@@ -1,7 +1,7 @@
 const open = require('open');
 
 const { i18n } = require('../lib/lang');
-const { FEEDBACK_OPTIONS, FEEDBACK_URLS } = require('../lib/constants');
+const { FEEDBACK_URLS } = require('../lib/constants');
 const { logger } = require('@hubspot/local-dev-lib/logger');
 
 const {
@@ -22,10 +22,8 @@ exports.handler = async options => {
   const { shouldOpen } = await shouldOpenBrowserPrompt(type, usedTypeFlag);
 
   if (shouldOpen || usedTypeFlag) {
-    const url =
-      type === FEEDBACK_OPTIONS.BUG || bugFlag
-        ? FEEDBACK_URLS.BUG
-        : FEEDBACK_URLS.GENERAL;
+    // NOTE: for now, all feedback should go to the hubspot-cli repository
+    const url = FEEDBACK_URLS.BUG;
     open(url, { url: true });
     logger.success(i18n(`${i18nKey}.success`, { url }));
   }

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -648,7 +648,7 @@ en:
             bug:
               describe: "Open Github issues in your browser to report a bug."
             general:
-              describe: "Open the projects feedback form in your browser."
+              describe: "Open Github issues in your browser to give feedback."
     remove:
       describe: "Delete a file or folder from HubSpot."
       deleted: "Deleted \"{{ path }}\" from account {{ accountId }}"
@@ -1216,7 +1216,7 @@ en:
           bug: "[--bug] Report a bug"
           general: "[--general] Tell us about your experience with HubSpot's developer tools"
         bugPrompt: "Create an issue on Github in your browser?"
-        generalPrompt: "Open the projects feedback form in your browser?"
+        generalPrompt: "Create an issue on Github in your browser?"
       buildIdPrompt:
         enterBuildId: "[--build] Deploy which build?"
         errors:


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
`hs feedback` was linking to a feedback survey that we no longer use. We're working to get another survey up for the command to link to, but in the meantime running `hs feedback --general` will now link to this CLI repository and users can report feedback in here.

## Screenshots
<!-- Provide images of the before and after functionality -->

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
