### PR TITLE
Error on private app dev against Dev account

### DIFF
--- a/packages/cli/commands/project/dev.js
+++ b/packages/cli/commands/project/dev.js
@@ -79,8 +79,8 @@ exports.handler = async options => {
 
   const components = await findProjectComponents(projectDir);
   const componentTypes = getProjectComponentTypes(components);
-  const hasPrivateApps = componentTypes[COMPONENT_TYPES.privateApp];
-  const hasPublicApps = componentTypes[COMPONENT_TYPES.publicApp];
+  const hasPrivateApps = !!componentTypes[COMPONENT_TYPES.privateApp];
+  const hasPublicApps = !!componentTypes[COMPONENT_TYPES.publicApp];
 
   if (hasPrivateApps && hasPublicApps) {
     logger.error(i18n(`${i18nKey}.errors.invalidProjectComponents`));

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -951,7 +951,7 @@ en:
       suggestRecommendedNestedAccount:
         nonSandboxWarning: "Testing in a sandbox is strongly recommended. To switch the target account, select an option below or run {{#bold}}`hs accounts use`{{/bold}} before running the command again."
         publicAppNonDeveloperTestAccountWarning: "Local development of public apps is only supported in {{#bold}}developer test accounts{{/bold}}."
-        privateAppNonDeveloperTestAccountWarning: "Local development of private apps is only supported in {{#bold}}developer test accounts{{/bold}}"
+        privateAppInAppDeveloperAccountError: "Local development of private apps is not supported in {{#bold}}app developer accounts{{/bold}}"
       createNewProjectForLocalDev:
         projectMustExistExplanation: "The project {{ projectName }} does not exist in the target account {{ accountIdentifier}}. This command requires the project to exist in the target account."
         publicAppProjectMustExistExplanation: "The project {{ projectName }} does not exist in {{ accountIdentifier}}, the app developer account associated with your target account. This command requires the project to exist in this app developer account."

--- a/packages/cli/lib/localDev.js
+++ b/packages/cli/lib/localDev.js
@@ -114,17 +114,18 @@ const suggestRecommendedNestedAccount = async (
   logger.log();
   uiLine();
   if (hasPublicApps) {
-    logger.warn(
+    logger.log(
       i18n(
         `${i18nKey}.suggestRecommendedNestedAccount.publicAppNonDeveloperTestAccountWarning`
       )
     );
   } else if (isAppDeveloperAccount(accountConfig)) {
-    logger.warn(
+    logger.error(
       i18n(
-        `${i18nKey}.suggestRecommendedNestedAccount.publicAppNonDeveloperTestAccountWarning`
+        `${i18nKey}.suggestRecommendedNestedAccount.privateAppInAppDeveloperAccountError`
       )
     );
+    process.exit(EXIT_CODES.ERROR);
   } else {
     logger.warn(
       i18n(`${i18nKey}.suggestRecommendedNestedAccount.nonSandboxWarning`)


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
Making sure that we error and exit when the user attempts to do local dev of a private app on an App Developer Account. This isn't supported and there isn't anything useful that we can automate here. The user needs to select another account type to do local dev against in this scenario.

## Screenshots
<!-- Provide images of the before and after functionality -->

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
