### PR TITLE
Better error handling for warn log fetch

### DIFF
--- a/packages/cli/commands/project/upload.js
+++ b/packages/cli/commands/project/upload.js
@@ -93,7 +93,7 @@ exports.handler = async options => {
       uiLine();
       logFeedbackMessage(result.buildId);
 
-      displayWarnLogs(accountId, projectConfig.name, result.buildId);
+      await displayWarnLogs(accountId, projectConfig.name, result.buildId);
       process.exit(EXIT_CODES.SUCCESS);
     }
   } catch (e) {

--- a/packages/cli/lib/projects.js
+++ b/packages/cli/lib/projects.js
@@ -893,9 +893,17 @@ const displayWarnLogs = async (
   let result;
 
   if (isDeploy) {
-    result = await fetchDeployWarnLogs(accountId, projectName, taskId);
+    try {
+      result = await fetchDeployWarnLogs(accountId, projectName, taskId);
+    } catch (e) {
+      logApiErrorInstance(e);
+    }
   } else {
-    result = await fetchBuildWarnLogs(accountId, projectName, taskId);
+    try {
+      result = await fetchBuildWarnLogs(accountId, projectName, taskId);
+    } catch (e) {
+      logApiErrorInstance(e);
+    }
   }
 
   if (result && result.logs.length) {


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
Better error handling for the warn log fetches. Previously this would log out the entire axios error response object. The other half of this fix is in [local-dev-lib here](https://github.com/HubSpot/hubspot-local-dev-lib/pull/133)

## Screenshots
<!-- Provide images of the before and after functionality -->

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
