### PR TITLE
Switch account type + create project warnings to logs

### DIFF
--- a/packages/cli/lib/localDev.js
+++ b/packages/cli/lib/localDev.js
@@ -114,19 +114,19 @@ const suggestRecommendedNestedAccount = async (
   logger.log();
   uiLine();
   if (hasPublicApps) {
-    logger.warn(
+    logger.log(
       i18n(
         `${i18nKey}.suggestRecommendedNestedAccount.publicAppNonDeveloperTestAccountWarning`
       )
     );
   } else if (isAppDeveloperAccount(accountConfig)) {
-    logger.warn(
+    logger.log(
       i18n(
         `${i18nKey}.suggestRecommendedNestedAccount.publicAppNonDeveloperTestAccountWarning`
       )
     );
   } else {
-    logger.warn(
+    logger.log(
       i18n(`${i18nKey}.suggestRecommendedNestedAccount.nonSandboxWarning`)
     );
   }

--- a/packages/cli/lib/localDev.js
+++ b/packages/cli/lib/localDev.js
@@ -319,7 +319,7 @@ const createNewProjectForLocalDev = async (
     );
     logger.log();
     uiLine();
-    logger.warn(explanationString);
+    logger.log(explanationString);
     uiLine();
 
     shouldCreateProject = await confirmPrompt(


### PR DESCRIPTION
## Description and Context
Some messages were being logged to the CLI as warnings, when they should have just been standard logs. See https://git.hubteam.com/HubSpot/hubspot-cli-issues/issues/559

## Screenshots
Before (warning)
<img width="568" alt="Screenshot 2024-05-08 at 11 30 24 AM" src="https://github.com/HubSpot/hubspot-cli/assets/10413161/32fc54e8-a40e-46d4-9a13-2df94ecad6c8">

After (log)
<img width="570" alt="Screenshot 2024-05-08 at 11 30 36 AM" src="https://github.com/HubSpot/hubspot-cli/assets/10413161/7567cfd2-ba0e-4d08-83ef-0df62c4d1bd2">

## Who to Notify
@brandenrodgers @kemmerle 