### PR TITLE
Improve error messaging for failed deploys during hs project dev

### DIFF
--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -917,7 +917,7 @@ en:
       noCompatibleComponents: "Skipping call to {{ serverKey }} because there are no compatible components in the project."
     LocalDevManager:
       failedToInitialize: "Missing required arguments to initialize Local Dev"
-      noDeployedBuild: "There is no deployed build for this project in {{ accountIdentifier }}. Run {{ uploadCommand }} to upload and deploy your project."
+      noDeployedBuild: "Your project {{#bold}}{{ projectName }}{{/bold}} exists in {{ accountIdentifier }}, but has no deployed build. Projects must be successfully deployed to be developed locally. Address any build and deploy errors your project may have, then run {{ uploadCommand }} to upload and deploy your project."
       noComponents: "There are no components in this project."
       noRunnableComponents: "No supported components were found under {{#bold}}{{ projectSourceDir }}{{/bold}}. Run {{ command }} to see a list of available components."
       betaMessage: "HubSpot projects local development"

--- a/packages/cli/lib/LocalDevManager.js
+++ b/packages/cli/lib/LocalDevManager.js
@@ -142,6 +142,7 @@ class LocalDevManager {
     if (!this.deployedBuild) {
       logger.error(
         i18n(`${i18nKey}.noDeployedBuild`, {
+          projectName: this.projectConfig.name,
           accountIdentifier: uiAccountDescription(this.targetProjectAccountId),
           uploadCommand: this.getUploadCommand(),
         })

--- a/packages/cli/lib/localDev.js
+++ b/packages/cli/lib/localDev.js
@@ -417,7 +417,7 @@ const createInitialBuildForNewProject = async (
 
     logger.log();
     failedSubTasks.forEach(failedSubTask => {
-      console.error(failedSubTask.errorMessage);
+      logger.error(failedSubTask.errorMessage);
     });
     logger.log();
 


### PR DESCRIPTION
## Description and Context
If your initial project upload doesn't deploy successfully while running `hs project dev`, you'll have to fix the deploy problems and upload separately. This isn't super clear though, for a few reasons:
* Deploy errors weren't properly shown as errors within `hs project dev`
* The error message when re-running `hs project dev` isn't as helpful as it could be.

This fixes both of these things

## Screenshots
Deploy errors: before
<img width="743" alt="Screenshot 2024-05-08 at 4 58 15 PM" src="https://github.com/HubSpot/hubspot-cli/assets/10413161/701aeccb-882b-41f1-89cf-bec2b3438427">

Deploy errors: after (note: we still need to fix this multi error issue, the change in question here is the existence of `[Error]`)
<img width="743" alt="Screenshot 2024-05-08 at 4 58 06 PM" src="https://github.com/HubSpot/hubspot-cli/assets/10413161/2cb79834-464a-428f-9f86-6ffccaceaae0">

Run upload prompt: before
<img width="742" alt="Screenshot 2024-05-08 at 4 58 42 PM" src="https://github.com/HubSpot/hubspot-cli/assets/10413161/a774f2ad-e3c4-4519-abd8-4a9b5327e1b2">

Run upload prompt: after
<img width="741" alt="Screenshot 2024-05-08 at 4 42 39 PM" src="https://github.com/HubSpot/hubspot-cli/assets/10413161/a870ae24-d733-4833-989d-683358caa137">


## TODO
Get confirmation from @markhazlewood on copy

## Who to Notify
@brandenrodgers @kemmerle 
