### PR TITLE
Generic active install warning

### DIFF
--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -940,6 +940,8 @@ en:
         pushToGithub: "  * Commit and push your changes to GitHub"
       activeInstallWarning:
         installCount: "{{#bold}}The app {{ appName }} has {{ installCount }} production installs{{/bold}}"
+        genericHeader: "{{#bold}}Local development can affect existing installs of your public app.{{/bold}}"
+        genericExplanation: "Some changes made during local development may need to be synced to HubSpot, which will impact users with existing installs. You will always be asked to confirm these changes before uploading them. If your app has any production installs, we strongly recommend created a copy of this app to develop on instead."
         explanation: "Some changes made during local development may need to be synced to HubSpot, which will impact those existing installs. We strongly recommend created a copy of this app to use instead."
         confirmation: "You will always be asked to confirm any permanent changes to your app’s configuration before uploading them."
       devServer:

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -933,7 +933,7 @@ en:
         uiExtensionLabel: "[UI Extension]"
         missingComponents: "Couldn't find the following components in the deployed build for this project: {{#bold}}'{{ missingComponents }}'{{/bold}}. This may cause issues in local development."
         defaultWarning: "Changing project configuration requires a new project build."
-        defaultPublicAppWarning: "Changing project configuration requires a new project build. This will affect existing users of your public app. If your app has users in production, we strongly recommend created a copy of this app to test your changes before proceding."
+        defaultPublicAppWarning: "Changing project configuration requires a new project build. This will affect existing users of your public app. If your app has users in production, we strongly recommend creating a copy of this app to test your changes before proceding."
         header: "{{ warning }} To reflect these changes and continue testing:"
         stopDev: "  * Stop {{ command }}"
         runUpload: "  * Run {{ command }}"
@@ -942,8 +942,8 @@ en:
       activeInstallWarning:
         installCount: "{{#bold}}The app {{ appName }} has {{ installCount }} production installs{{/bold}}"
         genericHeader: "{{#bold}}Local development can affect existing installs of your public app.{{/bold}}"
-        genericExplanation: "Some changes made during local development may need to be synced to HubSpot, which will impact users with existing installs. You will always be asked to confirm these changes before uploading them. If your app has any production installs, we strongly recommend created a copy of this app to develop on instead."
-        explanation: "Some changes made during local development may need to be synced to HubSpot, which will impact those existing installs. We strongly recommend created a copy of this app to use instead."
+        genericExplanation: "Some changes made during local development may need to be synced to HubSpot, which will impact users with existing installs. You will always be asked to confirm these changes before uploading them. If your app has any production installs, we strongly recommend creating a copy of this app to develop on instead."
+        explanation: "Some changes made during local development may need to be synced to HubSpot, which will impact those existing installs. We strongly recommend creating a copy of this app to use instead."
         confirmation: "You will always be asked to confirm any permanent changes to your app’s configuration before uploading them."
       devServer:
         cleanupError: "Failed to cleanup local dev server: {{ message }}"

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -938,6 +938,10 @@ en:
         runUpload: "  * Run {{ command }}"
         restartDev: "  * Re-run {{ command }}"
         pushToGithub: "  * Commit and push your changes to GitHub"
+      activeInstallWarning:
+        installCount: "{{#bold}}The app {{ appName }} has {{ installCount }} production installs{{/bold}}"
+        explanation: "Some changes made during local development may need to be synced to HubSpot, which will impact those existing installs. We strongly recommend created a copy of this app to use instead."
+        confirmation: "You will always be asked to confirm any permanent changes to your app’s configuration before uploading them."
       devServer:
         cleanupError: "Failed to cleanup local dev server: {{ message }}"
         setupError: "Failed to setup local dev server: {{ message }}"

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -933,6 +933,7 @@ en:
         uiExtensionLabel: "[UI Extension]"
         missingComponents: "Couldn't find the following components in the deployed build for this project: {{#bold}}'{{ missingComponents }}'{{/bold}}. This may cause issues in local development."
         defaultWarning: "Changing project configuration requires a new project build."
+        defaultPublicAppWarning: "Changing project configuration requires a new project build. This will affect existing users of your public app. If your app has users in production, we strongly recommend created a copy of this app to test your changes before proceding."
         header: "{{ warning }} To reflect these changes and continue testing:"
         stopDev: "  * Stop {{ command }}"
         runUpload: "  * Run {{ command }}"

--- a/packages/cli/lib/LocalDevManager.js
+++ b/packages/cli/lib/LocalDevManager.js
@@ -136,19 +136,15 @@ class LocalDevManager {
   }
 
   async checkActivePublicAppInstalls() {
-    // Add check for installs once we have that info
+    // TODO: Add check for installs once we have that info
     if (!this.activePublicAppData) {
       return;
     }
     uiLine();
-    logger.warn(
-      i18n(`${i18nKey}.activeInstallWarning.installCount`, {
-        appName: '[APP NAME]',
-        installCount: '[COUNT]',
-      })
-    );
-    logger.warn(i18n(`${i18nKey}.activeInstallWarning.explanation`));
-    logger.warn(i18n(`${i18nKey}.activeInstallWarning.confirmation`));
+    // TODO: Replace with final copy
+
+    logger.warn(i18n(`${i18nKey}.activeInstallWarning.genericHeader`));
+    logger.warn(i18n(`${i18nKey}.activeInstallWarning.genericExplanation`));
     uiLine();
   }
 

--- a/packages/cli/lib/LocalDevManager.js
+++ b/packages/cli/lib/LocalDevManager.js
@@ -111,6 +111,7 @@ class LocalDevManager {
     if (this.activeApp.type === COMPONENT_TYPES.publicApp) {
       try {
         await this.setActivePublicAppData();
+        await this.checkActivePublicAppInstalls();
         await this.checkPublicAppInstallation();
       } catch (e) {
         logErrorInstance(e);
@@ -132,6 +133,23 @@ class LocalDevManager {
     );
 
     this.activePublicAppData = activePublicAppData;
+  }
+
+  async checkActivePublicAppInstalls() {
+    // Add check for installs once we have that info
+    if (!this.activePublicAppData) {
+      return;
+    }
+    uiLine();
+    logger.warn(
+      i18n(`${i18nKey}.activeInstallWarning.installCount`, {
+        appName: '[APP NAME]',
+        installCount: '[COUNT]',
+      })
+    );
+    logger.warn(i18n(`${i18nKey}.activeInstallWarning.explanation`));
+    logger.warn(i18n(`${i18nKey}.activeInstallWarning.confirmation`));
+    uiLine();
   }
 
   async start() {

--- a/packages/cli/lib/LocalDevManager.js
+++ b/packages/cli/lib/LocalDevManager.js
@@ -144,7 +144,7 @@ class LocalDevManager {
     // TODO: Replace with final copy
 
     logger.warn(i18n(`${i18nKey}.activeInstallWarning.genericHeader`));
-    logger.warn(i18n(`${i18nKey}.activeInstallWarning.genericExplanation`));
+    logger.log(i18n(`${i18nKey}.activeInstallWarning.genericExplanation`));
     uiLine();
   }
 
@@ -283,7 +283,13 @@ class LocalDevManager {
   }
 
   logUploadWarning(reason) {
-    const warning = reason || i18n(`${i18nKey}.uploadWarning.defaultWarning`);
+    let warning = reason;
+    if (!reason) {
+      warning =
+        this.activeApp.type === COMPONENT_TYPES.publicApp
+          ? i18n(`${i18nKey}.uploadWarning.defaultPublicAppWarning`)
+          : i18n(`${i18nKey}.uploadWarning.defaultWarning`);
+    }
 
     // Avoid logging the warning to the console if it is currently the most
     // recently logged warning. We do not want to spam the console with the same message.


### PR DESCRIPTION
## Description and Context
While we wait for the endpoint for active installs to be ready, this adds some messaging to `hs project dev` to warn users of the potential risks of developing public apps that have active users. Also includes some WIP stuff for the full version of this once the endpoint's done.

This doesn't yet include the upload prompt depicted in the mockups, or the warning on shutdown.

See https://git.hubteam.com/HubSpot/hubspot-cli-issues/issues/522

## Screenshots
Warn users when they start local dev
<img width="744" alt="Screenshot 2024-05-09 at 2 57 32 PM" src="https://github.com/HubSpot/hubspot-cli/assets/10413161/bef0cd4e-bdde-4753-97db-79a20b5987ae">

Warn users when they make changes to app config
<img width="743" alt="Screenshot 2024-05-09 at 2 57 57 PM" src="https://github.com/HubSpot/hubspot-cli/assets/10413161/4bddfad2-22ae-4567-9683-db01772c25e1">


## TODO
There's a lot more work to do here when the endpoint is done, but this should be better than nothing for now.

## Who to Notify
@brandenrodgers @kemmerle @markhazlewood
