### PR TITLE
Upgrade theme-previewer-dev-server to 0.0.6 to remove peer dep errors

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@hubspot/local-dev-lib": "1.1.0",
     "@hubspot/serverless-dev-runtime": "5.2.1-beta.4",
-    "@hubspot/theme-preview-dev-server": "0.0.5",
+    "@hubspot/theme-preview-dev-server": "0.0.6",
     "@hubspot/ui-extensions-dev-server": "0.8.17",
     "archiver": "^5.3.0",
     "chalk": "^4.1.2",


### PR DESCRIPTION
## Description and Context
See https://hubspot.slack.com/archives/C02D10AE9S5/p1715263816328849

## Who to Notify
@brandenrodgers @kemmerle 
