### PR TITLE
Fix bugs with local dev init flow

### DIFF
--- a/packages/cli/commands/project/dev.js
+++ b/packages/cli/commands/project/dev.js
@@ -178,7 +178,7 @@ exports.handler = async options => {
     targetProjectAccountId = accountId;
   }
 
-  const { projectExists, project } = await ensureProjectExists(
+  let { projectExists, project } = await ensureProjectExists(
     targetProjectAccountId,
     projectConfig.name,
     {
@@ -199,7 +199,7 @@ exports.handler = async options => {
       project.sourceIntegration &&
       project.sourceIntegration.source === 'GITHUB';
   } else {
-    await createNewProjectForLocalDev(
+    project = await createNewProjectForLocalDev(
       projectConfig,
       targetProjectAccountId,
       createNewSandbox,

--- a/packages/cli/lib/localDev.js
+++ b/packages/cli/lib/localDev.js
@@ -291,7 +291,7 @@ const useExistingDevTestAccount = async (env, account) => {
   }
   const devTestAcctConfigName = await saveDevTestAccountToConfig(env, account);
   logger.success(
-    i18n(`cli.lib.developerTestAccount.create.success.configFileUpdated`, {
+    i18n(`lib.developerTestAccount.create.success.configFileUpdated`, {
       accountName: devTestAcctConfigName,
       authType: PERSONAL_ACCESS_KEY_AUTH_METHOD.name,
     })

--- a/packages/cli/lib/localDev.js
+++ b/packages/cli/lib/localDev.js
@@ -340,7 +340,7 @@ const createNewProjectForLocalDev = async (
     });
 
     try {
-      await createProject(targetAccountId, projectConfig.name);
+      const project = await createProject(targetAccountId, projectConfig.name);
       SpinniesManager.succeed('createProject', {
         text: i18n(`${i18nKey}.createNewProjectForLocalDev.createdProject`, {
           accountIdentifier: uiAccountDescription(targetAccountId),
@@ -348,6 +348,7 @@ const createNewProjectForLocalDev = async (
         }),
         succeedColor: 'white',
       });
+      return project;
     } catch (err) {
       SpinniesManager.fail('createProject');
       logger.log(


### PR DESCRIPTION
## Description and Context
This fixes two bugs with the local dev init flow:
* Lang key error when authing a developer test account for the first time within `hs project dev`
* Bug that broke `hs project dev` for projects that didn't already exist in the target account ( see https://hubspot.slack.com/archives/C066MUYG1UH/p1715267454068059?thread_ts=1715028096.143599&cid=C066MUYG1UH)

## Who to Notify
@brandenrodgers @kemmerle
