### PR TITLE
Fix install url encoding

### DIFF
--- a/packages/cli/lib/prompts/installPublicAppPrompt.js
+++ b/packages/cli/lib/prompts/installPublicAppPrompt.js
@@ -33,8 +33,8 @@ const installPublicAppPrompt = async (
   const url =
     `${websiteOrigin}/oauth/${targetAccountId}/authorize` +
     `?client_id=${encodeURIComponent(clientId)}` +
-    `&scope=${encodeURIComponent(scopes)}` +
-    `&redirect_uri=${encodeURIComponent(redirectUrls)}`;
+    `&scope=${encodeURIComponent(scopes.join(' '))}` +
+    `&redirect_uri=${encodeURIComponent(redirectUrls[0])}`;
 
   open(url);
 };


### PR DESCRIPTION
## Description and Context
See https://hubspot.slack.com/archives/C066MUYG1UH/p1715359708440239
This fixes the encoding of scopes in install urls in `hs project dev`. Previously, install urls broke when apps required more than one score

## Questions
Is it safe to always just use the first `redirectUrl`? The `redirect_uri` param only supports one url

## Who to Notify
@brandenrodgers @kemmerle @robrown-hubspot 
