### PR TITLE
Modify CLI entrypoint to hide deprecation warnings from Node

### DIFF
--- a/packages/cli/bin/hs
+++ b/packages/cli/bin/hs
@@ -1,3 +1,3 @@
-#!/usr/bin/env node
+#!/usr/bin/env node --no-deprecation
 
 require('./cli');


### PR DESCRIPTION
## Description and Context
These are ugly for the end user, and surfacing them to the user doesn't help the deprecations get resolved.

We should have some other means of checking these deprecations, since they *do* need to be fixed. But these warnings bury build/deploy errors and make them harder to grok (in the context of projects)

## Before/after

Before:
```
λ  extensions git:(master) ✗ hs project upload
(node:75662) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
(node:75662) [DEP0044] DeprecationWarning: The `util.isArray` API is .... Please use `Array.isArray()` instead.
✖ Failed to upload two-apps-nearby-restaurants-react project files to qa (...)
[ERROR] The post in account ... was bad. The JSON in the file '/app/app.functions/serverless.json' doesn't match the associated schema. Make sure your JSON file matches the version-specific schema. Then, update the following fields and try again.
- $.runtime: is not defined in the schema and the schema does not allow additional properties
- $.version: is not defined in the schema and the schema does not allow additional properties
```

after:
```
λ  extensions git:(master) ✗ hs project upload
✖ Failed to upload two-apps-nearby-restaurants-react project files to qa (...)
[ERROR] The post in account ... was bad. The JSON in the file '/app/app.functions/serverless.json' doesn't match the associated schema. Make sure your JSON file matches the version-specific schema. Then, update the following fields and try again.
- $.runtime: is not defined in the schema and the schema does not allow additional properties
- $.version: is not defined in the schema and the schema does not allow additional properties
```

# TODO

I *think* this will also hide the deprecations when developing locally with yarn. It would be cool if local development was done via some other wrapper that doesn't have this flag enabled. I don't know exactly the best practices here for development.

Related stack overflow https://stackoverflow.com/questions/58672947/disable-deprecation-in-javascript-console

## Who to Notify
<!-- /cc those you wish to know about the PR -->
