### PR TITLE
Bump local-dev-lib dep to 1.2.0

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/HubSpot/hubspot-cms-tools"
   },
   "dependencies": {
-    "@hubspot/local-dev-lib": "1.1.0",
+    "@hubspot/local-dev-lib": "1.2.0",
     "@hubspot/serverless-dev-runtime": "5.2.1-beta.4",
     "@hubspot/theme-preview-dev-server": "0.0.6",
     "@hubspot/ui-extensions-dev-server": "0.8.19",

--- a/packages/serverless-dev-runtime/package.json
+++ b/packages/serverless-dev-runtime/package.json
@@ -6,7 +6,7 @@
   "repository": "https://github.com/HubSpot/hubspot-cli",
   "license": "Apache-2.0",
   "dependencies": {
-    "@hubspot/local-dev-lib": "1.1.0",
+    "@hubspot/local-dev-lib": "1.2.0",
     "body-parser": "^1.19.0",
     "chalk": "^4.1.0",
     "chokidar": "^3.4.3",

--- a/packages/webpack-cms-plugins/package.json
+++ b/packages/webpack-cms-plugins/package.json
@@ -17,7 +17,7 @@
     "test": "echo \"Error: run tests from root\" && exit 1"
   },
   "dependencies": {
-    "@hubspot/local-dev-lib": "1.1.0"
+    "@hubspot/local-dev-lib": "1.2.0"
   },
   "gitHead": "0659fd19cabc3645af431b177c11d0c1b089e0f8"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -475,10 +475,10 @@
     express "^4.18.2"
     uuid "^9.0.1"
 
-"@hubspot/local-dev-lib@1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@hubspot/local-dev-lib/-/local-dev-lib-1.1.0.tgz#6c6fd7cc94a2d7d74c822ea0623fb47ce94f6a27"
-  integrity sha512-vchW2L5atfBDYyiCEWVAZ15oiUwhInNIM+eQwFU5zDCQuOTAikPubwFdUCd4ydYduA8ZBpNrxiJOasRqk/9NBQ==
+"@hubspot/local-dev-lib@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@hubspot/local-dev-lib/-/local-dev-lib-1.2.0.tgz#69cee0d9871e4400524258ddf514ef6b4db73934"
+  integrity sha512-fWVguzfEcHhEPRYRC1HK+3kPk+ONPtXQi6qqzjjg08hUOWGxDvPZI01+TLGDkAwpx9S9SbXtxRwcFP9AsAjtEQ==
   dependencies:
     address "^2.0.1"
     axios "^1.3.5"


### PR DESCRIPTION
## Description and Context
This bumps the dependency for `local-dev-lib` to `v1.2.0`.

## Who to Notify
@brandenrodgers @kemmerle 
