### PR TITLE
fix: Remove incorrect log message for `hs watch --initial-upload`

### DIFF
--- a/packages/cli/commands/watch.js
+++ b/packages/cli/commands/watch.js
@@ -77,9 +77,8 @@ exports.handler = async options => {
   if (disableInitial) {
     logger.info(i18n(`${i18nKey}.warnings.disableInitial`));
   } else {
-    logger.info(i18n(`${i18nKey}.warnings.notUploaded`, { path: src }));
-
     if (!initialUpload) {
+      logger.info(i18n(`${i18nKey}.warnings.notUploaded`, { path: src }));
       logger.info(i18n(`${i18nKey}.warnings.initialUpload`));
     }
   }

--- a/packages/cli/commands/watch.js
+++ b/packages/cli/commands/watch.js
@@ -76,11 +76,9 @@ exports.handler = async options => {
 
   if (disableInitial) {
     logger.info(i18n(`${i18nKey}.warnings.disableInitial`));
-  } else {
-    if (!initialUpload) {
-      logger.info(i18n(`${i18nKey}.warnings.notUploaded`, { path: src }));
-      logger.info(i18n(`${i18nKey}.warnings.initialUpload`));
-    }
+  } else if (!initialUpload) {
+    logger.info(i18n(`${i18nKey}.warnings.notUploaded`, { path: src }));
+    logger.info(i18n(`${i18nKey}.warnings.initialUpload`));
   }
 
   if (initialUpload) {


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
- Remove the log stating `The "hs watch" command no longer uploads the watched directory when started. The directory "{{ path }}" was not uploaded.` when `--initial-upload` flag is provided.

## Screenshots
<!-- Provide images of the before and after functionality -->

### Before
![Screenshot 2024-05-20 at 10 23 08 AM](https://github.com/HubSpot/hubspot-cli/assets/4262172/ae9c6e57-9e98-4003-bc36-c233c8a2ffc7)


### After

#### With `--initial-upload`
![Screenshot 2024-05-20 at 10 24 00 AM](https://github.com/HubSpot/hubspot-cli/assets/4262172/1bab5291-887a-4645-95da-e39b17b61a0d)


#### Without `--initial-upload`


![Screenshot 2024-05-20 at 10 29 22 AM](https://github.com/HubSpot/hubspot-cli/assets/4262172/f0a2cc4f-415d-4bf2-a050-329532512fbe)
