### PR TITLE
chore: Remove unused boolean args passed to options methods.

### DIFF
--- a/packages/cli/commands/accounts.js
+++ b/packages/cli/commands/accounts.js
@@ -13,8 +13,8 @@ exports.command = 'accounts';
 exports.describe = i18n(`${i18nKey}.describe`);
 
 exports.builder = yargs => {
-  addConfigOptions(yargs, true);
-  addAccountOptions(yargs, true);
+  addConfigOptions(yargs);
+  addAccountOptions(yargs);
 
   yargs
     .command({

--- a/packages/cli/commands/accounts/clean.js
+++ b/packages/cli/commands/accounts/clean.js
@@ -127,10 +127,10 @@ exports.handler = async options => {
 };
 
 exports.builder = yargs => {
-  addConfigOptions(yargs, true);
-  addAccountOptions(yargs, true);
-  addUseEnvironmentOptions(yargs, true);
-  addTestingOptions(yargs, true);
+  addConfigOptions(yargs);
+  addAccountOptions(yargs);
+  addUseEnvironmentOptions(yargs);
+  addTestingOptions(yargs);
 
   yargs.example([['$0 accounts clean']]);
 

--- a/packages/cli/commands/accounts/info.js
+++ b/packages/cli/commands/accounts/info.js
@@ -39,8 +39,8 @@ exports.handler = async options => {
 };
 
 exports.builder = yargs => {
-  addConfigOptions(yargs, true);
-  addAccountOptions(yargs, true);
+  addConfigOptions(yargs);
+  addAccountOptions(yargs);
 
   yargs.example([
     ['$0 accounts info', i18n(`${i18nKey}.examples.default`)],

--- a/packages/cli/commands/accounts/list.js
+++ b/packages/cli/commands/accounts/list.js
@@ -104,8 +104,8 @@ exports.handler = async options => {
 };
 
 exports.builder = yargs => {
-  addConfigOptions(yargs, true);
-  addAccountOptions(yargs, true);
+  addConfigOptions(yargs);
+  addAccountOptions(yargs);
 
   yargs.example([['$0 accounts list']]);
 

--- a/packages/cli/commands/accounts/rename.js
+++ b/packages/cli/commands/accounts/rename.js
@@ -34,8 +34,8 @@ exports.handler = async options => {
 };
 
 exports.builder = yargs => {
-  addConfigOptions(yargs, true);
-  addAccountOptions(yargs, true);
+  addConfigOptions(yargs);
+  addAccountOptions(yargs);
 
   yargs.positional('accountName', {
     describe: i18n(`${i18nKey}.positionals.accountName.describe`),

--- a/packages/cli/commands/auth.js
+++ b/packages/cli/commands/auth.js
@@ -218,8 +218,8 @@ exports.builder = yargs => {
     },
   });
 
-  addConfigOptions(yargs, true);
-  addTestingOptions(yargs, true);
+  addConfigOptions(yargs);
+  addTestingOptions(yargs);
 
   return yargs;
 };

--- a/packages/cli/commands/cms.js
+++ b/packages/cli/commands/cms.js
@@ -10,8 +10,8 @@ exports.command = 'cms';
 exports.describe = i18n(`${i18nKey}.describe`);
 
 exports.builder = yargs => {
-  addConfigOptions(yargs, true);
-  addAccountOptions(yargs, true);
+  addConfigOptions(yargs);
+  addAccountOptions(yargs);
 
   yargs
     .command(lighthouseScore)

--- a/packages/cli/commands/cms/lighthouseScore.js
+++ b/packages/cli/commands/cms/lighthouseScore.js
@@ -310,9 +310,9 @@ exports.builder = yargs => {
     ],
   ]);
 
-  addConfigOptions(yargs, true);
-  addAccountOptions(yargs, true);
-  addUseEnvironmentOptions(yargs, true);
+  addConfigOptions(yargs);
+  addAccountOptions(yargs);
+  addUseEnvironmentOptions(yargs);
 
   return yargs;
 };

--- a/packages/cli/commands/config.js
+++ b/packages/cli/commands/config.js
@@ -8,8 +8,8 @@ exports.command = 'config';
 exports.describe = i18n(`${i18nKey}.describe`);
 
 exports.builder = yargs => {
-  addConfigOptions(yargs, true);
-  addAccountOptions(yargs, true);
+  addConfigOptions(yargs);
+  addAccountOptions(yargs);
 
   yargs.command(set).demandCommand(1, '');
 

--- a/packages/cli/commands/customObject.js
+++ b/packages/cli/commands/customObject.js
@@ -22,8 +22,8 @@ const logBetaMessage = () => {
 };
 
 exports.builder = yargs => {
-  addConfigOptions(yargs, true);
-  addAccountOptions(yargs, true);
+  addConfigOptions(yargs);
+  addAccountOptions(yargs);
 
   yargs
     .middleware([logBetaMessage])

--- a/packages/cli/commands/customObject/schema/create.js
+++ b/packages/cli/commands/customObject/schema/create.js
@@ -74,7 +74,7 @@ exports.handler = async options => {
 };
 
 exports.builder = yargs => {
-  addTestingOptions(yargs, true);
+  addTestingOptions(yargs);
 
   yargs.positional('definition', {
     describe: i18n(`${i18nKey}.positionals.definition.describe`),

--- a/packages/cli/commands/customObject/schema/update.js
+++ b/packages/cli/commands/customObject/schema/update.js
@@ -74,7 +74,7 @@ exports.handler = async options => {
 };
 
 exports.builder = yargs => {
-  addTestingOptions(yargs, true);
+  addTestingOptions(yargs);
 
   yargs.positional('name', {
     describe: i18n(`${i18nKey}.positionals.name.describe`),

--- a/packages/cli/commands/fetch.js
+++ b/packages/cli/commands/fetch.js
@@ -56,11 +56,11 @@ exports.handler = async options => {
 };
 
 exports.builder = yargs => {
-  addConfigOptions(yargs, true);
-  addAccountOptions(yargs, true);
-  addOverwriteOptions(yargs, true);
-  addModeOptions(yargs, { read: true }, true);
-  addUseEnvironmentOptions(yargs, true);
+  addConfigOptions(yargs);
+  addAccountOptions(yargs);
+  addOverwriteOptions(yargs);
+  addModeOptions(yargs, { read: true });
+  addUseEnvironmentOptions(yargs);
 
   yargs.positional('src', {
     describe: i18n(`${i18nKey}.positionals.src.describe`),

--- a/packages/cli/commands/filemanager.js
+++ b/packages/cli/commands/filemanager.js
@@ -13,9 +13,9 @@ exports.command = 'filemanager';
 exports.describe = i18n(`${i18nKey}.describe`);
 
 exports.builder = yargs => {
-  addOverwriteOptions(yargs, true);
-  addConfigOptions(yargs, true);
-  addAccountOptions(yargs, true);
+  addOverwriteOptions(yargs);
+  addConfigOptions(yargs);
+  addAccountOptions(yargs);
 
   yargs
     .command(upload)

--- a/packages/cli/commands/filemanager/fetch.js
+++ b/packages/cli/commands/filemanager/fetch.js
@@ -50,9 +50,9 @@ exports.handler = async options => {
 };
 
 exports.builder = yargs => {
-  addConfigOptions(yargs, true);
-  addAccountOptions(yargs, true);
-  addUseEnvironmentOptions(yargs, true);
+  addConfigOptions(yargs);
+  addAccountOptions(yargs);
+  addUseEnvironmentOptions(yargs);
 
   yargs.positional('src', {
     describe: i18n(`${i18nKey}.positionals.src.describe`),

--- a/packages/cli/commands/filemanager/upload.js
+++ b/packages/cli/commands/filemanager/upload.js
@@ -141,9 +141,9 @@ exports.handler = async options => {
 };
 
 exports.builder = yargs => {
-  addConfigOptions(yargs, true);
-  addAccountOptions(yargs, true);
-  addUseEnvironmentOptions(yargs, true);
+  addConfigOptions(yargs);
+  addAccountOptions(yargs);
+  addUseEnvironmentOptions(yargs);
 
   yargs.positional('src', {
     describe: i18n(`${i18nKey}.positionals.src.describe`),

--- a/packages/cli/commands/functions.js
+++ b/packages/cli/commands/functions.js
@@ -10,8 +10,8 @@ exports.command = 'functions';
 exports.describe = i18n(`${i18nKey}.describe`);
 
 exports.builder = yargs => {
-  addConfigOptions(yargs, true);
-  addAccountOptions(yargs, true);
+  addConfigOptions(yargs);
+  addAccountOptions(yargs);
 
   yargs
     .command({

--- a/packages/cli/commands/functions/deploy.js
+++ b/packages/cli/commands/functions/deploy.js
@@ -112,9 +112,9 @@ exports.builder = yargs => {
     ],
   ]);
 
-  addConfigOptions(yargs, true);
-  addAccountOptions(yargs, true);
-  addUseEnvironmentOptions(yargs, true);
+  addConfigOptions(yargs);
+  addAccountOptions(yargs);
+  addUseEnvironmentOptions(yargs);
 
   return yargs;
 };

--- a/packages/cli/commands/functions/list.js
+++ b/packages/cli/commands/functions/list.js
@@ -52,9 +52,9 @@ exports.handler = async options => {
 };
 
 exports.builder = yargs => {
-  addConfigOptions(yargs, true);
-  addAccountOptions(yargs, true);
-  addUseEnvironmentOptions(yargs, true);
+  addConfigOptions(yargs);
+  addAccountOptions(yargs);
+  addUseEnvironmentOptions(yargs);
 
   yargs.options({
     json: {

--- a/packages/cli/commands/functions/server.js
+++ b/packages/cli/commands/functions/server.js
@@ -68,9 +68,9 @@ exports.builder = yargs => {
     ],
   ]);
 
-  addConfigOptions(yargs, true);
-  addAccountOptions(yargs, true);
-  addUseEnvironmentOptions(yargs, true);
+  addConfigOptions(yargs);
+  addAccountOptions(yargs);
+  addUseEnvironmentOptions(yargs);
 
   return yargs;
 };

--- a/packages/cli/commands/hubdb.js
+++ b/packages/cli/commands/hubdb.js
@@ -11,8 +11,8 @@ exports.command = 'hubdb';
 exports.describe = i18n(`${i18nKey}.describe`);
 
 exports.builder = yargs => {
-  addConfigOptions(yargs, true);
-  addAccountOptions(yargs, true);
+  addConfigOptions(yargs);
+  addAccountOptions(yargs);
 
   yargs
     .command(clearCommand)

--- a/packages/cli/commands/hubdb/clear.js
+++ b/packages/cli/commands/hubdb/clear.js
@@ -57,9 +57,9 @@ exports.handler = async options => {
 };
 
 exports.builder = yargs => {
-  addAccountOptions(yargs, true);
-  addConfigOptions(yargs, true);
-  addUseEnvironmentOptions(yargs, true);
+  addAccountOptions(yargs);
+  addConfigOptions(yargs);
+  addUseEnvironmentOptions(yargs);
 
   yargs.positional('tableId', {
     describe: i18n(`${i18nKey}.positionals.tableId.describe`),

--- a/packages/cli/commands/hubdb/create.js
+++ b/packages/cli/commands/hubdb/create.js
@@ -61,9 +61,9 @@ exports.handler = async options => {
 };
 
 exports.builder = yargs => {
-  addAccountOptions(yargs, true);
-  addConfigOptions(yargs, true);
-  addUseEnvironmentOptions(yargs, true);
+  addAccountOptions(yargs);
+  addConfigOptions(yargs);
+  addUseEnvironmentOptions(yargs);
 
   yargs.positional('src', {
     describe: i18n(`${i18nKey}.positionals.src.describe`),

--- a/packages/cli/commands/hubdb/delete.js
+++ b/packages/cli/commands/hubdb/delete.js
@@ -45,9 +45,9 @@ exports.handler = async options => {
 };
 
 exports.builder = yargs => {
-  addAccountOptions(yargs, true);
-  addConfigOptions(yargs, true);
-  addUseEnvironmentOptions(yargs, true);
+  addAccountOptions(yargs);
+  addConfigOptions(yargs);
+  addUseEnvironmentOptions(yargs);
 
   yargs.positional('tableId', {
     describe: i18n(`${i18nKey}.positionals.tableId.describe`),

--- a/packages/cli/commands/hubdb/fetch.js
+++ b/packages/cli/commands/hubdb/fetch.js
@@ -42,9 +42,9 @@ exports.handler = async options => {
 };
 
 exports.builder = yargs => {
-  addAccountOptions(yargs, true);
-  addConfigOptions(yargs, true);
-  addUseEnvironmentOptions(yargs, true);
+  addAccountOptions(yargs);
+  addConfigOptions(yargs);
+  addUseEnvironmentOptions(yargs);
 
   yargs.positional('tableId', {
     describe: i18n(`${i18nKey}.positionals.tableId.describe`),

--- a/packages/cli/commands/init.js
+++ b/packages/cli/commands/init.js
@@ -193,8 +193,8 @@ exports.builder = yargs => {
     },
   });
 
-  addConfigOptions(yargs, true);
-  addTestingOptions(yargs, true);
+  addConfigOptions(yargs);
+  addTestingOptions(yargs);
 
   return yargs;
 };

--- a/packages/cli/commands/lint.js
+++ b/packages/cli/commands/lint.js
@@ -53,8 +53,8 @@ exports.handler = async options => {
 };
 
 exports.builder = yargs => {
-  addConfigOptions(yargs, true);
-  addAccountOptions(yargs, true);
+  addConfigOptions(yargs);
+  addAccountOptions(yargs);
   yargs.positional('path', {
     describe: i18n(`${i18nKey}.positionals.path.describe`),
     type: 'string',

--- a/packages/cli/commands/list.js
+++ b/packages/cli/commands/list.js
@@ -87,9 +87,9 @@ exports.builder = yargs => {
   });
   yargs.example([['$0 list'], ['$0 list /'], ['$0 list serverless']]);
 
-  addConfigOptions(yargs, true);
-  addAccountOptions(yargs, true);
-  addUseEnvironmentOptions(yargs, true);
+  addConfigOptions(yargs);
+  addAccountOptions(yargs);
+  addUseEnvironmentOptions(yargs);
 
   return yargs;
 };

--- a/packages/cli/commands/logs.js
+++ b/packages/cli/commands/logs.js
@@ -131,9 +131,9 @@ exports.builder = yargs => {
     ['$0 logs my-endpoint --follow', i18n(`${i18nKey}.examples.follow`)],
   ]);
 
-  addConfigOptions(yargs, true);
-  addAccountOptions(yargs, true);
-  addUseEnvironmentOptions(yargs, true);
+  addConfigOptions(yargs);
+  addAccountOptions(yargs);
+  addUseEnvironmentOptions(yargs);
 
   return yargs;
 };

--- a/packages/cli/commands/module.js
+++ b/packages/cli/commands/module.js
@@ -8,8 +8,8 @@ exports.command = 'module';
 exports.describe = false; //i18n(`${i18nKey}.describe`);
 
 exports.builder = yargs => {
-  addConfigOptions(yargs, true);
-  addAccountOptions(yargs, true);
+  addConfigOptions(yargs);
+  addAccountOptions(yargs);
 
   yargs.command(marketplaceValidate).demandCommand(1, '');
 

--- a/packages/cli/commands/module/marketplace-validate.js
+++ b/packages/cli/commands/module/marketplace-validate.js
@@ -55,9 +55,9 @@ exports.handler = async options => {
 };
 
 exports.builder = yargs => {
-  addConfigOptions(yargs, true);
-  addAccountOptions(yargs, true);
-  addUseEnvironmentOptions(yargs, true);
+  addConfigOptions(yargs);
+  addAccountOptions(yargs);
+  addUseEnvironmentOptions(yargs);
 
   yargs.positional('src', {
     describe: i18n(`${i18nKey}.positionals.src.describe`),

--- a/packages/cli/commands/mv.js
+++ b/packages/cli/commands/mv.js
@@ -77,9 +77,9 @@ exports.handler = async options => {
 };
 
 exports.builder = yargs => {
-  addConfigOptions(yargs, true);
-  addAccountOptions(yargs, true);
-  addUseEnvironmentOptions(yargs, true);
+  addConfigOptions(yargs);
+  addAccountOptions(yargs);
+  addUseEnvironmentOptions(yargs);
   yargs.positional('srcPath', {
     describe: 'Remote hubspot path',
     type: 'string',

--- a/packages/cli/commands/open.js
+++ b/packages/cli/commands/open.js
@@ -67,9 +67,9 @@ exports.builder = yargs => {
     ['$0 open sn'],
   ]);
 
-  addConfigOptions(yargs, true);
-  addAccountOptions(yargs, true);
-  addUseEnvironmentOptions(yargs, true);
+  addConfigOptions(yargs);
+  addAccountOptions(yargs);
+  addUseEnvironmentOptions(yargs);
 
   return yargs;
 };

--- a/packages/cli/commands/project.js
+++ b/packages/cli/commands/project.js
@@ -19,8 +19,8 @@ exports.command = 'project';
 exports.describe = uiBetaTag(i18n(`${i18nKey}.describe`), false);
 
 exports.builder = yargs => {
-  addConfigOptions(yargs, true);
-  addAccountOptions(yargs, true);
+  addConfigOptions(yargs);
+  addAccountOptions(yargs);
 
   // TODO: deploy must be updated
   yargs.command(create).demandCommand(0, '');

--- a/packages/cli/commands/project/create.js
+++ b/packages/cli/commands/project/create.js
@@ -93,9 +93,9 @@ exports.builder = yargs => {
 
   yargs.example([['$0 project create', i18n(`${i18nKey}.examples.default`)]]);
 
-  addConfigOptions(yargs, true);
-  addAccountOptions(yargs, true);
-  addUseEnvironmentOptions(yargs, true);
+  addConfigOptions(yargs);
+  addAccountOptions(yargs);
+  addUseEnvironmentOptions(yargs);
 
   return yargs;
 };

--- a/packages/cli/commands/project/deploy.js
+++ b/packages/cli/commands/project/deploy.js
@@ -142,9 +142,9 @@ exports.builder = yargs => {
     ],
   ]);
 
-  addConfigOptions(yargs, true);
-  addAccountOptions(yargs, true);
-  addUseEnvironmentOptions(yargs, true);
+  addConfigOptions(yargs);
+  addAccountOptions(yargs);
+  addUseEnvironmentOptions(yargs);
 
   return yargs;
 };

--- a/packages/cli/commands/project/dev.js
+++ b/packages/cli/commands/project/dev.js
@@ -232,10 +232,10 @@ exports.handler = async options => {
 };
 
 exports.builder = yargs => {
-  addConfigOptions(yargs, true);
-  addAccountOptions(yargs, true);
-  addUseEnvironmentOptions(yargs, true);
-  addTestingOptions(yargs, true);
+  addConfigOptions(yargs);
+  addAccountOptions(yargs);
+  addUseEnvironmentOptions(yargs);
+  addTestingOptions(yargs);
 
   yargs.example([['$0 project dev', i18n(`${i18nKey}.examples.default`)]]);
 

--- a/packages/cli/commands/project/download.js
+++ b/packages/cli/commands/project/download.js
@@ -114,7 +114,7 @@ exports.handler = async options => {
 };
 
 exports.builder = yargs => {
-  addUseEnvironmentOptions(yargs, true);
+  addUseEnvironmentOptions(yargs);
 
   yargs.options({
     project: {

--- a/packages/cli/commands/project/listBuilds.js
+++ b/packages/cli/commands/project/listBuilds.js
@@ -155,9 +155,9 @@ exports.builder = yargs => {
     ],
   ]);
 
-  addConfigOptions(yargs, true);
-  addAccountOptions(yargs, true);
-  addUseEnvironmentOptions(yargs, true);
+  addConfigOptions(yargs);
+  addAccountOptions(yargs);
+  addUseEnvironmentOptions(yargs);
 
   return yargs;
 };

--- a/packages/cli/commands/project/logs.js
+++ b/packages/cli/commands/project/logs.js
@@ -308,9 +308,9 @@ exports.builder = yargs => {
     ],
   ]);
 
-  addConfigOptions(yargs, true);
-  addAccountOptions(yargs, true);
-  addUseEnvironmentOptions(yargs, true);
+  addConfigOptions(yargs);
+  addAccountOptions(yargs);
+  addUseEnvironmentOptions(yargs);
 
   return yargs;
 };

--- a/packages/cli/commands/project/migrateApp.js
+++ b/packages/cli/commands/project/migrateApp.js
@@ -198,9 +198,9 @@ exports.builder = yargs => {
     ['$0 project migrate-app', i18n(`${i18nKey}.examples.default`)],
   ]);
 
-  addConfigOptions(yargs, true);
-  addAccountOptions(yargs, true);
-  addUseEnvironmentOptions(yargs, true);
+  addConfigOptions(yargs);
+  addAccountOptions(yargs);
+  addUseEnvironmentOptions(yargs);
 
   return yargs;
 };

--- a/packages/cli/commands/project/open.js
+++ b/packages/cli/commands/project/open.js
@@ -66,10 +66,10 @@ exports.handler = async options => {
 };
 
 exports.builder = yargs => {
-  addConfigOptions(yargs, true);
-  addAccountOptions(yargs, true);
-  addUseEnvironmentOptions(yargs, true);
-  addTestingOptions(yargs, true);
+  addConfigOptions(yargs);
+  addAccountOptions(yargs);
+  addUseEnvironmentOptions(yargs);
+  addTestingOptions(yargs);
 
   yargs.options({
     project: {

--- a/packages/cli/commands/project/upload.js
+++ b/packages/cli/commands/project/upload.js
@@ -126,9 +126,9 @@ exports.builder = yargs => {
     ['$0 project upload myProjectFolder', i18n(`${i18nKey}.examples.default`)],
   ]);
 
-  addConfigOptions(yargs, true);
-  addAccountOptions(yargs, true);
-  addUseEnvironmentOptions(yargs, true);
+  addConfigOptions(yargs);
+  addAccountOptions(yargs);
+  addUseEnvironmentOptions(yargs);
 
   return yargs;
 };

--- a/packages/cli/commands/project/watch.js
+++ b/packages/cli/commands/project/watch.js
@@ -179,9 +179,9 @@ exports.builder = yargs => {
     ['$0 project watch myProjectFolder', i18n(`${i18nKey}.examples.default`)],
   ]);
 
-  addConfigOptions(yargs, true);
-  addAccountOptions(yargs, true);
-  addUseEnvironmentOptions(yargs, true);
+  addConfigOptions(yargs);
+  addAccountOptions(yargs);
+  addUseEnvironmentOptions(yargs);
 
   return yargs;
 };

--- a/packages/cli/commands/remove.js
+++ b/packages/cli/commands/remove.js
@@ -47,9 +47,9 @@ exports.handler = async options => {
 };
 
 exports.builder = yargs => {
-  addConfigOptions(yargs, true);
-  addAccountOptions(yargs, true);
-  addUseEnvironmentOptions(yargs, true);
+  addConfigOptions(yargs);
+  addAccountOptions(yargs);
+  addUseEnvironmentOptions(yargs);
   yargs.positional('path', {
     describe: i18n(`${i18nKey}.positionals.path.describe`),
     type: 'string',

--- a/packages/cli/commands/sandbox.js
+++ b/packages/cli/commands/sandbox.js
@@ -10,8 +10,8 @@ exports.command = 'sandbox';
 exports.describe = i18n(`${i18nKey}.describe`);
 
 exports.builder = yargs => {
-  addConfigOptions(yargs, true);
-  addAccountOptions(yargs, true);
+  addConfigOptions(yargs);
+  addAccountOptions(yargs);
 
   yargs
     .command(create)

--- a/packages/cli/commands/sandbox/create.js
+++ b/packages/cli/commands/sandbox/create.js
@@ -238,10 +238,10 @@ exports.builder = yargs => {
     ],
   ]);
 
-  addConfigOptions(yargs, true);
-  addAccountOptions(yargs, true);
-  addUseEnvironmentOptions(yargs, true);
-  addTestingOptions(yargs, true);
+  addConfigOptions(yargs);
+  addAccountOptions(yargs);
+  addUseEnvironmentOptions(yargs);
+  addTestingOptions(yargs);
 
   return yargs;
 };

--- a/packages/cli/commands/sandbox/delete.js
+++ b/packages/cli/commands/sandbox/delete.js
@@ -242,10 +242,10 @@ exports.builder = yargs => {
     ],
   ]);
 
-  addConfigOptions(yargs, true);
-  addAccountOptions(yargs, true);
-  addUseEnvironmentOptions(yargs, true);
-  addTestingOptions(yargs, true);
+  addConfigOptions(yargs);
+  addAccountOptions(yargs);
+  addUseEnvironmentOptions(yargs);
+  addTestingOptions(yargs);
 
   return yargs;
 };

--- a/packages/cli/commands/sandbox/sync.js
+++ b/packages/cli/commands/sandbox/sync.js
@@ -206,10 +206,10 @@ exports.builder = yargs => {
 
   yargs.example([['$0 sandbox sync', i18n(`${i18nKey}.examples.default`)]]);
 
-  addConfigOptions(yargs, true);
-  addAccountOptions(yargs, true);
-  addUseEnvironmentOptions(yargs, true);
-  addTestingOptions(yargs, true);
+  addConfigOptions(yargs);
+  addAccountOptions(yargs);
+  addUseEnvironmentOptions(yargs);
+  addTestingOptions(yargs);
 
   return yargs;
 };

--- a/packages/cli/commands/secrets.js
+++ b/packages/cli/commands/secrets.js
@@ -12,8 +12,8 @@ exports.command = 'secrets';
 exports.describe = i18n(`${i18nKey}.describe`);
 
 exports.builder = yargs => {
-  addConfigOptions(yargs, true);
-  addAccountOptions(yargs, true);
+  addConfigOptions(yargs);
+  addAccountOptions(yargs);
   yargs
     .command(listSecretsCommand)
     .command(addSecretCommand)

--- a/packages/cli/commands/secrets/addSecret.js
+++ b/packages/cli/commands/secrets/addSecret.js
@@ -58,9 +58,9 @@ exports.handler = async options => {
 };
 
 exports.builder = yargs => {
-  addConfigOptions(yargs, true);
-  addAccountOptions(yargs, true);
-  addUseEnvironmentOptions(yargs, true);
+  addConfigOptions(yargs);
+  addAccountOptions(yargs);
+  addUseEnvironmentOptions(yargs);
   yargs.positional('name', {
     describe: i18n(`${i18nKey}.positionals.name.describe`),
     type: 'string',

--- a/packages/cli/commands/secrets/deleteSecret.js
+++ b/packages/cli/commands/secrets/deleteSecret.js
@@ -55,9 +55,9 @@ exports.handler = async options => {
 };
 
 exports.builder = yargs => {
-  addConfigOptions(yargs, true);
-  addAccountOptions(yargs, true);
-  addUseEnvironmentOptions(yargs, true);
+  addConfigOptions(yargs);
+  addAccountOptions(yargs);
+  addUseEnvironmentOptions(yargs);
   yargs.positional('name', {
     describe: i18n(`${i18nKey}.positionals.name.describe`),
     type: 'string',

--- a/packages/cli/commands/secrets/listSecrets.js
+++ b/packages/cli/commands/secrets/listSecrets.js
@@ -49,8 +49,8 @@ exports.handler = async options => {
 };
 
 exports.builder = yargs => {
-  addConfigOptions(yargs, true);
-  addAccountOptions(yargs, true);
-  addUseEnvironmentOptions(yargs, true);
+  addConfigOptions(yargs);
+  addAccountOptions(yargs);
+  addUseEnvironmentOptions(yargs);
   return yargs;
 };

--- a/packages/cli/commands/secrets/updateSecret.js
+++ b/packages/cli/commands/secrets/updateSecret.js
@@ -59,9 +59,9 @@ exports.handler = async options => {
 };
 
 exports.builder = yargs => {
-  addConfigOptions(yargs, true);
-  addAccountOptions(yargs, true);
-  addUseEnvironmentOptions(yargs, true);
+  addConfigOptions(yargs);
+  addAccountOptions(yargs);
+  addUseEnvironmentOptions(yargs);
   yargs.positional('name', {
     describe: i18n(`${i18nKey}.positionals.name.describe`),
     type: 'string',

--- a/packages/cli/commands/theme/marketplace-validate.js
+++ b/packages/cli/commands/theme/marketplace-validate.js
@@ -55,9 +55,9 @@ exports.handler = async options => {
 };
 
 exports.builder = yargs => {
-  addConfigOptions(yargs, true);
-  addAccountOptions(yargs, true);
-  addUseEnvironmentOptions(yargs, true);
+  addConfigOptions(yargs);
+  addAccountOptions(yargs);
+  addUseEnvironmentOptions(yargs);
 
   yargs.positional('src', {
     describe: i18n(`${i18nKey}.positionals.src.describe`),

--- a/packages/cli/commands/theme/preview.js
+++ b/packages/cli/commands/theme/preview.js
@@ -188,8 +188,8 @@ exports.handler = async options => {
 };
 
 exports.builder = yargs => {
-  addConfigOptions(yargs, true);
-  addAccountOptions(yargs, true);
+  addConfigOptions(yargs);
+  addAccountOptions(yargs);
 
   yargs.option('src', {
     describe: i18n(`${i18nKey}.options.src.describe`),

--- a/packages/cli/commands/upload.js
+++ b/packages/cli/commands/upload.js
@@ -279,10 +279,10 @@ exports.handler = async options => {
 };
 
 exports.builder = yargs => {
-  addConfigOptions(yargs, true);
-  addAccountOptions(yargs, true);
-  addModeOptions(yargs, { write: true }, true);
-  addUseEnvironmentOptions(yargs, true);
+  addConfigOptions(yargs);
+  addAccountOptions(yargs);
+  addModeOptions(yargs, { write: true });
+  addUseEnvironmentOptions(yargs);
 
   yargs.positional('src', {
     describe: i18n(`${i18nKey}.positionals.src.describe`),

--- a/packages/cli/commands/watch.js
+++ b/packages/cli/commands/watch.js
@@ -144,10 +144,10 @@ exports.handler = async options => {
 };
 
 exports.builder = yargs => {
-  addConfigOptions(yargs, true);
-  addAccountOptions(yargs, true);
-  addModeOptions(yargs, { write: true }, true);
-  addUseEnvironmentOptions(yargs, true);
+  addConfigOptions(yargs);
+  addAccountOptions(yargs);
+  addModeOptions(yargs, { write: true });
+  addUseEnvironmentOptions(yargs);
 
   yargs.positional('src', {
     describe: i18n(`${i18nKey}.positionals.src.describe`),


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->

When the migration to `yargs` occurred, some methods had a last argument left behind, and the methods no longer require them.

- Remove the last boolean argument from the invocations of the following methods:
   - [`addAccountOptions`](https://github.com/HubSpot/hubspot-cli/blob/main/packages/cli/lib/commonOpts.js#L18-L23)
   - [`addConfigOptions`](https://github.com/HubSpot/hubspot-cli/blob/main/packages/cli/lib/commonOpts.js#L25-L30)
   - [`addOverwriteOptions`](https://github.com/HubSpot/hubspot-cli/blob/main/packages/cli/lib/commonOpts.js#L32-L38)
   - [`addModeOptions`](https://github.com/HubSpot/hubspot-cli/blob/main/packages/cli/lib/commonOpts.js#L40-L53)
   - [`addTestingOptions`](https://github.com/HubSpot/hubspot-cli/blob/main/packages/cli/lib/commonOpts.js#L55-L61)
   - [`addUseEnvironmentOptions`](https://github.com/HubSpot/hubspot-cli/blob/main/packages/cli/lib/commonOpts.js#L63-L68)
