### PR TITLE
Add check for existing directory in migrate-app command

### DIFF
--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -1203,6 +1203,7 @@ en:
         errors:
           nameRequired: "A project name is required"
           locationRequired: "A project location is required"
+          invalidLocation: "The selected destination already exists. Please provide a new path for this project."
           invalidTemplate: "[--template] Could not find template {{ template }}. Please choose an available template."
           noProjectsInConfig: "Please ensure that there is a config.json file that contains a \"projects\" field."
           missingPropertiesInConfig: "Please ensure that each of the projects in your config.json file contain the following properties: [\"name\", \"label\", \"path\", \"insertPath\"]."

--- a/packages/cli/lib/prompts/createProjectPrompt.js
+++ b/packages/cli/lib/prompts/createProjectPrompt.js
@@ -1,3 +1,4 @@
+const fs = require('fs');
 const path = require('path');
 const { getCwd } = require('@hubspot/local-dev-lib/path');
 const { PROJECT_COMPONENT_TYPES } = require('../../lib/constants');
@@ -83,6 +84,9 @@ const createProjectPrompt = async (
       validate: input => {
         if (!input) {
           return i18n(`${i18nKey}.errors.locationRequired`);
+        }
+        if (fs.existsSync(input)) {
+          return i18n(`${i18nKey}.errors.invalidLocation`);
         }
         return true;
       },


### PR DESCRIPTION
## Description and Context
@mendel-at-hubspot noticed that we were not checking whether the directory exists in the `migrate-app` command. This PR adds that check. 

## Screenshots
<!-- Provide images of the before and after functionality -->

<img width="1239" alt="Screenshot 2024-05-28 at 1 35 28 PM" src="https://github.com/HubSpot/hubspot-cli/assets/25392256/1d8e1711-f8b0-44fd-a6e7-75b12cd97cf7">

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

- [ ] Address feedback 

## Who to Notify
<!-- /cc those you wish to know about the PR -->

@mendel-at-hubspot @markhazlewood @brandenrodgers @camden11 @joe-yeager 
