### PR TITLE
Inform users when auto deploy is off during hs project upload

### DIFF
--- a/packages/cli/commands/project/upload.js
+++ b/packages/cli/commands/project/upload.js
@@ -6,7 +6,7 @@ const {
 } = require('../../lib/commonOpts');
 const chalk = require('chalk');
 const { logger } = require('@hubspot/local-dev-lib/logger');
-const { uiBetaTag, uiLine } = require('../../lib/ui');
+const { uiBetaTag, uiCommandReference } = require('../../lib/ui');
 const { trackCommandUsage } = require('../../lib/usageTracking');
 const { loadAndValidateOptions } = require('../../lib/validation');
 const {
@@ -82,7 +82,6 @@ exports.handler = async options => {
       process.exit(EXIT_CODES.ERROR);
     }
     if (result.succeeded && !result.buildResult.isAutoDeployEnabled) {
-      uiLine();
       logger.log(
         chalk.bold(
           i18n(`${i18nKey}.logs.buildSucceeded`, {
@@ -90,7 +89,13 @@ exports.handler = async options => {
           })
         )
       );
-      uiLine();
+      logger.log(
+        i18n(`${i18nKey}.logs.autoDeployDisabled`, {
+          deployCommand: uiCommandReference(
+            `hs project deploy --buildId=${result.buildId}`
+          ),
+        })
+      );
       logFeedbackMessage(result.buildId);
 
       await displayWarnLogs(accountId, projectConfig.name, result.buildId);

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -605,6 +605,7 @@ en:
             buildSucceeded: "Build #{{ buildId }} succeeded\n"
             readyToGoLive: "🚀 Ready to take your project live?"
             runCommand: "Run `{{ command }}`"
+            autoDeployDisabled: "Automatic deploys are disabled for this project. Run {{ deployCommand }} to deploy this build."
           errors:
             projectLockedError: "Your project is locked. This may mean that another user is running the {{#bold}}`hs project dev`{{/bold}} command for this project. If this is you, unlock the project in Projects UI."
           options:


### PR DESCRIPTION
## Description and Context
See https://git.hubteam.com/HubSpot/hubspot-cli-issues/issues/574

This adds a log to `hs project upload` that lets users know if their project has auto deploy set to off, and tells them how to deploy their build if so. Also removes a lot of unneccessary `uiLine`s

## Screenshots
Before
<img width="503" alt="Screenshot 2024-06-03 at 4 02 06 PM" src="https://github.com/HubSpot/hubspot-cli/assets/10413161/1f46ec36-b0a4-4736-8957-89f6920908c7">

After
<img width="772" alt="Screenshot 2024-06-03 at 4 03 47 PM" src="https://github.com/HubSpot/hubspot-cli/assets/10413161/728db5bc-9889-4595-a256-cbfe55e1f0be">

## Who to Notify
@brandenrodgers @kemmerle @joe-yeager 
