### PR TITLE
Fix error handling in migrate-app command

### DIFF
--- a/packages/cli/commands/project/migrateApp.js
+++ b/packages/cli/commands/project/migrateApp.js
@@ -168,12 +168,16 @@ exports.handler = async options => {
       );
       process.exit(EXIT_CODES.SUCCESS);
     }
-  } catch (e) {
+  } catch (error) {
     SpinniesManager.fail('migrateApp', {
       text: i18n(`${i18nKey}.migrationStatus.failure`),
       failColor: 'white',
     });
-    logApiErrorInstance(e.error, new ApiErrorContext({ accountId }));
+    if (error.error) {
+      logApiErrorInstance(error.error, new ApiErrorContext({ accountId }));
+    } else {
+      logApiErrorInstance(error, new ApiErrorContext({ accountId }));
+    }
     process.exit(EXIT_CODES.ERROR);
   }
 };

--- a/packages/cli/commands/project/migrateApp.js
+++ b/packages/cli/commands/project/migrateApp.js
@@ -173,11 +173,11 @@ exports.handler = async options => {
       text: i18n(`${i18nKey}.migrationStatus.failure`),
       failColor: 'white',
     });
-    if (error.error) {
-      logApiErrorInstance(error.error, new ApiErrorContext({ accountId }));
-    } else {
-      logApiErrorInstance(error, new ApiErrorContext({ accountId }));
-    }
+    logApiErrorInstance(
+      error.error || error,
+      new ApiErrorContext({ accountId })
+    );
+
     process.exit(EXIT_CODES.ERROR);
   }
 };


### PR DESCRIPTION
## Description and Context
In this PR, I've fixed a bug with our error handling in the `migrate-app` command. In certain scenarios, the `error` returned from the API is a property on the response object (as in `error.error`). In others, the API simply returns the error. We now account for both instances. 

## Screenshots
<!-- Provide images of the before and after functionality -->

Before 😢 :

<img width="2558" alt="Screenshot 2024-06-06 at 11 04 27 AM" src="https://github.com/HubSpot/hubspot-cli/assets/25392256/22381c44-3911-43ce-81bc-6ac64572dad2">

After 😄 :

<img width="2560" alt="Screenshot 2024-06-06 at 11 04 55 AM" src="https://github.com/HubSpot/hubspot-cli/assets/25392256/06f35eef-906c-40f6-b42c-f8d24190e7df">

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

- [x] Address any feedback

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@mendel-at-hubspot @brandenrodgers @camden11 @joe-yeager 
