### PR TITLE
Filter listed apps in the `hs project migrate-app` command

### DIFF
--- a/packages/cli/commands/project/migrateApp.js
+++ b/packages/cli/commands/project/migrateApp.js
@@ -75,7 +75,6 @@ exports.handler = async options => {
       : await selectPublicAppPrompt({
           accountId,
           accountName,
-          options,
           migrateApp: true,
         });
 

--- a/packages/cli/commands/project/migrateApp.js
+++ b/packages/cli/commands/project/migrateApp.js
@@ -80,10 +80,22 @@ exports.handler = async options => {
         });
 
   const publicApps = await fetchPublicAppOptions(accountId, accountName);
-  if (!publicApps.find(a => a.id === appId)) {
+  const selectedApp = publicApps.find(a => a.id === appId);
+  if (!selectedApp) {
     logger.error(i18n(`${i18nKey}.errors.invalidAppId`, { appId }));
     process.exit(EXIT_CODES.ERROR);
   }
+  // if (selectedApp.listingInfo) {
+  //   const { shouldContinue } = await promptUser({
+  //     name: 'shouldContinue',
+  //     type: 'confirm',
+  //     message: i18n(`${i18nKey}.continuePrompt`),
+  //   });
+  // }
+
+  // if (!shouldContinue) {
+  //   process.exit(EXIT_CODES.SUCCESS);
+  // }
 
   const { name, location } = await createProjectPrompt('', options, true);
 

--- a/packages/cli/commands/project/migrateApp.js
+++ b/packages/cli/commands/project/migrateApp.js
@@ -85,17 +85,17 @@ exports.handler = async options => {
     logger.error(i18n(`${i18nKey}.errors.invalidAppId`, { appId }));
     process.exit(EXIT_CODES.ERROR);
   }
-  // if (selectedApp.listingInfo) {
-  //   const { shouldContinue } = await promptUser({
-  //     name: 'shouldContinue',
-  //     type: 'confirm',
-  //     message: i18n(`${i18nKey}.continuePrompt`),
-  //   });
-  // }
+  if (selectedApp.listingInfo) {
+    const { shouldContinue } = await promptUser({
+      name: 'shouldContinue',
+      type: 'confirm',
+      message: i18n(`${i18nKey}.continuePrompt`),
+    });
 
-  // if (!shouldContinue) {
-  //   process.exit(EXIT_CODES.SUCCESS);
-  // }
+    if (!shouldContinue) {
+      process.exit(EXIT_CODES.SUCCESS);
+    }
+  }
 
   const { name, location } = await createProjectPrompt('', options, true);
 

--- a/packages/cli/commands/project/migrateApp.js
+++ b/packages/cli/commands/project/migrateApp.js
@@ -80,21 +80,9 @@ exports.handler = async options => {
         });
 
   const publicApps = await fetchPublicAppOptions(accountId, accountName);
-  const selectedApp = publicApps.find(a => a.id === appId);
-  if (!selectedApp) {
+  if (!publicApps.find(a => a.id === appId)) {
     logger.error(i18n(`${i18nKey}.errors.invalidAppId`, { appId }));
     process.exit(EXIT_CODES.ERROR);
-  }
-  if (selectedApp.listingInfo) {
-    const { shouldContinue } = await promptUser({
-      name: 'shouldContinue',
-      type: 'confirm',
-      message: i18n(`${i18nKey}.continuePrompt`),
-    });
-
-    if (!shouldContinue) {
-      process.exit(EXIT_CODES.SUCCESS);
-    }
   }
 
   const { name, location } = await createProjectPrompt('', options, true);

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -520,7 +520,6 @@ en:
             buildAndDeploy: "This will create a new project with a single app component and immediately build and deploy it to your developer account (build #1)."
             existingApps: "{{#bold}}This will not affect existing app users or installs.{{/bold}}"
             copyApp: "We strongly recommend making a copy of your app to test this process in a development app before replacing production."
-          continuePrompt: "This app is listed in the HubSpot Marketplace. Proceed with migrating this app to a project component?"
           createAppPrompt: "Proceed with migrating this app to a project component?"
           projectDetailsLink: "View project details in your developer account"
           errors:
@@ -1211,7 +1210,7 @@ en:
           noProjectsInConfig: "Please ensure that there is a config.json file that contains a \"projects\" field."
           missingPropertiesInConfig: "Please ensure that each of the projects in your config.json file contain the following properties: [\"name\", \"label\", \"path\", \"insertPath\"]."
       selectPublicAppPrompt:
-        selectAppIdMigrate: "[--appId] Choose an app under {{ accountName }} to migrate:"
+        selectAppIdMigrate: "[--appId] Choose an app under {{ accountName }} to migrate \n(Some apps that cannot be migrated are not shown):"
         selectAppIdClone: "[--appId] Choose an app under {{ accountName }} to clone:"
         errors:
           noApps: "{{#bold}}No apps to migrate{{/bold}}"

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -527,7 +527,7 @@ en:
               \n- Run {{ useCommand }} to switch your default account to an app developer account.
               \n- Run {{ authCommand }} to connect an app developer account to the HubSpot CLI.\n"
             projectAlreadyExists: "A project with name {{ projectName }} already exists. Please choose another name."
-            invalidAppId: "[--appId] Could not find appId {{ appId }}. Please choose another public app."
+            invalidAppId: "[--appId] Could not find appId {{ appId }}, or {{ appId }} cannot be migrated at this time. Please choose another public app."
         add:
           describe: "Create a new component within a project"
           options:

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -520,6 +520,7 @@ en:
             buildAndDeploy: "This will create a new project with a single app component and immediately build and deploy it to your developer account (build #1)."
             existingApps: "{{#bold}}This will not affect existing app users or installs.{{/bold}}"
             copyApp: "We strongly recommend making a copy of your app to test this process in a development app before replacing production."
+          continuePrompt: "This app is listed in the HubSpot Marketplace. Proceed with migrating this app to a project component?"
           createAppPrompt: "Proceed with migrating this app to a project component?"
           projectDetailsLink: "View project details in your developer account"
           errors:

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -527,7 +527,7 @@ en:
               \n- Run {{ useCommand }} to switch your default account to an app developer account.
               \n- Run {{ authCommand }} to connect an app developer account to the HubSpot CLI.\n"
             projectAlreadyExists: "A project with name {{ projectName }} already exists. Please choose another name."
-            invalidAppId: "[--appId] Could not find appId {{ appId }}, or {{ appId }} cannot be migrated at this time. Please choose another public app."
+            invalidAppId: "[--appId] Could not find appId {{ appId }}. Please choose another public app."
         add:
           describe: "Create a new component within a project"
           options:
@@ -1210,13 +1210,13 @@ en:
           noProjectsInConfig: "Please ensure that there is a config.json file that contains a \"projects\" field."
           missingPropertiesInConfig: "Please ensure that each of the projects in your config.json file contain the following properties: [\"name\", \"label\", \"path\", \"insertPath\"]."
       selectPublicAppPrompt:
-        selectAppIdMigrate: "[--appId] Choose an app under {{ accountName }} to migrate \n(Some apps that cannot be migrated are not shown):"
+        selectAppIdMigrate: "[--appId] Choose an app under {{ accountName }} to migrate:"
         selectAppIdClone: "[--appId] Choose an app under {{ accountName }} to clone:"
         errors:
           noApps: "{{#bold}}No apps to migrate{{/bold}}"
           noAppsMessage: "The selected developer account {{#bold}}{{ accountName }}{{/bold}} doesn't have any apps that can be migrated to the projects framework."
           errorFetchingApps: "There was an error fetching public apps."
-          invalidAppId: "[--appId] Could not find appId {{ appId }}. Please choose another public app."
+          marketplaceApp: "Marketplace app"
       developerTestAccountPrompt:
         name:
           message: "Name your developer test account"

--- a/packages/cli/lib/prompts/selectPublicAppPrompt.js
+++ b/packages/cli/lib/prompts/selectPublicAppPrompt.js
@@ -14,7 +14,7 @@ const fetchPublicAppOptions = async (accountId, accountName) => {
   try {
     const publicApps = await fetchPublicAppsForPortal(accountId);
     const filteredPublicApps = publicApps.filter(
-      app => !app.projectId && !app.sourceId
+      app => !app.projectId && !app.sourceId && !app.listingInfo
     );
 
     if (!filteredPublicApps.length) {

--- a/packages/cli/lib/prompts/selectPublicAppPrompt.js
+++ b/packages/cli/lib/prompts/selectPublicAppPrompt.js
@@ -14,7 +14,7 @@ const fetchPublicAppOptions = async (accountId, accountName) => {
   try {
     const publicApps = await fetchPublicAppsForPortal(accountId);
     const filteredPublicApps = publicApps.filter(
-      app => !app.projectId && !app.sourceId && !app.listingInfo
+      app => !app.projectId && !app.sourceId
     );
 
     if (!filteredPublicApps.length) {
@@ -35,7 +35,6 @@ const fetchPublicAppOptions = async (accountId, accountName) => {
 const selectPublicAppPrompt = async ({
   accountId,
   accountName,
-  promptOptions = {},
   migrateApp = false,
 }) => {
   const publicApps = await fetchPublicAppOptions(accountId, accountName);
@@ -44,21 +43,17 @@ const selectPublicAppPrompt = async ({
   return promptUser([
     {
       name: 'appId',
-      message: () => {
-        return promptOptions.appId &&
-          !publicApps.find(a => a.id === promptOptions.appId)
-          ? i18n(`${i18nKey}.errors.invalidAppId`, {
-              appId: promptOptions.appId,
-            })
-          : i18n(`${i18nKey}.${translationKey}`, {
-              accountName,
-            });
-      },
-      when:
-        !promptOptions.appId ||
-        !publicApps.find(a => a.id === promptOptions.appId),
+      message: i18n(`${i18nKey}.${translationKey}`, {
+        accountName,
+      }),
       type: 'list',
       choices: publicApps.map(app => {
+        if (app.listingInfo) {
+          return {
+            name: `${app.name} (${app.id})`,
+            disabled: i18n(`${i18nKey}.errors.marketplaceApp`),
+          };
+        }
         return {
           name: `${app.name} (${app.id})`,
           value: app.id,


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
In this PR, I've added a filter to exclude listed public apps from the `migrate-app` command.

However, this may require a bit of discussion. We have two ways we could check for listed apps:

1) We could simply block customers from migrating listed apps at this time.

2) We could add a warning and a `yes/no` prompt before customers can migrate listed apps. 

Basically, it depends on how much control we'd like to give the customer at this time. I've coded both options, with option 2 being commented out. I am leaning toward option 2, given our Slack conversations about the flow we want customers to follow. @mindspin311 said that we would allow customers to migrate the app but require them to contact HubSpot before the second upload. 

UPDATE: In the cross-team sync, we decided to go with a third option: To list all the public apps in the portal and disable the choices for listed apps. @markhazlewood, I didn't have control over the styling here, so it does not match your mocks completely:

<img width="2093" alt="Screenshot 2024-06-06 at 8 57 15 PM" src="https://github.com/HubSpot/hubspot-cli/assets/25392256/3c93d2c0-c1c3-4bb7-b31b-5e20da792e05">

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

- [x] Address initial feedback. 
- [x] Address secondary feedback for Option 3. 

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@mendel-at-hubspot @markhazlewood @brandenrodgers @camden11 @joe-yeager 
