### PR TITLE
Fix marketplace-validate error logging for invalid path

### DIFF
--- a/packages/cli/commands/module/marketplace-validate.js
+++ b/packages/cli/commands/module/marketplace-validate.js
@@ -48,7 +48,7 @@ exports.handler = async options => {
     accountId,
     validationId
   );
-  processValidationErrors(validationResults);
+  processValidationErrors(i18nKey, validationResults);
   displayValidationResults(i18nKey, validationResults);
 
   process.exit();

--- a/packages/cli/commands/theme/marketplace-validate.js
+++ b/packages/cli/commands/theme/marketplace-validate.js
@@ -48,7 +48,7 @@ exports.handler = async options => {
     accountId,
     validationId
   );
-  processValidationErrors(validationResults);
+  processValidationErrors(i18nKey, validationResults);
   displayValidationResults(i18nKey, validationResults);
 
   process.exit();

--- a/packages/cli/lib/marketplace-validate.js
+++ b/packages/cli/lib/marketplace-validate.js
@@ -57,12 +57,20 @@ const fetchValidationResults = async (accountId, validationId) => {
   }
 };
 
-const processValidationErrors = validationResults => {
+const processValidationErrors = (i18nKey, validationResults) => {
   if (validationResults.errors.length) {
-    const { errors } = validationResults;
+    const { assetPath, errors } = validationResults;
 
     errors.forEach(err => {
-      logger.error(`${err.context}`);
+      if (err.failureReasonType === 'DOWNLOAD_EMPTY') {
+        logger.error(
+          i18n(`${i18nKey}.errors.invalidPath`, {
+            path: assetPath,
+          })
+        );
+      } else {
+        logger.error(`${err.context}`);
+      }
     });
     process.exit(EXIT_CODES.ERROR);
   }


### PR DESCRIPTION
## Description and Context
Currently if the path provided doesn't exist in the Design Manager it just logs an 

```
[ERROR] {taskId=652993, path=mymodule, portalId=881618273}
```

Updates it to properly log what the issue was. The i18nKeys for these already existed just weren't hooked up, I think missed when the validation got moved from client side to a BE service.

New error for themes: `[ERROR] The path "MyExampleThem" is not a path to a folder in the Design Manager`
New error for modules: `[ERROR] The path "mymodule" is not a path to a module within the Design Manager.`
