### PR TITLE
Address June 7 bug bash feedback

### DIFF
--- a/packages/cli/commands/project/migrateApp.js
+++ b/packages/cli/commands/project/migrateApp.js
@@ -142,7 +142,7 @@ exports.handler = async options => {
       if ((key.ctrl && key.name === 'c') || key.name === 'q') {
         SpinniesManager.remove('migrateApp');
         logger.log(i18n(`${i18nKey}.migrationInterrupted`));
-        process.exit();
+        process.exit(EXIT_CODES.SUCCESS);
       }
     });
 

--- a/packages/cli/commands/project/migrateApp.js
+++ b/packages/cli/commands/project/migrateApp.js
@@ -80,7 +80,9 @@ exports.handler = async options => {
         });
 
   const publicApps = await fetchPublicAppOptions(accountId, accountName);
-  if (!publicApps.find(a => a.id === appId)) {
+  const selectedApp = publicApps.find(a => a.id === appId);
+  const appName = selectedApp ? selectedApp.name : 'app';
+  if (!selectedApp) {
     logger.error(i18n(`${i18nKey}.errors.invalidAppId`, { appId }));
     process.exit(EXIT_CODES.ERROR);
   }
@@ -106,7 +108,7 @@ exports.handler = async options => {
 
   logger.log('');
   uiLine();
-  logger.log(uiBetaTag(i18n(`${i18nKey}.warning.title`), false));
+  logger.log(uiBetaTag(i18n(`${i18nKey}.warning.title`, { appName }), false));
   logger.log(i18n(`${i18nKey}.warning.projectConversion`));
   logger.log(i18n(`${i18nKey}.warning.appConfig`));
   logger.log('');

--- a/packages/cli/commands/project/migrateApp.js
+++ b/packages/cli/commands/project/migrateApp.js
@@ -58,14 +58,15 @@ exports.handler = async options => {
   trackCommandUsage('migrate-app', {}, accountId);
 
   if (!isAppDeveloperAccount(accountConfig)) {
-    logger.error(
-      i18n(`${i18nKey}.errors.invalidAccountType`, {
-        accountName,
-        accountType: accountConfig.accountType,
+    uiLine();
+    logger.error(i18n(`${i18nKey}.errors.invalidAccountTypeTitle`));
+    logger.log(
+      i18n(`${i18nKey}.errors.invalidAccountTypeDescription`, {
         useCommand: uiCommandReference('hs accounts use'),
         authCommand: uiCommandReference('hs auth'),
       })
     );
+    uiLine();
     process.exit(EXIT_CODES.ERROR);
   }
 

--- a/packages/cli/commands/project/migrateApp.js
+++ b/packages/cli/commands/project/migrateApp.js
@@ -150,7 +150,6 @@ exports.handler = async options => {
     const { id } = migrateResponse;
     const pollResponse = await poll(checkMigrationStatus, accountId, id);
     const { status, project } = pollResponse;
-
     if (status === 'SUCCESS') {
       const absoluteDestPath = path.resolve(getCwd(), projectLocation);
       const { env } = getAccountConfig(accountId);

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -520,6 +520,7 @@ en:
             buildAndDeploy: "This will create a new project with a single app component and immediately build and deploy it to your developer account (build #1)."
             existingApps: "{{#bold}}This will not affect existing app users or installs.{{/bold}}"
             copyApp: "We strongly recommend making a copy of your app to test this process in a development app before replacing production."
+          migrationInterrupted: "\nThe command is terminated, but app migration is still in progress. Please check your account to ensure that the project and associated app have been created successfully."
           createAppPrompt: "Proceed with migrating this app to a project component?"
           projectDetailsLink: "View project details in your developer account"
           errors:

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -514,8 +514,8 @@ en:
             done: "Converting app configuration to public-app.json component definition ... DONE"
             failure: "Converting app configuration to public-app.json component definition ... FAILED"
           warning:
-            title: "{{#bold}}Migrate an app to the projects framework?{{/bold}}"
-            projectConversion: "{{#bold}}The selected app will be permanently converted to a project component.{{/bold}}"
+            title: "{{#bold}}Migrate {{appName}} to the projects framework?{{/bold}}"
+            projectConversion: "{{#bold}}The selected app will be converted to a project component.{{/bold}}"
             appConfig: "All supported app configuration will be moved to the {{#bold}}public-app.json{{/bold}} component definition file. Future updates to those features must be made through the project build and deploy pipeline, not the developer account UI."
             buildAndDeploy: "This will create a new project with a single app component and immediately build and deploy it to your developer account (build #1)."
             existingApps: "{{#bold}}This will not affect existing app users or installs.{{/bold}}"

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -521,7 +521,7 @@ en:
             existingApps: "{{#bold}}This will not affect existing app users or installs.{{/bold}}"
             copyApp: "We strongly recommend making a copy of your app to test this process in a development app before replacing production."
           migrationInterrupted: "\nThe command is terminated, but app migration is still in progress. Please check your account to ensure that the project and associated app have been created successfully."
-          createAppPrompt: "Proceed with migrating this app to a project component?"
+          createAppPrompt: "Proceed with migrating this app to a project component (this process can't be aborted)?"
           projectDetailsLink: "View project details in your developer account"
           errors:
             invalidAccountTypeTitle: "{{#bold}}Developer account not targeted{{/bold}}"

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -523,9 +523,8 @@ en:
           createAppPrompt: "Proceed with migrating this app to a project component?"
           projectDetailsLink: "View project details in your developer account"
           errors:
-            invalidAccountType: "Public apps must be migrated within an app developer account. Your current account {{#bold}}{{ accountName }}{{/bold}} is a {{ accountType }}.
-              \n- Run {{ useCommand }} to switch your default account to an app developer account.
-              \n- Run {{ authCommand }} to connect an app developer account to the HubSpot CLI.\n"
+            invalidAccountTypeTitle: "{{#bold}}Developer account not targeted{{/bold}}"
+            invalidAccountTypeDescription: "Only public apps created in a developer account can be converted to a project component. Select a connected developer account with {{useCommand}} or {{authCommand}} and try again."
             projectAlreadyExists: "A project with name {{ projectName }} already exists. Please choose another name."
             invalidAppId: "[--appId] Could not find appId {{ appId }}. Please choose another public app."
         add:


### PR DESCRIPTION
## Description and Context
I am addressing some feedback from the June 7 bug bash: 

1) Revise some of the copy in the warning we display to users before they can migrate their app.
2) Revise the error warning to match mocks when users run the command from a non-developer account. 

There was other feedback in the Bug Bash Google Sheet, for which I've left detailed notes. 

## Screenshots
<!-- Provide images of the before and after functionality -->

Revised warning copy and new warnings when user attempts to abort command:

<img width="2560" alt="Screenshot 2024-06-11 at 11 37 50 AM" src="https://github.com/HubSpot/hubspot-cli/assets/25392256/badaf66d-c696-4e5a-835e-199cde6f242f">

Revised error message for non-developer accounts:

<img width="2559" alt="Screenshot 2024-06-10 at 2 26 03 PM" src="https://github.com/HubSpot/hubspot-cli/assets/25392256/d36d7796-d3fe-4692-bd8d-060e23d87106">



## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

- [x] Add message when user attempts to abort command. 
- [x] Address any feedback

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@markhazlewood @brandenrodgers @camden11 @joe-yeager 
