### PR TITLE
Rename account name prompts

### DIFF
--- a/packages/cli/commands/auth.js
+++ b/packages/cli/commands/auth.js
@@ -31,9 +31,7 @@ const {
   personalAccessKeyPrompt,
   OAUTH_FLOW,
 } = require('../lib/prompts/personalAccessKeyPrompt');
-const {
-  enterAccountNamePrompt,
-} = require('../lib/prompts/enterAccountNamePrompt');
+const { cliAccountNamePrompt } = require('../lib/prompts/accountNamePrompt');
 const {
   setAsDefaultAccountPrompt,
 } = require('../lib/prompts/setAsDefaultAccountPrompt');
@@ -129,7 +127,7 @@ exports.handler = async options => {
       validName = updatedConfig.name;
 
       if (!validName) {
-        const { name: namePrompt } = await enterAccountNamePrompt(defaultName);
+        const { name: namePrompt } = await cliAccountNamePrompt(defaultName);
         validName = namePrompt;
       }
 

--- a/packages/cli/commands/init.js
+++ b/packages/cli/commands/init.js
@@ -40,9 +40,7 @@ const {
   OAUTH_FLOW,
   personalAccessKeyPrompt,
 } = require('../lib/prompts/personalAccessKeyPrompt');
-const {
-  enterAccountNamePrompt,
-} = require('../lib/prompts/enterAccountNamePrompt');
+const { cliAccountNamePrompt } = require('../lib/prompts/accountNamePrompt');
 const { logDebugInfo } = require('../lib/debugInfo');
 const { authenticateWithOauth } = require('../lib/oauth');
 const { EXIT_CODES } = require('../lib/enums/exitCodes');
@@ -63,7 +61,7 @@ const personalAccessKeyConfigCreationFlow = async (env, account) => {
   try {
     const token = await getAccessToken(personalAccessKey, env);
     const defaultName = token.hubName ? toKebabCase(token.hubName) : null;
-    const { name } = await enterAccountNamePrompt(defaultName);
+    const { name } = await cliAccountNamePrompt(defaultName);
 
     updatedConfig = updateConfigWithAccessToken(
       token,

--- a/packages/cli/commands/sandbox/create.js
+++ b/packages/cli/commands/sandbox/create.js
@@ -37,7 +37,7 @@ const {
 const { buildNewAccount } = require('../../lib/buildAccount');
 const {
   hubspotAccountNamePrompt,
-} = require('../../lib/prompts/enterAccountNamePrompt');
+} = require('../../lib/prompts/accountNamePrompt');
 
 const i18nKey = 'commands.sandbox.subcommands.create';
 

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -1142,7 +1142,7 @@ en:
         setAsDefaultAccountMessage: "Set this account as the default?"
         setAsDefaultAccount: "Account \"{{ accountName }}\" set as the default account"
         keepingCurrentDefault: "Account \"{{ accountName }}\" will continue to be the default account"
-      enterAccountNamePrompt:
+      accountNamePrompt:
         enterAccountName: "Enter a unique name to reference this account in the CLI:"
         enterDeveloperTestAccountName: "Name your developer test account:"
         enterStandardSandboxName: "Name your standard sandbox:"

--- a/packages/cli/lib/buildAccount.js
+++ b/packages/cli/lib/buildAccount.js
@@ -13,7 +13,7 @@ const {
 } = require('@hubspot/local-dev-lib/config');
 const { logger } = require('@hubspot/local-dev-lib/logger');
 const { i18n } = require('./lang');
-const { enterAccountNamePrompt } = require('./prompts/enterAccountNamePrompt');
+const { cliAccountNamePrompt } = require('./prompts/accountNamePrompt');
 const SpinniesManager = require('./ui/SpinniesManager');
 const {
   debugErrorAndContext,
@@ -65,11 +65,11 @@ async function saveAccountToConfig({
       if (!force) {
         logger.log('');
         logger.warn(
-          i18n(`lib.prompts.enterAccountNamePrompt.errors.accountNameExists`, {
+          i18n(`lib.prompts.accountNamePrompt.errors.accountNameExists`, {
             name: nameForConfig,
           })
         );
-        const { name: promptName } = await enterAccountNamePrompt(
+        const { name: promptName } = await cliAccountNamePrompt(
           nameForConfig + `_${accountId}`
         );
         validName = promptName;

--- a/packages/cli/lib/localDev.js
+++ b/packages/cli/lib/localDev.js
@@ -55,9 +55,7 @@ const {
   PERSONAL_ACCESS_KEY_AUTH_METHOD,
 } = require('@hubspot/local-dev-lib/constants/auth');
 const { buildNewAccount, saveAccountToConfig } = require('./buildAccount');
-const {
-  hubspotAccountNamePrompt,
-} = require('./prompts/enterAccountNamePrompt');
+const { hubspotAccountNamePrompt } = require('./prompts/accountNamePrompt');
 
 const i18nKey = 'lib.localDev';
 

--- a/packages/cli/lib/prompts/accountNamePrompt.js
+++ b/packages/cli/lib/prompts/accountNamePrompt.js
@@ -8,7 +8,6 @@ const {
 
 const i18nKey = 'lib.prompts.accountNamePrompt';
 
-// Used for CLI Config account names
 const getCliAccountNamePromptConfig = defaultName => ({
   name: 'name',
   message: i18n(`${i18nKey}.enterAccountName`),
@@ -31,7 +30,6 @@ const cliAccountNamePrompt = defaultName => {
   return promptUser(getCliAccountNamePromptConfig(defaultName));
 };
 
-// Used for HubSpot portal account names
 const hubspotAccountNamePrompt = ({ accountType, currentPortalCount = 0 }) => {
   const isDevelopmentSandbox =
     accountType === HUBSPOT_ACCOUNT_TYPES.DEVELOPMENT_SANDBOX;

--- a/packages/cli/lib/prompts/accountNamePrompt.js
+++ b/packages/cli/lib/prompts/accountNamePrompt.js
@@ -6,10 +6,10 @@ const {
   HUBSPOT_ACCOUNT_TYPES,
 } = require('@hubspot/local-dev-lib/constants/config');
 
-const i18nKey = 'lib.prompts.enterAccountNamePrompt';
+const i18nKey = 'lib.prompts.accountNamePrompt';
 
 // Used for CLI Config account names
-const accountNamePrompt = defaultName => ({
+const getCliAccountNamePromptConfig = defaultName => ({
   name: 'name',
   message: i18n(`${i18nKey}.enterAccountName`),
   default: defaultName,
@@ -27,8 +27,8 @@ const accountNamePrompt = defaultName => ({
   },
 });
 
-const enterAccountNamePrompt = defaultName => {
-  return promptUser(accountNamePrompt(defaultName));
+const cliAccountNamePrompt = defaultName => {
+  return promptUser(getCliAccountNamePromptConfig(defaultName));
 };
 
 // Used for HubSpot portal account names
@@ -77,7 +77,7 @@ const hubspotAccountNamePrompt = ({ accountType, currentPortalCount = 0 }) => {
 };
 
 module.exports = {
-  accountNamePrompt,
-  enterAccountNamePrompt,
+  getCliAccountNamePromptConfig,
+  cliAccountNamePrompt,
   hubspotAccountNamePrompt,
 };

--- a/packages/cli/lib/prompts/personalAccessKeyPrompt.js
+++ b/packages/cli/lib/prompts/personalAccessKeyPrompt.js
@@ -7,7 +7,7 @@ const { deleteEmptyConfigFile } = require('@hubspot/local-dev-lib/config');
 const { getHubSpotWebsiteOrigin } = require('@hubspot/local-dev-lib/urls');
 const { logger } = require('@hubspot/local-dev-lib/logger');
 const { promptUser } = require('./promptUtils');
-const { accountNamePrompt } = require('./enterAccountNamePrompt');
+const { getCliAccountNamePromptConfig } = require('./accountNamePrompt');
 const { i18n } = require('../lang');
 const { uiInfoSection } = require('../ui');
 const { EXIT_CODES } = require('../enums/exitCodes');
@@ -124,7 +124,7 @@ const SCOPES = {
 };
 
 const OAUTH_FLOW = [
-  accountNamePrompt(),
+  getCliAccountNamePromptConfig(),
   ACCOUNT_ID,
   CLIENT_ID,
   CLIENT_SECRET,


### PR DESCRIPTION
## Description and Context
This is in response to something I missed in @adamawang 's last PR https://github.com/HubSpot/hubspot-cli/pull/1086

Now that we have a `hubspotAccountNamePrompt`, figured we should make it more clear what the other `accountNamePrompt` is doing. This renames it accordingly

## Who to Notify
@brandenrodgers @kemmerle @joe-yeager 
