### PR TITLE
Refactor errors in `hs project migrate-app` command

### DIFF
--- a/packages/cli/commands/project/migrateApp.js
+++ b/packages/cli/commands/project/migrateApp.js
@@ -185,10 +185,11 @@ exports.handler = async options => {
       text: i18n(`${i18nKey}.migrationStatus.failure`),
       failColor: 'white',
     });
-    logApiErrorInstance(
-      error.error || error,
-      new ApiErrorContext({ accountId })
-    );
+    if (error.errors) {
+      error.errors.map(logApiErrorInstance);
+    } else {
+      logApiErrorInstance(error, new ApiErrorContext({ accountId }));
+    }
 
     process.exit(EXIT_CODES.ERROR);
   }

--- a/packages/cli/commands/project/migrateApp.js
+++ b/packages/cli/commands/project/migrateApp.js
@@ -186,7 +186,7 @@ exports.handler = async options => {
       failColor: 'white',
     });
     if (error.errors) {
-      error.errors.map(logApiErrorInstance);
+      error.errors.forEach(logApiErrorInstance);
     } else {
       logApiErrorInstance(error, new ApiErrorContext({ accountId }));
     }


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->

@mendel-at-hubspot refactored errors returned while migrating apps. Now the error response will have an `errors` property that is an array of errors. This allows us to return multiple errors to the user. NOTE: We will still keep the older `error` property on the response object for folks on older versions of the CLI.

## Screenshots
<!-- Provide images of the before and after functionality -->

New error handling (Doesn't appear very different with only one error returned)
<img width="2560" alt="Screenshot 2024-06-13 at 1 09 32 PM" src="https://github.com/HubSpot/hubspot-cli/assets/25392256/c20079cd-dc09-46cb-878c-228868e1a359">

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

- [ ] Address any feedback

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@mendel-at-hubspot @brandenrodgers @camden11 @joe-yeager 