### PR TITLE
Scope change reinstall prompt

### DIFF
--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -1278,7 +1278,9 @@ en:
         message: "You are about to remove any remote files in \"{{ filePath }}\" on HubSpot account {{ accountId }} that don't exist locally. Are you sure you want to do this?"
       installPublicAppPrompt:
         explanation: "Local development requires this app to be installed in the target test account"
+        reinstallExplanation: "This app's required scopes have been updated since it was last installed on the target test account. To avoid issues with local development, we recommend reinstalling the app with the updated scopes."
         prompt: "Open hubspot.com to install this app?"
+        reinstallPrompt: "Open hubspot.com to reinstall this app?"
         decline: "To continue local development of this app, install it in your target test account and re-run {{#bold}}`hs project dev`{{/bold}}"
       activeInstallConfirmationPrompt:
         message: "Proceed with local development of this {{#bold}}production{{/bold}} app?"

--- a/packages/cli/lib/LocalDevManager.js
+++ b/packages/cli/lib/LocalDevManager.js
@@ -298,16 +298,20 @@ class LocalDevManager {
 
   async checkPublicAppInstallation() {
     const {
-      isInstalledWithScopeGroups: isInstalled,
+      isInstalledWithScopeGroups,
+      previouslyAuthorizedScopeGroups,
     } = await this.getActiveAppInstallationData();
 
-    if (!isInstalled) {
+    const isReinstall = previouslyAuthorizedScopeGroups.length > 0;
+
+    if (!isInstalledWithScopeGroups) {
       await installPublicAppPrompt(
         this.env,
         this.targetAccountId,
         this.activePublicAppData.clientId,
         this.activeApp.config.auth.requiredScopes,
-        this.activeApp.config.auth.redirectUrls
+        this.activeApp.config.auth.redirectUrls,
+        isReinstall
       );
     }
   }

--- a/packages/cli/lib/prompts/installPublicAppPrompt.js
+++ b/packages/cli/lib/prompts/installPublicAppPrompt.js
@@ -12,20 +12,29 @@ const installPublicAppPrompt = async (
   targetAccountId,
   clientId,
   scopes,
-  redirectUrls
+  redirectUrls,
+  isReinstall = false
 ) => {
   logger.log('');
-  logger.log(i18n(`${i18nKey}.explanation`));
+  if (isReinstall) {
+    logger.log(i18n(`${i18nKey}.reinstallExplanation`));
+  } else {
+    logger.log(i18n(`${i18nKey}.explanation`));
+  }
 
   const { shouldOpenBrowser } = await promptUser({
     name: 'shouldOpenBrowser',
     type: 'confirm',
-    message: i18n(`${i18nKey}.prompt`),
+    message: i18n(
+      isReinstall ? `${i18nKey}.reinstallPrompt` : `${i18nKey}.prompt`
+    ),
   });
 
-  if (!shouldOpenBrowser) {
+  if (!isReinstall && !shouldOpenBrowser) {
     logger.log(i18n(`${i18nKey}.decline`));
     process.exit(EXIT_CODES.SUCCESS);
+  } else if (!shouldOpenBrowser) {
+    return;
   }
 
   const websiteOrigin = getHubSpotWebsiteOrigin(env);


### PR DESCRIPTION
## Description and Context
See https://git.hubteam.com/HubSpot/hubspot-cli-issues/issues/589

Previously, users that had outdated scopes on an already installed public app would see the same prompt as if they hadn't installed at all, which was confusing. This adds new language specific to scope mismatches, and also allows users to _not_ reinstall the app, since scopes won't necessarily make a difference with CRM cards. (If users without the app installed decline the prompt, it exits).

## Screenshots
<img width="855" alt="Screenshot 2024-06-13 at 1 46 46 PM" src="https://github.com/HubSpot/hubspot-cli/assets/10413161/2de2b8d2-96f2-45b2-b7b0-5399a20ca3fe">


## Questions
Do we want to allow users to proceed anyway or should we force them to reinstall?

## Who to Notify
@brandenrodgers @kemmerle @joe-yeager @tamara-at-hubspot 
