### PR TITLE
Generate private app tokens if possible for private app localdev

### DIFF
--- a/packages/cli/lib/DevServerManager.js
+++ b/packages/cli/lib/DevServerManager.js
@@ -96,7 +96,7 @@ class DevServerManager {
     this.initialized = true;
   }
 
-  async start({ accountId, projectConfig, getPrivateAppToken }) {
+  async start({ accountId, projectConfig, getPrivateAppUserToken }) {
     if (this.initialized) {
       await this.iterateDevServers(async serverInterface => {
         if (serverInterface.start) {
@@ -104,7 +104,7 @@ class DevServerManager {
             accountId,
             projectConfig,
             requestPorts,
-            getPrivateAppToken,
+            getPrivateAppUserToken,
           });
         }
       });

--- a/packages/cli/lib/DevServerManager.js
+++ b/packages/cli/lib/DevServerManager.js
@@ -96,7 +96,7 @@ class DevServerManager {
     this.initialized = true;
   }
 
-  async start({ accountId, projectConfig }) {
+  async start({ accountId, projectConfig, getPrivateAppToken }) {
     if (this.initialized) {
       await this.iterateDevServers(async serverInterface => {
         if (serverInterface.start) {
@@ -104,6 +104,7 @@ class DevServerManager {
             accountId,
             projectConfig,
             requestPorts,
+            getPrivateAppToken,
           });
         }
       });

--- a/packages/cli/lib/LocalDevManager.js
+++ b/packages/cli/lib/LocalDevManager.js
@@ -130,10 +130,14 @@ class LocalDevManager {
         logErrorInstance(e);
       }
     } else if (this.activeApp.type == COMPONENT_TYPES.privateApp) {
-      this.privateAppUserTokenManager = new PrivateAppUserTokenManager(
-        this.targetAccountId
-      );
-      this.privateAppUserTokenManager.init();
+      try {
+        this.privateAppUserTokenManager = new PrivateAppUserTokenManager(
+          this.targetAccountId
+        );
+        await this.privateAppUserTokenManager.init();
+      } catch (e) {
+        logErrorInstance(e);
+      }
     }
   }
 
@@ -187,6 +191,21 @@ class LocalDevManager {
 
     if (!proceed) {
       process.exit(EXIT_CODES.SUCCESS);
+    }
+  }
+
+  async getPrivateAppToken(appId) {
+    try {
+      if (this.privateAppUserTokenManager) {
+        logger.debug('calling');
+        const result = await this.privateAppUserTokenManager.getPrivateAppToken(
+          appId
+        );
+        return result;
+      }
+    } catch (e) {
+      logger.debug('errored');
+      logErrorInstance(e);
     }
   }
 
@@ -516,13 +535,11 @@ class LocalDevManager {
 
   async devServerStart() {
     try {
-      var args = {
+      const args = {
         accountId: this.targetAccountId,
         projectConfig: this.projectConfig,
         ...(this.privateAppUserTokenManager && {
-          getPrivateAppToken: this.privateAppUserTokenManager.getPrivateAppToken.bind(
-            this.privateAppUserTokenManager
-          ),
+          getPrivateAppToken: this.getPrivateAppToken.bind(this),
         }),
       };
       logger.debug('args for dev server start {{args}}', { args });

--- a/packages/cli/lib/LocalDevManager.js
+++ b/packages/cli/lib/LocalDevManager.js
@@ -194,17 +194,15 @@ class LocalDevManager {
     }
   }
 
-  async getPrivateAppToken(appId) {
+  async getPrivateAppUserToken(appId) {
     try {
       if (this.privateAppUserTokenManager) {
-        logger.debug('calling');
-        const result = await this.privateAppUserTokenManager.getPrivateAppToken(
+        const result = await this.privateAppUserTokenManager.getPrivateAppUserToken(
           appId
         );
         return result;
       }
     } catch (e) {
-      logger.debug('errored');
       logErrorInstance(e);
     }
   }
@@ -539,7 +537,7 @@ class LocalDevManager {
         accountId: this.targetAccountId,
         projectConfig: this.projectConfig,
         ...(this.privateAppUserTokenManager && {
-          getPrivateAppToken: this.getPrivateAppToken.bind(this),
+          getPrivateAppUserToken: this.getPrivateAppUserToken.bind(this),
         }),
       };
       logger.debug('args for dev server start {{args}}', { args });


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->

Private app user tokens are temporary Private App tokens scoped to the portal and user of the Personal Access Key. Using this user can avoid grabbing the real Private app token that is used for in the serverless instances.

Add usage to PrivateApplicationUserTokenManager and pass the getToken function to local dev server. 

## Scre
<img width="909" alt="Screenshot 2024-06-18 at 11 17 12 AM" src="https://github.com/HubSpot/hubspot-cli/assets/159944531/2c1340c3-a64f-4ef8-b219-fa0133d28ff7">

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
