### PR TITLE
fix: Update error handling from request to axios

### DIFF
--- a/packages/cli/commands/functions/deploy.js
+++ b/packages/cli/commands/functions/deploy.js
@@ -75,13 +75,13 @@ exports.handler = async options => {
     );
   } catch (e) {
     spinner && spinner.stop && spinner.stop();
-    if (e.statusCode === 404) {
+    if (e.response && e.response.status === 404) {
       logger.error(
         i18n(`${i18nKey}.errors.noPackageJson`, {
           functionPath,
         })
       );
-    } else if (e.statusCode === 400) {
+    } else if (e.response && e.response.status === 400) {
       logger.error(e.error.message);
     } else if (e.status === 'ERROR') {
       await outputBuildLog(e.cdnUrl);

--- a/packages/cli/commands/project/listBuilds.js
+++ b/packages/cli/commands/project/listBuilds.js
@@ -124,7 +124,7 @@ exports.handler = async options => {
 
     await fetchAndDisplayBuilds(project, { limit });
   } catch (e) {
-    if (e.statusCode === 404) {
+    if (e.response && e.response.status === 404) {
       logger.error(`Project ${projectConfig.name} not found. `);
     } else {
       logApiErrorInstance(

--- a/packages/cli/commands/project/logs.js
+++ b/packages/cli/commands/project/logs.js
@@ -49,7 +49,7 @@ const getPrivateAppsUrl = accountId => {
 // We currently cannot fetch logs directly to the CLI. See internal CLI issue #413 for more information.
 
 // const handleLogsError = (e, name, projectName) => {
-//   if (e.statusCode === 404) {
+//   if (e.response && e.response.status === 404) {
 //     logger.debug(`Log fetch error: ${e.message}`);
 //     logger.log(i18n(`${i18nKey}.logs.noLogsFound`, { name }));
 //   } else {

--- a/packages/cli/lib/serverlessLogs.js
+++ b/packages/cli/lib/serverlessLogs.js
@@ -52,7 +52,7 @@ const tailLogs = async ({
     initialAfter = latestLog && base64EncodeString(latestLog.id);
   } catch (e) {
     // A 404 means no latest log exists(never executed)
-    if (e.statusCode !== 404) {
+    if (e.response && e.response.status !== 404) {
       await logServerlessFunctionApiErrorInstance(
         accountId,
         e,
@@ -68,7 +68,7 @@ const tailLogs = async ({
       latestLog = await tailCall(after);
       nextAfter = latestLog.paging.next.after;
     } catch (e) {
-      if (e.statusCode !== 404) {
+      if (e.response && e.response.status !== 404) {
         logApiErrorInstance(
           e,
           new ApiErrorContext({

--- a/packages/webpack-cms-plugins/HubSpotAutoUploadPlugin.js
+++ b/packages/webpack-cms-plugins/HubSpotAutoUploadPlugin.js
@@ -137,10 +137,10 @@ class HubSpotAutoUploadPlugin {
               statusCode: error.statusCode,
             };
             if (
-              error.statusCode === 400 &&
               error.response &&
-              error.response.body &&
-              (error.response.body.message || error.response.body.errors)
+              error.response.status === 400 &&
+              error.response.data &&
+              (error.response.data.message || error.response.data.errors)
             ) {
               logValidationErrors(error, context);
             } else {


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
When the migration from `cli-lib` to `local-dev-lib` occurred, the underlying http library was changed from `request` to `axios` so these error handling situations need to be updated to the `axios` way of checking for status code.

## Screenshots
<!-- Provide images of the before and after functionality -->

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@brandenrodgers @camden11 @kemmerle 