### PR TITLE
Clean up package.json files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "hubspot-cms-tools",
+  "name": "hubspot-local-dev-tools",
   "version": "1.0.0",
-  "description": "CLI tools for working with HubSpot",
-  "repository": "https://github.com/HubSpot/hubspot-cms-tools",
+  "description": "Local development tools for working with HubSpot",
+  "repository": "https://github.com/HubSpot/hubspot-cli",
   "private": true,
   "devDependencies": {
     "depcheck": "1.3.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/HubSpot/hubspot-cli"
+    "url": "https://github.com/HubSpot/hubspot-cms-tools"
   },
   "dependencies": {
     "@hubspot/local-dev-lib": "1.6.0",
@@ -40,7 +40,8 @@
     "node": ">=16"
   },
   "bin": {
-    "hs": "./bin/hs"
+    "hs": "./bin/hs",
+    "hscms": "./bin/hscms"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/HubSpot/hubspot-cms-tools"
+    "url": "https://github.com/HubSpot/hubspot-cli"
   },
   "dependencies": {
     "@hubspot/local-dev-lib": "1.6.0",
@@ -40,8 +40,7 @@
     "node": ">=16"
   },
   "bin": {
-    "hs": "./bin/hs",
-    "hscms": "./bin/hscms"
+    "hs": "./bin/hs"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/webpack-cms-plugins/package.json
+++ b/packages/webpack-cms-plugins/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/HubSpot/hubspot-cms-tools"
+    "url": "https://github.com/HubSpot/hubspot-cli"
   },
   "engines": {
     "node": ">=10"


### PR DESCRIPTION
## Description and Context
I was poking around and noticed we had some references to what I presume is the old name of this repo. Cleaned those up. Also wasn't sure what to use as the name for the monorepo package.json so went with `hubspot-local-dev-tools`. We could also just call it `hubspot-cli` too. It's not a published package so I don't think it matters a ton.

## Who to Notify
@joe-yeager @kemmerle @brandenrodgers 
