### PR TITLE
Hide undeployable components from build/deploy polling

### DIFF
--- a/packages/cli/lib/projects.js
+++ b/packages/cli/lib/projects.js
@@ -22,7 +22,7 @@ const {
 const {
   createProject,
   getBuildStatus,
-  getBuildStructure,
+  getBuildDisplayStructure,
   getDeployStatus,
   getDeployStructure,
   fetchProject,
@@ -854,7 +854,7 @@ const pollBuildStatus = makePollTaskStatusFunc({
       getProjectBuildDetailUrl(taskName, taskId, accountId)
     ),
   statusFn: getBuildStatus,
-  structureFn: getBuildStructure,
+  structureFn: getBuildDisplayStructure,
   statusText: PROJECT_BUILD_TEXT,
   statusStrings: {
     INITIALIZE: (name, buildId) => `Building ${chalk.bold(name)} #${buildId}`,

--- a/packages/cli/lib/projects.js
+++ b/packages/cli/lib/projects.js
@@ -22,7 +22,7 @@ const {
 const {
   createProject,
   getBuildStatus,
-  getBuildDisplayStructure,
+  getBuildStructure,
   getDeployStatus,
   getDeployStructure,
   fetchProject,
@@ -635,9 +635,9 @@ const makePollTaskStatusFunc = ({
 
     const tasksById = initialTaskStatus[statusText.SUBTASK_KEY].reduce(
       (acc, task) => {
-        const type = task[statusText.TYPE_KEY];
-        if (type !== 'APP_ID' && type !== 'SERVERLESS_PKG') {
-          acc[task.id] = task;
+        const { id, visible } = task;
+        if (visible) {
+          acc[id] = task;
         }
         return acc;
       },
@@ -854,7 +854,7 @@ const pollBuildStatus = makePollTaskStatusFunc({
       getProjectBuildDetailUrl(taskName, taskId, accountId)
     ),
   statusFn: getBuildStatus,
-  structureFn: getBuildDisplayStructure,
+  structureFn: getBuildStructure,
   statusText: PROJECT_BUILD_TEXT,
   statusStrings: {
     INITIALIZE: (name, buildId) => `Building ${chalk.bold(name)} #${buildId}`,


### PR DESCRIPTION
## Description and Context
This uses the new `visible` flag on subcomponent data from the build/deploy status endpoints to hide components that are not deployable during build/deploy polling in `hs project upload`.

See https://git.hubteam.com/HubSpot/hubspot-cli-issues/issues/459

## Screenshots
Before
<img width="543" alt="Screenshot 2024-07-16 at 10 41 05 AM" src="https://github.com/user-attachments/assets/5571bb4f-a1f1-4b2b-893f-cf6706d981a1">

After
<img width="554" alt="Screenshot 2024-07-16 at 10 41 21 AM" src="https://github.com/user-attachments/assets/f5f0e7d9-1f84-42a4-86d4-f5fa20c7de4b">


## Who to Notify
@brandenrodgers @kemmerle @joe-yeager 
