### PR TITLE
Fix bug app migration restrictions

### DIFF
--- a/packages/cli/commands/project/cloneApp.js
+++ b/packages/cli/commands/project/cloneApp.js
@@ -77,7 +77,7 @@ exports.handler = async options => {
         accountId,
         accountName,
         options,
-        migrateApp: false,
+        isMigratingApp: false,
       });
       appId = appIdResponse.appId;
     }

--- a/packages/cli/commands/project/migrateApp.js
+++ b/packages/cli/commands/project/migrateApp.js
@@ -85,7 +85,8 @@ exports.handler = async options => {
   let appName;
   try {
     const selectedApp = await fetchPublicAppMetadata(appId, accountId);
-    if (selectedApp.preventProjectMigrations) {
+    const { preventProjectMigrations, listingInfo } = selectedApp;
+    if (preventProjectMigrations && listingInfo) {
       logger.error(i18n(`${i18nKey}.errors.invalidApp`, { appId }));
       process.exit(EXIT_CODES.ERROR);
     }

--- a/packages/cli/commands/project/migrateApp.js
+++ b/packages/cli/commands/project/migrateApp.js
@@ -85,6 +85,8 @@ exports.handler = async options => {
   let appName;
   try {
     const selectedApp = await fetchPublicAppMetadata(appId, accountId);
+    // preventProjectMigrations returns true if we have not added app to allowlist config.
+    // listingInfo will only exist for marketplace apps
     const { preventProjectMigrations, listingInfo } = selectedApp;
     if (preventProjectMigrations && listingInfo) {
       logger.error(i18n(`${i18nKey}.errors.invalidApp`, { appId }));

--- a/packages/cli/commands/project/migrateApp.js
+++ b/packages/cli/commands/project/migrateApp.js
@@ -79,7 +79,7 @@ exports.handler = async options => {
       : await selectPublicAppPrompt({
           accountId,
           accountName,
-          migrateApp: true,
+          isMigratingApp: true,
         });
 
   let appName;

--- a/packages/cli/lib/prompts/selectPublicAppPrompt.js
+++ b/packages/cli/lib/prompts/selectPublicAppPrompt.js
@@ -13,7 +13,7 @@ const i18nKey = 'lib.prompts.selectPublicAppPrompt';
 const fetchPublicAppOptions = async (
   accountId,
   accountName,
-  migrateApp = false
+  isMigratingApp = false
 ) => {
   try {
     const publicApps = await fetchPublicAppsForPortal(accountId);
@@ -23,15 +23,15 @@ const fetchPublicAppOptions = async (
 
     if (
       !filteredPublicApps.length ||
-      (migrateApp &&
-        !filteredPublicApps.find(
+      (isMigratingApp &&
+        !filteredPublicApps.some(
           app => !app.preventProjectMigrations || !app.listingInfo
         ))
     ) {
-      const headerTranslationKey = migrateApp
+      const headerTranslationKey = isMigratingApp
         ? 'noAppsMigration'
         : 'noAppsClone';
-      const messageTranslationKey = migrateApp
+      const messageTranslationKey = isMigratingApp
         ? 'noAppsMigrationMessage'
         : 'noAppsCloneMessage';
       uiLine();
@@ -53,14 +53,16 @@ const fetchPublicAppOptions = async (
 const selectPublicAppPrompt = async ({
   accountId,
   accountName,
-  migrateApp = false,
+  isMigratingApp = false,
 }) => {
   const publicApps = await fetchPublicAppOptions(
     accountId,
     accountName,
-    migrateApp
+    isMigratingApp
   );
-  const translationKey = migrateApp ? 'selectAppIdMigrate' : 'selectAppIdClone';
+  const translationKey = isMigratingApp
+    ? 'selectAppIdMigrate'
+    : 'selectAppIdClone';
 
   return promptUser([
     {
@@ -71,7 +73,7 @@ const selectPublicAppPrompt = async ({
       type: 'list',
       choices: publicApps.map(app => {
         const { preventProjectMigrations, listingInfo } = app;
-        if (migrateApp && preventProjectMigrations && listingInfo) {
+        if (isMigratingApp && preventProjectMigrations && listingInfo) {
           return {
             name: `${app.name} (${app.id})`,
             disabled: i18n(`${i18nKey}.errors.cannotBeMigrated`),


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->

I was incorrectly determining how to restrict public apps from being migrated. I was only using the `preventProjectMigration` property to determine whether to allow migration, when I should have been using the `preventProjectMigration` property in tandem with the `listingInfo` property. 

The `listingInfo` property exists for apps that are currently posted to the marketplace.
The `preventProjectMigrations` property returns `true` if the apps team has not added this app to their allowlist config. This extra buffer is in place to allow us to review apps before they get migrated and posted to the marketplace.

## Testing
<!-- Provide images of the before and after functionality -->
You can JITA into my test account (Will provide details on Slack) to test out the PR. 

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

- [x] Address any feedback
- [x] TEST

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@brandenrodgers @camden11 @robrown-hubspot 
