### PR TITLE
Fix project commands declaration

### DIFF
--- a/packages/cli/commands/project.js
+++ b/packages/cli/commands/project.js
@@ -23,19 +23,20 @@ exports.builder = yargs => {
   addConfigOptions(yargs);
   addAccountOptions(yargs);
 
-  // TODO: deploy must be updated
-  yargs.command(create).demandCommand(0, '');
-  yargs.command(add).demandCommand(0, '');
-  yargs.command(watch).demandCommand(0, '');
-  yargs.command(dev).demandCommand(0, '');
-  yargs.command(upload).demandCommand(0, '');
-  yargs.command(deploy).demandCommand(1, '');
-  yargs.command(logs).demandCommand(1, '');
-  yargs.command(listBuilds).demandCommand(0, '');
-  yargs.command(download).demandCommand(0, '');
-  yargs.command(open).demandCommand(0, '');
-  yargs.command(migrateApp).demandCommand(0, '');
-  yargs.command(cloneApp).demandCommand(0, '');
+  yargs
+    .command(create)
+    .command(add)
+    .command(watch)
+    .command(dev)
+    .command(upload)
+    .command(deploy)
+    .command(logs)
+    .command(listBuilds)
+    .command(download)
+    .command(open)
+    .command(migrateApp)
+    .command(cloneApp)
+    .demandCommand(1, '');
 
   return yargs;
 };


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
We were not following the pattern defined in our other commands. We define subcommands using the pattern `yargs.command(subcommand).demandCommand(1, '')`.

The result of this is a more useful CLI output when the user runs `hs project` without specifying any subcommands. The empty string is necessary because the `demandCommand()` function requires two arguments. Using an empty string forces it to fall back to logging out the `--help` output.

## Screenshots
<!-- Provide images of the before and after functionality -->
### Before
<img width="470" alt="image" src="https://github.com/user-attachments/assets/dfa941b6-bce8-4cde-8e2e-989711f5a11d">

### After
<img width="784" alt="image" src="https://github.com/user-attachments/assets/425b89bb-149b-4a62-9400-c4befeba691d">

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
