### PR TITLE
Active install warning without delay

### DIFF
--- a/packages/cli/lib/LocalDevManager.js
+++ b/packages/cli/lib/LocalDevManager.js
@@ -9,7 +9,7 @@ const {
 } = require('@hubspot/local-dev-lib/api/localDevAuth');
 const {
   fetchPublicAppsForPortal,
-  fetchPublicAppDeveloperTestAccountInstallData,
+  fetchPublicAppProductionInstallCounts,
 } = require('@hubspot/local-dev-lib/api/appsDev');
 const {
   getAccountId,
@@ -138,17 +138,16 @@ class LocalDevManager {
       ({ sourceId }) => sourceId === this.activeApp.config.uid
     );
 
+    // TODO: Update to account for new API with { data }
     const {
-      testPortalInstallCount,
-    } = await fetchPublicAppDeveloperTestAccountInstallData(
+      uniquePortalInstallCount,
+    } = await fetchPublicAppProductionInstallCounts(
       activePublicAppData.id,
       this.targetProjectAccountId
     );
 
     this.activePublicAppData = activePublicAppData;
-    this.publicAppActiveInstalls =
-      activePublicAppData.publicApplicationInstallCounts
-        .uniquePortalInstallCount - testPortalInstallCount;
+    this.publicAppActiveInstalls = uniquePortalInstallCount;
   }
 
   async checkActivePublicAppInstalls() {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/HubSpot/hubspot-cms-tools"
   },
   "dependencies": {
-    "@hubspot/local-dev-lib": "1.9.0",
+    "@hubspot/local-dev-lib": "1.9.1",
     "@hubspot/serverless-dev-runtime": "5.2.1-beta.11",
     "@hubspot/theme-preview-dev-server": "0.0.7",
     "@hubspot/ui-extensions-dev-server": "0.8.20",

--- a/packages/serverless-dev-runtime/package.json
+++ b/packages/serverless-dev-runtime/package.json
@@ -6,7 +6,7 @@
   "repository": "https://github.com/HubSpot/hubspot-cli",
   "license": "Apache-2.0",
   "dependencies": {
-    "@hubspot/local-dev-lib": "1.9.0",
+    "@hubspot/local-dev-lib": "1.9.1",
     "body-parser": "^1.19.0",
     "chalk": "^4.1.0",
     "chokidar": "^3.4.3",

--- a/packages/webpack-cms-plugins/package.json
+++ b/packages/webpack-cms-plugins/package.json
@@ -17,7 +17,7 @@
     "test": "echo \"Error: run tests from root\" && exit 1"
   },
   "dependencies": {
-    "@hubspot/local-dev-lib": "1.9.0"
+    "@hubspot/local-dev-lib": "1.9.1"
   },
   "gitHead": "0659fd19cabc3645af431b177c11d0c1b089e0f8"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -473,10 +473,10 @@
     express "^4.18.2"
     uuid "^9.0.1"
 
-"@hubspot/local-dev-lib@1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@hubspot/local-dev-lib/-/local-dev-lib-1.9.0.tgz#857875eb744e8d86e2008494ecb2628385cc4784"
-  integrity sha512-PLWLn6W5dhjWijieMi9xJBxDOu6YQzy7jFPrSX5BhHlJHtyJai0px2xLm3oTSfoG4jaLH2lhgTQzmtYEfJ5h2Q==
+"@hubspot/local-dev-lib@1.9.1":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@hubspot/local-dev-lib/-/local-dev-lib-1.9.1.tgz#4417a5d15af4cd93d5e7d2c4ff870f550e916a56"
+  integrity sha512-UhTE+nFU+PP6cZLiE05yMxxmdMpH9R3mTT2WhuHQhsyZNXDVxU/TNqeJ2qity9Cjcng6fnOHkCJK3+z0wKKVPw==
   dependencies:
     address "^2.0.1"
     axios "^1.3.5"


### PR DESCRIPTION
## Description and Context
Previously, we were using the `apps-dev/external/public/v3/full/portal` and `apps-dev/external/public/v3/{appId}/test-portal-installs` endpoints to determine the number of active installs a public app has. These endpoints both have a 30ish minute delay in calculating installs, which could result in inaccurate numbers or not showing the active install warning when it should be shown. This updates the CLI to use the new `/install-counts-without-test-portals`, which does not have a delay. 

## Who to Notify
@brandenrodgers @kemmerle @joe-yeager 
