### PR TITLE
chore: Switch developerTestAccount & sandbox usages from `lib` to `api`

### DIFF
--- a/packages/cli/commands/sandbox/delete.js
+++ b/packages/cli/commands/sandbox/delete.js
@@ -10,7 +10,7 @@ const { trackCommandUsage } = require('../../lib/usageTracking');
 const { loadAndValidateOptions } = require('../../lib/validation');
 const { logError, debugError } = require('../../lib/errorHandlers/index');
 const { isSpecifiedError } = require('@hubspot/local-dev-lib/errors/index');
-const { deleteSandbox } = require('@hubspot/local-dev-lib/sandboxes');
+const { deleteSandbox } = require('@hubspot/local-dev-lib/api/sandboxHubs');
 const { i18n } = require('../../lib/lang');
 const { deleteSandboxPrompt } = require('../../lib/prompts/sandboxesPrompt');
 const {

--- a/packages/cli/lib/buildAccount.js
+++ b/packages/cli/lib/buildAccount.js
@@ -22,7 +22,7 @@ const {
 const {
   HUBSPOT_ACCOUNT_TYPES,
 } = require('@hubspot/local-dev-lib/constants/config');
-const { createSandbox } = require('@hubspot/local-dev-lib/sandboxes');
+const { createSandbox } = require('@hubspot/local-dev-lib/api/sandboxHubs');
 const { sandboxApiTypeMap, handleSandboxCreateError } = require('./sandboxes');
 const {
   handleDeveloperTestAccountCreateError,
@@ -131,7 +131,9 @@ async function buildNewAccount({
   try {
     if (isSandbox) {
       const sandboxApiType = sandboxApiTypeMap[accountType]; // API expects sandbox type as 1 or 2.
-      result = await createSandbox(accountId, name, sandboxApiType);
+
+      const { data } = await createSandbox(accountId, name, sandboxApiType);
+      result = { name, ...data };
       resultAccountId = result.sandbox.sandboxHubId;
     } else if (isDeveloperTestAccount) {
       const { data } = await createDeveloperTestAccount(accountId, name);

--- a/packages/cli/lib/buildAccount.js
+++ b/packages/cli/lib/buildAccount.js
@@ -18,7 +18,7 @@ const SpinniesManager = require('./ui/SpinniesManager');
 const { debugError, logError } = require('./errorHandlers/index');
 const {
   createDeveloperTestAccount,
-} = require('@hubspot/local-dev-lib/developerTestAccounts');
+} = require('@hubspot/local-dev-lib/api/developerTestAccounts');
 const {
   HUBSPOT_ACCOUNT_TYPES,
 } = require('@hubspot/local-dev-lib/constants/config');
@@ -134,8 +134,8 @@ async function buildNewAccount({
       result = await createSandbox(accountId, name, sandboxApiType);
       resultAccountId = result.sandbox.sandboxHubId;
     } else if (isDeveloperTestAccount) {
-      result = await createDeveloperTestAccount(accountId, name);
-      resultAccountId = result.id;
+      const { data } = await createDeveloperTestAccount(accountId, name);
+      resultAccountId = data.id;
     }
 
     SpinniesManager.succeed('buildNewAccount', {

--- a/packages/cli/lib/buildAccount.js
+++ b/packages/cli/lib/buildAccount.js
@@ -135,7 +135,8 @@ async function buildNewAccount({
       resultAccountId = result.sandbox.sandboxHubId;
     } else if (isDeveloperTestAccount) {
       const { data } = await createDeveloperTestAccount(accountId, name);
-      resultAccountId = data.id;
+      result = data;
+      resultAccountId = result.id;
     }
 
     SpinniesManager.succeed('buildNewAccount', {

--- a/packages/cli/lib/developerTestAccounts.js
+++ b/packages/cli/lib/developerTestAccounts.js
@@ -5,7 +5,7 @@ const { getAccountId, getConfig } = require('@hubspot/local-dev-lib/config');
 const { i18n } = require('./lang');
 const {
   fetchDeveloperTestAccounts,
-} = require('@hubspot/local-dev-lib/developerTestAccounts');
+} = require('@hubspot/local-dev-lib/api/developerTestAccounts');
 const {
   isMissingScopeError,
   isSpecifiedError,
@@ -32,31 +32,31 @@ const getHasDevTestAccounts = appDeveloperAccountConfig => {
 
 const validateDevTestAccountUsageLimits = async accountConfig => {
   const accountId = getAccountId(accountConfig.portalId);
-  const response = await fetchDeveloperTestAccounts(accountId);
-  if (response) {
-    const limit = response.maxTestPortals;
-    const count = response.results.length;
-    if (count >= limit) {
-      const hasDevTestAccounts = getHasDevTestAccounts(accountConfig);
-      if (hasDevTestAccounts) {
-        throw new Error(
-          i18n('lib.developerTestAccount.create.failure.alreadyInConfig', {
-            accountName: accountConfig.name || accountId,
-            limit,
-          })
-        );
-      } else {
-        throw new Error(
-          i18n('lib.developerTestAccount.create.failure.limit', {
-            accountName: accountConfig.name || accountId,
-            limit,
-          })
-        );
-      }
-    }
-    return response;
+  const { data } = await fetchDeveloperTestAccounts(accountId);
+  if (!data) {
+    return null;
   }
-  return null;
+  const limit = data.maxTestPortals;
+  const count = data.results.length;
+  if (count >= limit) {
+    const hasDevTestAccounts = getHasDevTestAccounts(accountConfig);
+    if (hasDevTestAccounts) {
+      throw new Error(
+        i18n('lib.developerTestAccount.create.failure.alreadyInConfig', {
+          accountName: accountConfig.name || accountId,
+          limit,
+        })
+      );
+    } else {
+      throw new Error(
+        i18n('lib.developerTestAccount.create.failure.limit', {
+          accountName: accountConfig.name || accountId,
+          limit,
+        })
+      );
+    }
+  }
+  return data;
 };
 
 function handleDeveloperTestAccountCreateError({

--- a/packages/cli/lib/prompts/projectDevTargetAccountPrompt.js
+++ b/packages/cli/lib/prompts/projectDevTargetAccountPrompt.js
@@ -11,7 +11,7 @@ const {
 const { logger } = require('@hubspot/local-dev-lib/logger');
 const {
   fetchDeveloperTestAccounts,
-} = require('@hubspot/local-dev-lib/developerTestAccounts');
+} = require('@hubspot/local-dev-lib/api/developerTestAccounts');
 
 const i18nKey = 'lib.prompts.projectDevTargetAccountPrompt';
 
@@ -102,9 +102,8 @@ const selectDeveloperTestTargetAccountPrompt = async (
   let choices = [];
   let devTestAccountsResponse = undefined;
   try {
-    devTestAccountsResponse = await fetchDeveloperTestAccounts(
-      defaultAccountId
-    );
+    const { data } = await fetchDeveloperTestAccounts(defaultAccountId);
+    devTestAccountsResponse = data;
   } catch (err) {
     logger.debug('Unable to fetch developer test account usage limits: ', err);
   }

--- a/packages/cli/lib/prompts/projectDevTargetAccountPrompt.js
+++ b/packages/cli/lib/prompts/projectDevTargetAccountPrompt.js
@@ -3,7 +3,9 @@ const { i18n } = require('../lang');
 const { uiAccountDescription, uiCommandReference } = require('../ui');
 const { isSandbox, isDeveloperTestAccount } = require('../accountTypes');
 const { getAccountId } = require('@hubspot/local-dev-lib/config');
-const { getSandboxUsageLimits } = require('@hubspot/local-dev-lib/sandboxes');
+const {
+  getSandboxUsageLimits,
+} = require('@hubspot/local-dev-lib/api/sandboxHubs');
 const {
   HUBSPOT_ACCOUNT_TYPES,
   HUBSPOT_ACCOUNT_TYPE_STRINGS,
@@ -38,7 +40,8 @@ const selectSandboxTargetAccountPrompt = async (
   let choices = [];
   let sandboxUsage = {};
   try {
-    sandboxUsage = await getSandboxUsageLimits(defaultAccountId);
+    const { data } = await getSandboxUsageLimits(defaultAccountId);
+    sandboxUsage = data.usage;
   } catch (err) {
     logger.debug('Unable to fetch sandbox usage limits: ', err);
   }

--- a/packages/cli/lib/sandboxSync.js
+++ b/packages/cli/lib/sandboxSync.js
@@ -3,7 +3,7 @@ const { getHubSpotWebsiteOrigin } = require('@hubspot/local-dev-lib/urls');
 const { logger } = require('@hubspot/local-dev-lib/logger');
 const { i18n } = require('./lang');
 const { getAvailableSyncTypes } = require('./sandboxes');
-const { initiateSync } = require('@hubspot/local-dev-lib/sandboxes');
+const { initiateSync } = require('@hubspot/local-dev-lib/api/sandboxSync');
 const { debugError, logError } = require('./errorHandlers/index');
 const {
   isSpecifiedError,

--- a/packages/cli/lib/sandboxes.js
+++ b/packages/cli/lib/sandboxes.js
@@ -1,9 +1,9 @@
 const { i18n } = require('./lang');
 const { logger } = require('@hubspot/local-dev-lib/logger');
 const {
-  fetchTypes,
   getSandboxUsageLimits,
-} = require('@hubspot/local-dev-lib/sandboxes');
+} = require('@hubspot/local-dev-lib/api/sandboxHubs');
+const { fetchTypes } = require('@hubspot/local-dev-lib/api/sandboxSync');
 const {
   getConfig,
   getAccountId,
@@ -73,7 +73,9 @@ function getSandboxLimit(error) {
 async function getAvailableSyncTypes(parentAccountConfig, config) {
   const parentPortalId = getAccountId(parentAccountConfig.portalId);
   const portalId = getAccountId(config.portalId);
-  const syncTypes = await fetchTypes(parentPortalId, portalId);
+  const {
+    data: { results: syncTypes },
+  } = await fetchTypes(parentPortalId, portalId);
   if (!syncTypes) {
     throw new Error(
       'Unable to fetch available sandbox sync types. Please try again.'
@@ -126,7 +128,9 @@ const getSyncTypesWithContactRecordsPrompt = async (
  */
 const validateSandboxUsageLimits = async (accountConfig, sandboxType, env) => {
   const accountId = getAccountId(accountConfig.portalId);
-  const usage = await getSandboxUsageLimits(accountId);
+  const {
+    data: { usage },
+  } = await getSandboxUsageLimits(accountId);
   if (!usage) {
     throw new Error('Unable to fetch sandbox usage limits. Please try again.');
   }


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
- Switches to use `api/developerTestAccounts.ts` instead of `lib/developerTestAccounts.ts` because we are deprecating `lib/developerTestAccounts.ts` because it is a very thin wrapper and we can directly use `api/developerTestAccounts.ts`
- Switches usages of `lib/sandboxes.ts` to `api/sandboxHubs` and `api/sandboxSync`

Companion PR: https://github.com/HubSpot/hubspot-local-dev-lib/pull/178

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@kemmerle @adamawang @camden11 @brandenrodgers 