### PR TITLE
Chore: Add detailed usage tracking to migration commands

### DIFF
--- a/packages/cli/commands/project/cloneApp.js
+++ b/packages/cli/commands/project/cloneApp.js
@@ -39,6 +39,9 @@ const { getCwd } = require('@hubspot/local-dev-lib/path');
 const { logger } = require('@hubspot/local-dev-lib/logger');
 const { getAccountConfig } = require('@hubspot/local-dev-lib/config');
 const { extractZipArchive } = require('@hubspot/local-dev-lib/archive');
+const {
+  fetchPublicAppMetadata,
+} = require('@hubspot/local-dev-lib/api/appsDev');
 
 const i18nKey = 'commands.project.subcommands.cloneApp';
 
@@ -79,7 +82,15 @@ exports.handler = async options => {
       });
       appId = appIdResponse.appId;
     }
-    trackCommandMetadataUsage('clone-app', { appId }, accountId);
+    const selectedApp = await fetchPublicAppMetadata(appId, accountId);
+    // preventProjectMigrations returns true if we have not added app to allowlist config.
+    // listingInfo will only exist for marketplace apps
+    const { preventProjectMigrations, listingInfo } = selectedApp;
+    trackCommandMetadataUsage(
+      'clone-app',
+      { appId, preventProjectMigrations, listingInfo },
+      accountId
+    );
 
     const projectResponse = await createProjectPrompt('', options, true);
     name = projectResponse.name;

--- a/packages/cli/commands/project/cloneApp.js
+++ b/packages/cli/commands/project/cloneApp.js
@@ -133,6 +133,7 @@ exports.handler = async options => {
       };
       const success = writeProjectConfig(configPath, configContent);
 
+      const isListed = Boolean(listingInfo);
       trackCommandMetadataUsage(
         'clone-app',
         {
@@ -140,7 +141,7 @@ exports.handler = async options => {
           appId,
           status,
           preventProjectMigrations,
-          listingInfo,
+          isListed,
         },
         accountId
       );

--- a/packages/cli/commands/project/migrateApp.js
+++ b/packages/cli/commands/project/migrateApp.js
@@ -80,14 +80,17 @@ exports.handler = async options => {
           isMigratingApp: true,
         });
 
-  trackCommandMetadataUsage('migrate-app', { appId }, accountId);
-
   let appName;
   try {
     const selectedApp = await fetchPublicAppMetadata(appId, accountId);
     // preventProjectMigrations returns true if we have not added app to allowlist config.
     // listingInfo will only exist for marketplace apps
     const { preventProjectMigrations, listingInfo } = selectedApp;
+    trackCommandMetadataUsage(
+      'migrate-app',
+      { appId, preventProjectMigrations, listingInfo },
+      accountId
+    );
     if (preventProjectMigrations && listingInfo) {
       logger.error(i18n(`${i18nKey}.errors.invalidApp`, { appId }));
       process.exit(EXIT_CODES.ERROR);

--- a/packages/cli/commands/project/migrateApp.js
+++ b/packages/cli/commands/project/migrateApp.js
@@ -5,7 +5,10 @@ const {
   getAccountId,
   addUseEnvironmentOptions,
 } = require('../../lib/commonOpts');
-const { trackCommandMetadataUsage } = require('../../lib/usageTracking');
+const {
+  trackCommandUsage,
+  trackCommandMetadataUsage,
+} = require('../../lib/usageTracking');
 const { loadAndValidateOptions } = require('../../lib/validation');
 const {
   createProjectPrompt,
@@ -58,6 +61,8 @@ exports.handler = async options => {
   const accountConfig = getAccountConfig(accountId);
   const accountName = uiAccountDescription(accountId);
 
+  trackCommandUsage('migrate-app', {}, accountId);
+
   if (!isAppDeveloperAccount(accountConfig)) {
     uiLine();
     logger.error(i18n(`${i18nKey}.errors.invalidAccountTypeTitle`));
@@ -81,16 +86,14 @@ exports.handler = async options => {
         });
 
   let appName;
+  let preventProjectMigrations;
+  let listingInfo;
   try {
     const selectedApp = await fetchPublicAppMetadata(appId, accountId);
     // preventProjectMigrations returns true if we have not added app to allowlist config.
     // listingInfo will only exist for marketplace apps
-    const { preventProjectMigrations, listingInfo } = selectedApp;
-    trackCommandMetadataUsage(
-      'migrate-app',
-      { appId, preventProjectMigrations, listingInfo },
-      accountId
-    );
+    preventProjectMigrations = selectedApp.preventProjectMigrations;
+    listingInfo = selectedApp.listingInfo;
     if (preventProjectMigrations && listingInfo) {
       logger.error(i18n(`${i18nKey}.errors.invalidApp`, { appId }));
       process.exit(EXIT_CODES.ERROR);
@@ -190,7 +193,7 @@ exports.handler = async options => {
 
       trackCommandMetadataUsage(
         'migrate-app',
-        { projectName, appId, status },
+        { projectName, appId, status, preventProjectMigrations, listingInfo },
         accountId
       );
 

--- a/packages/cli/commands/project/migrateApp.js
+++ b/packages/cli/commands/project/migrateApp.js
@@ -5,7 +5,7 @@ const {
   getAccountId,
   addUseEnvironmentOptions,
 } = require('../../lib/commonOpts');
-const { trackCommandUsage } = require('../../lib/usageTracking');
+const { trackCommandMetadataUsage } = require('../../lib/usageTracking');
 const { loadAndValidateOptions } = require('../../lib/validation');
 const {
   createProjectPrompt,
@@ -58,8 +58,6 @@ exports.handler = async options => {
   const accountConfig = getAccountConfig(accountId);
   const accountName = uiAccountDescription(accountId);
 
-  trackCommandUsage('migrate-app', {}, accountId);
-
   if (!isAppDeveloperAccount(accountConfig)) {
     uiLine();
     logger.error(i18n(`${i18nKey}.errors.invalidAccountTypeTitle`));
@@ -81,6 +79,8 @@ exports.handler = async options => {
           accountName,
           isMigratingApp: true,
         });
+
+  trackCommandMetadataUsage('migrate-app', { appId }, accountId);
 
   let appName;
   try {
@@ -185,6 +185,12 @@ exports.handler = async options => {
         { includesRootDir: true, hideLogs: true }
       );
 
+      trackCommandMetadataUsage(
+        'migrate-app',
+        { projectName, appId, status },
+        accountId
+      );
+
       SpinniesManager.succeed('migrateApp', {
         text: i18n(`${i18nKey}.migrationStatus.done`),
         succeedColor: 'white',
@@ -202,6 +208,11 @@ exports.handler = async options => {
       process.exit(EXIT_CODES.SUCCESS);
     }
   } catch (error) {
+    trackCommandMetadataUsage(
+      'migrate-app',
+      { projectName, appId, status: 'FAILURE', error },
+      accountId
+    );
     SpinniesManager.fail('migrateApp', {
       text: i18n(`${i18nKey}.migrationStatus.failure`),
       failColor: 'white',

--- a/packages/cli/commands/project/migrateApp.js
+++ b/packages/cli/commands/project/migrateApp.js
@@ -191,9 +191,10 @@ exports.handler = async options => {
         { includesRootDir: true, hideLogs: true }
       );
 
+      const isListed = Boolean(listingInfo);
       trackCommandMetadataUsage(
         'migrate-app',
-        { projectName, appId, status, preventProjectMigrations, listingInfo },
+        { projectName, appId, status, preventProjectMigrations, isListed },
         accountId
       );
 


### PR DESCRIPTION
## Description and Context
We are adding more detailed usage tracking to the `migrate-app` and `clone-app` commands. In both commands, I have added three tracking events:

1) When the command is initially run, I've added an event after the `appId` is selected. **I am wondering whether I should add any other metadata here.** 

2) When the command succeeds, I've added an event where I've included the project name, app id, and status.

3) When the command fails, I've added an event where I've included the project name, app id, status, and error.

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

- [x] Get feedback from Product folks (Laurie) 

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@brandenrodgers @camden11 @joe-yeager 
