### PR TITLE
Fixing project deploy command

### DIFF
--- a/packages/cli/commands/project/__tests__/deploy.test.js
+++ b/packages/cli/commands/project/__tests__/deploy.test.js
@@ -5,7 +5,7 @@ jest.mock('@hubspot/local-dev-lib/api/projects');
 jest.mock('../../../lib/validation');
 jest.mock('../../../lib/projects');
 jest.mock('../../../lib/prompts/projectNamePrompt');
-jest.mock('../../../lib/prompts/buildIdPrompt');
+jest.mock('../../../lib/prompts/deployBuildIdPrompt');
 jest.mock('@hubspot/local-dev-lib/config');
 jest.mock('../../../lib/usageTracking');
 jest.mock('../../../lib/ui');
@@ -45,7 +45,9 @@ const {
   getProjectDetailUrl,
 } = require('../../../lib/projects');
 const { projectNamePrompt } = require('../../../lib/prompts/projectNamePrompt');
-const { buildIdPrompt } = require('../../../lib/prompts/buildIdPrompt');
+const {
+  deployBuildIdPrompt,
+} = require('../../../lib/prompts/deployBuildIdPrompt');
 const { getAccountConfig } = require('@hubspot/local-dev-lib/config');
 
 const yargs = require('yargs');
@@ -163,7 +165,7 @@ describe('commands/project/deploy', () => {
       getAccountConfig.mockReturnValue({ accountType });
       fetchProject.mockResolvedValue(projectDetails);
       deployProject.mockResolvedValue(deployDetails);
-      buildIdPrompt.mockResolvedValue({
+      deployBuildIdPrompt.mockResolvedValue({
         buildId: projectDetails.latestBuild.buildId,
       });
 
@@ -294,8 +296,8 @@ describe('commands/project/deploy', () => {
     it('should prompt for build id if no option is provided', async () => {
       delete options.buildId;
       await handler(options);
-      expect(buildIdPrompt).toHaveBeenCalledTimes(1);
-      expect(buildIdPrompt).toHaveBeenCalledWith(
+      expect(deployBuildIdPrompt).toHaveBeenCalledTimes(1);
+      expect(deployBuildIdPrompt).toHaveBeenCalledWith(
         projectDetails.latestBuild.buildId,
         projectDetails.deployedBuildId,
         options.project,
@@ -305,11 +307,11 @@ describe('commands/project/deploy', () => {
 
     it('should log an error and exit if the prompted value is invalid', async () => {
       delete options.buildId;
-      buildIdPrompt.mockReturnValue({});
+      deployBuildIdPrompt.mockReturnValue({});
 
       await handler(options);
 
-      expect(buildIdPrompt).toHaveBeenCalledTimes(1);
+      expect(deployBuildIdPrompt).toHaveBeenCalledTimes(1);
       expect(logger.error).toHaveBeenCalledTimes(1);
       expect(logger.error).toHaveBeenCalledWith(
         'You must specify a build to deploy'

--- a/packages/cli/commands/project/__tests__/deploy.test.js
+++ b/packages/cli/commands/project/__tests__/deploy.test.js
@@ -60,8 +60,8 @@ const chalk = require('chalk');
 
 describe('commands/project/deploy', () => {
   const projectFlag = 'project';
-  const buildFlag = 'buildId';
-  const buildAliases = ['build'];
+  const buildFlag = 'build';
+  const buildAliases = ['buildId'];
 
   describe('describe', () => {
     it('should contain the beta tag', () => {

--- a/packages/cli/commands/project/__tests__/deploy.test.js
+++ b/packages/cli/commands/project/__tests__/deploy.test.js
@@ -300,7 +300,6 @@ describe('commands/project/deploy', () => {
       expect(deployBuildIdPrompt).toHaveBeenCalledWith(
         projectDetails.latestBuild.buildId,
         projectDetails.deployedBuildId,
-        options.project,
         expect.any(Function)
       );
     });

--- a/packages/cli/commands/project/deploy.js
+++ b/packages/cli/commands/project/deploy.js
@@ -22,7 +22,9 @@ const {
   getProjectDetailUrl,
 } = require('../../lib/projects');
 const { projectNamePrompt } = require('../../lib/prompts/projectNamePrompt');
-const { buildIdPrompt } = require('../../lib/prompts/buildIdPrompt');
+const {
+  deployBuildIdPrompt,
+} = require('../../lib/prompts/deployBuildIdPrompt');
 const { i18n } = require('../../lib/lang');
 const { uiBetaTag, uiLink } = require('../../lib/ui');
 const { getAccountConfig } = require('@hubspot/local-dev-lib/config');
@@ -115,20 +117,19 @@ exports.handler = async options => {
         return process.exit(EXIT_CODES.ERROR);
       }
     } else {
-      const buildIdPromptResponse = await buildIdPrompt(
+      const deployBuildIdPromptResponse = await deployBuildIdPrompt(
         latestBuild.buildId,
         deployedBuildId,
-        projectName,
         buildId =>
           validateBuildId(
             buildId,
-            latestBuild.buildId,
             deployedBuildId,
+            latestBuild.buildId,
             projectName,
             accountId
           )
       );
-      buildIdToDeploy = buildIdPromptResponse.buildId;
+      buildIdToDeploy = deployBuildIdPromptResponse.buildId;
     }
 
     if (!buildIdToDeploy) {
@@ -181,9 +182,9 @@ exports.builder = yargs => {
       describe: i18n(`${i18nKey}.options.project.describe`),
       type: 'string',
     },
-    buildId: {
-      alias: ['build'],
-      describe: i18n(`${i18nKey}.options.buildId.describe`),
+    build: {
+      alias: ['buildId'],
+      describe: i18n(`${i18nKey}.options.build.describe`),
       type: 'number',
     },
   });
@@ -191,7 +192,7 @@ exports.builder = yargs => {
   yargs.example([
     ['$0 project deploy', i18n(`${i18nKey}.examples.default`)],
     [
-      '$0 project deploy --project="my-project" --buildId=5',
+      '$0 project deploy --project="my-project" --build=5',
       i18n(`${i18nKey}.examples.withOptions`),
     ],
   ]);

--- a/packages/cli/commands/project/upload.js
+++ b/packages/cli/commands/project/upload.js
@@ -92,7 +92,7 @@ exports.handler = async options => {
       logger.log(
         i18n(`${i18nKey}.logs.autoDeployDisabled`, {
           deployCommand: uiCommandReference(
-            `hs project deploy --buildId=${result.buildId}`
+            `hs project deploy --build=${result.buildId}`
           ),
         })
       );

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -577,7 +577,7 @@ en:
             default: "Deploy the latest build of the current project"
             withOptions: "Deploy build 5 of the project my-project"
           options:
-            buildId:
+            build:
               describe: "Project build ID to be deployed"
             project:
               describe: "Project name"
@@ -1296,8 +1296,8 @@ en:
           general: "[--general] Tell us about your experience with HubSpot's developer tools"
         bugPrompt: "Create an issue on Github in your browser?"
         generalPrompt: "Create an issue on Github in your browser?"
-      buildIdPrompt:
-        enterBuildId: "[--buildId] Deploy which build?"
+      deployBuildIdPrompt:
+        enterBuildId: "[--build] Deploy which build?"
       previewPrompt:
         enterSrc: "[--src] Enter a local theme directory to preview."
         enterDest: "[--dest] Enter the destination path for the src theme in HubSpot Design Tools."

--- a/packages/cli/lib/prompts/deployBuildIdPrompt.js
+++ b/packages/cli/lib/prompts/deployBuildIdPrompt.js
@@ -1,13 +1,9 @@
 const { promptUser } = require('./promptUtils');
 const { i18n } = require('../lang');
 
-const i18nKey = 'lib.prompts.buildIdPrompt';
-const buildIdPrompt = (
-  latestBuildId,
-  deployedBuildId,
-  projectName,
-  validate
-) => {
+const i18nKey = 'lib.prompts.deployBuildIdPrompt';
+
+const deployBuildIdPrompt = (latestBuildId, deployedBuildId, validate) => {
   return promptUser({
     name: 'buildId',
     message: i18n(`${i18nKey}.enterBuildId`),
@@ -22,5 +18,5 @@ const buildIdPrompt = (
 };
 
 module.exports = {
-  buildIdPrompt,
+  deployBuildIdPrompt,
 };


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
The `hs project deploy` command was broken when not passing in the `--buildId` flag directly. This was because we were passing in the args to the validate command incorrectly. Now you are able to successfully run `hs project deploy` with no flags and things should work as expected.

## Screenshots
<!-- Provide images of the before and after functionality -->
<img width="532" alt="image" src="https://github.com/user-attachments/assets/c7d84488-4da2-4f7f-abfe-00b544d09aff">

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
