### PR TITLE
Remove nested build label for project upload polling

### DIFF
--- a/packages/cli/lib/projects.js
+++ b/packages/cli/lib/projects.js
@@ -688,7 +688,7 @@ const makePollTaskStatusFunc = ({
         const formattedTaskType = PROJECT_TASK_TYPES[taskType]
           ? `[${PROJECT_TASK_TYPES[taskType]}]`
           : '';
-        const text = `${statusText.STATUS_TEXT} ${chalk.bold(
+        const text = `${indent <= 2 ? statusText.STATUS_TEXT : ''} ${chalk.bold(
           taskName
         )} ${formattedTaskType} ...${newline ? '\n' : ''}`;
 


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
This changes the format of our polling output during build/deploy for projects. All this PR does is remove the nested "building..." and "deploying..." labels. There's a BE pr that changes the format of the webhook subscriptions to remove the redundant app name from the label.

## Screenshots
<!-- Provide images of the before and after functionality -->

### For a private app
<img width="565" alt="Screenshot 2024-08-15 at 3 48 09 PM" src="https://github.com/user-attachments/assets/58260e91-c51e-4f79-89a2-8097f94acc62">

### For a public app
<img width="663" alt="Screenshot 2024-08-15 at 3 49 41 PM" src="https://github.com/user-attachments/assets/6c01a320-b13b-45e5-b92c-323258301efc">

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
