### PR TITLE
Fix error messaging in hs cms convert-fields

### DIFF
--- a/packages/cli/commands/cms/convertFields.js
+++ b/packages/cli/commands/cms/convertFields.js
@@ -93,7 +93,7 @@ exports.builder = yargs => {
   yargs.option('src', {
     describe: i18n(`${i18nKey}.positionals.src.describe`),
     type: 'string',
-    demandOption: true,
+    demandOption: i18n(`${i18nKey}.errors.missingSrc`),
   });
   yargs.option('fieldOptions', {
     describe: i18n(`${i18nKey}.options.options.describe`),

--- a/packages/cli/commands/cms/convertFields.js
+++ b/packages/cli/commands/cms/convertFields.js
@@ -13,6 +13,7 @@ const {
 
 const { trackConvertFieldsUsage } = require('../../lib/usageTracking');
 const { logErrorInstance } = require('../../lib/errorHandlers/standardErrors');
+const { EXIT_CODES } = require('../../lib/enums/exitCodes');
 const i18nKey = 'commands.convertFields';
 
 exports.command = 'convert-fields';
@@ -24,23 +25,27 @@ const invalidPath = src => {
       path: src,
     })
   );
+  process.exit(EXIT_CODES.ERROR);
 };
 
 exports.handler = async options => {
-  const src = path.resolve(getCwd(), options.src);
-  const themeJSONPath = getThemeJSONPath(src);
-  const projectRoot = themeJSONPath
-    ? path.dirname(themeJSONPath)
-    : path.dirname(getCwd());
   let stats;
+  let projectRoot;
+  let src;
+
   try {
+    src = path.resolve(getCwd(), options.src);
+    const themeJSONPath = getThemeJSONPath(options.src);
+    projectRoot = themeJSONPath
+      ? path.dirname(themeJSONPath)
+      : path.dirname(getCwd());
     stats = fs.statSync(src);
     if (!stats.isFile() && !stats.isDirectory()) {
-      invalidPath(src);
+      invalidPath(options.src);
       return;
     }
   } catch (e) {
-    invalidPath(src);
+    invalidPath(options.src);
   }
 
   trackConvertFieldsUsage('process');
@@ -88,6 +93,7 @@ exports.builder = yargs => {
   yargs.option('src', {
     describe: i18n(`${i18nKey}.positionals.src.describe`),
     type: 'string',
+    demandOption: true,
   });
   yargs.option('fieldOptions', {
     describe: i18n(`${i18nKey}.options.options.describe`),

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -968,6 +968,8 @@ en:
       options:
         options:
           describe: "Options to pass to javascript fields files"
+      errors:
+        invalidPath: "The path \"{{ path }}\" specified in the \"--src\" flag is not a path to a file or folder"
   lib:
     process:
       exitDebug: "Attempting to gracefully exit. Triggered by {{ signal }}"

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -969,7 +969,9 @@ en:
         options:
           describe: "Options to pass to javascript fields files"
       errors:
-        invalidPath: "The path \"{{ path }}\" specified in the \"--src\" flag is not a path to a file or folder"
+        invalidPath: "The path \"{{ path }}\" specified in the \"--src\" flag is not a path to a file or directory"
+        missingSrc: "Please specify the path to your javascript fields file or directory with the --src flag."
+
   lib:
     process:
       exitDebug: "Attempting to gracefully exit. Triggered by {{ signal }}"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8098,16 +8098,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -8148,7 +8139,7 @@ stringify-object@^3.2.1, stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -8161,13 +8152,6 @@ strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -8857,7 +8841,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -8870,15 +8854,6 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
## Description and Context
See https://git.hubteam.com/HubSpot/hubspot-cli-issues/issues/630
We noticed during our CLI bug bash that not providing the `--src` flag to `hs cms conver-fields` leads to a misleading error message. I also noticed that providing an invalid `src` results in a missing translation and even worse error message. This fixes both of those things

## Screenshots
No `--src` before
<img width="731" alt="Screenshot 2024-08-21 at 12 16 07 PM" src="https://github.com/user-attachments/assets/15df8318-3464-4d07-b1f4-0101c4589977">

No `--src` after
<img width="668" alt="Screenshot 2024-08-21 at 12 16 25 PM" src="https://github.com/user-attachments/assets/58a794ef-6170-4772-8e84-70baa0e12c2c">

Invalid `--src` before
<img width="738" alt="Screenshot 2024-08-21 at 12 21 02 PM" src="https://github.com/user-attachments/assets/04dfedb3-ce18-473e-87a9-bccd09f9b251">

Invalid `--src` after
<img width="804" alt="Screenshot 2024-08-21 at 12 25 06 PM" src="https://github.com/user-attachments/assets/de5a1c22-94ab-4af4-b7b2-179ec9bffc3c">


## Who to Notify
@brandenrodgers @joe-yeager @TanyaScales 
