### PR TITLE
Clean up generic errors

### DIFF
--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -1420,8 +1420,6 @@ en:
         errorOccurred: "Error: {{ error }}"
         errorContext: "Context: {{ context }}"
         errorCause: "Cause: {{ cause }}"
-        systemErrorOccurred: "A system error has occurred: {{ errorMessage }}"
-        genericErrorOccurred: "A {{ name }} has occurred."
         unknownErrorOccurred: "An unknown error has occurred."
       suppressErrors:
         platformVersionErrors:

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -1422,7 +1422,7 @@ en:
         errorCause: "Cause: {{ cause }}"
         systemErrorOccurred: "A system error has occurred: {{ errorMessage }}"
         genericErrorOccurred: "A {{ name }} has occurred."
-        unknownErrorOccurred: "An unknown error has occurred"
+        unknownErrorOccurred: "An unknown error has occurred."
       suppressErrors:
         platformVersionErrors:
           header: "Platform version update required"

--- a/packages/cli/lib/errorHandlers/index.js
+++ b/packages/cli/lib/errorHandlers/index.js
@@ -32,10 +32,9 @@ function logError(error, context = {}) {
     }
   } else if (isSystemError(error)) {
     logger.error(error.message);
-  } else if (error instanceof Error || error.message || error.reason) {
-    // Error or Error subclass
-    const name = error.name || 'Error';
-    const message = [i18n(`${i18nKey}.genericErrorOccurred`, { name })];
+  } else if (error.message || error.reason) {
+    const message = [];
+
     [error.message, error.reason].forEach(msg => {
       if (msg) {
         message.push(msg);


### PR DESCRIPTION
## Description and Context
This removes the "an error has occurred" text the prefaces many error messages, since it's redundant with the `[ERROR]` logged at the beginning of every error message. The intent of this log was to inform users that a specific _kind_ of error had occurred, but I think it's likely that that's not really relevant information for most people. Also, with the new error setup, most specific kinds of errors are already handled as system errors or hubspot HTTP errors.

See issue: https://git.hubteam.com/HubSpot/hubspot-cli-issues/issues/594

## Screenshots
Having a hard time finding a good example of this, since the vast majority of errors are HubSpot HTTP errors or system errors and are handled different. Here's an example from `hs project add` that I've since fixed.

Before
<img width="683" alt="Screenshot 2024-08-22 at 4 08 04 PM" src="https://github.com/user-attachments/assets/5b63ab8f-a95f-4dd4-bbee-dd6eb91ea441">

After
<img width="726" alt="Screenshot 2024-08-22 at 4 08 22 PM" src="https://github.com/user-attachments/assets/0545db93-d085-42b4-bb0b-7c945550b01e">

## Who to Notify
@brandenrodgers @joe-yeager 