### PR TITLE
Fix bug with hs project dev --account flag on private apps

### DIFF
--- a/packages/cli/commands/project/dev.js
+++ b/packages/cli/commands/project/dev.js
@@ -46,12 +46,12 @@ const {
   confirmDefaultAccountIsTarget,
   suggestRecommendedNestedAccount,
   checkIfAppDeveloperAccount,
-  checkIfDeveloperTestAccount,
   createSandboxForLocalDev,
   createDeveloperTestAccountForLocalDev,
   createNewProjectForLocalDev,
   createInitialBuildForNewProject,
   useExistingDevTestAccount,
+  validateAccountOption,
 } = require('../../lib/localDev');
 
 const i18nKey = 'commands.project.subcommands.dev';
@@ -106,10 +106,12 @@ exports.handler = async options => {
   // The account that we are locally testing against
   let targetTestingAccountId = options.account ? accountId : null;
 
-  if (options.account && hasPublicApps) {
-    checkIfDeveloperTestAccount(accountConfig);
-    targetProjectAccountId = accountConfig.parentAccountId;
-    targetTestingAccountId = accountId;
+  if (options.account) {
+    validateAccountOption(accountConfig, hasPublicApps);
+
+    if (hasPublicApps) {
+      targetProjectAccountId = accountConfig.parentAccountId;
+    }
   }
 
   let createNewSandbox = false;

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -1017,10 +1017,10 @@ en:
     localDev:
       confirmDefaultAccountIsTarget:
         declineDefaultAccountExplanation: "To develop on a different account, run {{ useCommand }} to change your default account, then re-run {{ devCommand }}."
-      checkIfAppDevloperAccount: "This project contains a public app. Local development of public apps is only supported on developer accounts and developer test accounts. Change your default account using {{#bold}}`hs accounts use`{{/bold}}, or link a new account with {{#bold}}`hs auth`{{/bold}}."
+      checkIfAppDevloperAccount: "This project contains a public app. Local development of public apps is only supported on developer accounts and developer test accounts. Change your default account using {{ useCommand }}, or link a new account with {{ authCommand }}."
       validateAccountOption:
-        invalidPublicAppAccount: "This project contains a public app. The \"--account\" flag must point to a developer test account to develop this project locally. Alternatively, change your default account to an App Developer Account using {{#bold}}`hs accounts use`{{/bold}} and run {{#bold}}`hs project dev`{{/bold}} to set up a new Developer Test Account."
-        invalidPrivateAppAccount: "This project contains a private app. The account specified with the \"--account\" flag points to a developer account, which do not support the local development of private apps. Update the \"--account\" flag to point to a standard, sandbox, or developer test account, or change your default account by running {{#bold}}`hs accounts use`{{/bold}}."
+        invalidPublicAppAccount: "This project contains a public app. The \"--account\" flag must point to a developer test account to develop this project locally. Alternatively, change your default account to an App Developer Account using {{ useCommand }} and run {{ devCommand }} to set up a new Developer Test Account."
+        invalidPrivateAppAccount: "This project contains a private app. The account specified with the \"--account\" flag points to a developer account, which do not support the local development of private apps. Update the \"--account\" flag to point to a standard, sandbox, or developer test account, or change your default account by running {{ useCommand }}."
         nonSandboxWarning: "Testing in a sandbox is strongly recommended. To switch the target account, select an option below or run {{#bold}}`hs accounts use`{{/bold}} before running the command again."
         publicAppNonDeveloperTestAccountWarning: "Local development of public apps is only supported in {{#bold}}developer test accounts{{/bold}}."
         privateAppInAppDeveloperAccountError: "Local development of private apps is not supported in {{#bold}}app developer accounts{{/bold}}"

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -1018,8 +1018,9 @@ en:
       confirmDefaultAccountIsTarget:
         declineDefaultAccountExplanation: "To develop on a different account, run {{ useCommand }} to change your default account, then re-run {{ devCommand }}."
       checkIfAppDevloperAccount: "This project contains a public app. Local development of public apps is only supported on developer accounts and developer test accounts. Change your default account using {{#bold}}`hs accounts use`{{/bold}}, or link a new account with {{#bold}}`hs auth`{{/bold}}."
-      checkIfDeveloperTestAccount: "This project contains a public app. The \"--account\" flag must point to a developer test account to develop this project locally. Alternatively, change your default account to an App Developer Account using {{#bold}}`hs accounts use`{{/bold}} and run {{#bold}}`hs project dev`{{/bold}} to set up a new Developer Test Account."
-      suggestRecommendedNestedAccount:
+      validateAccountOption:
+        invalidPublicAppAccount: "This project contains a public app. The \"--account\" flag must point to a developer test account to develop this project locally. Alternatively, change your default account to an App Developer Account using {{#bold}}`hs accounts use`{{/bold}} and run {{#bold}}`hs project dev`{{/bold}} to set up a new Developer Test Account."
+        invalidPrivateAppAccount: "This project contains a private app. The account specified with the \"--account\" flag points to a developer account, which do not support the local development of private apps. Update the \"--account\" flag to point to a standard, sandbox, or developer test account, or change your default account by running {{#bold}}`hs accounts use`{{/bold}}."
         nonSandboxWarning: "Testing in a sandbox is strongly recommended. To switch the target account, select an option below or run {{#bold}}`hs accounts use`{{/bold}} before running the command again."
         publicAppNonDeveloperTestAccountWarning: "Local development of public apps is only supported in {{#bold}}developer test accounts{{/bold}}."
         privateAppInAppDeveloperAccountError: "Local development of private apps is not supported in {{#bold}}app developer accounts{{/bold}}"

--- a/packages/cli/lib/localDev.js
+++ b/packages/cli/lib/localDev.js
@@ -85,7 +85,12 @@ const confirmDefaultAccountIsTarget = async accountConfig => {
 // Confirm the default account is a developer account if developing public apps
 const checkIfAppDeveloperAccount = accountConfig => {
   if (!isAppDeveloperAccount(accountConfig)) {
-    logger.error(i18n(`${i18nKey}.checkIfAppDevloperAccount`));
+    logger.error(
+      i18n(`${i18nKey}.checkIfAppDevloperAccount`, {
+        useCommand: uiCommandReference('hs accounts use'),
+        authCommand: uiCommandReference('hs auth'),
+      })
+    );
     process.exit(EXIT_CODES.SUCCESS);
   }
 };
@@ -94,12 +99,17 @@ const checkIfAppDeveloperAccount = accountConfig => {
 const validateAccountOption = (accountConfig, hasPublicApps) => {
   if (hasPublicApps && !isDeveloperTestAccount(accountConfig)) {
     logger.error(
-      i18n(`${i18nKey}.validateAccountOption.invalidPublicAppAccount`)
+      i18n(`${i18nKey}.validateAccountOption.invalidPublicAppAccount`, {
+        useCommand: uiCommandReference('hs accounts use'),
+        devCommand: uiCommandReference('hs project dev'),
+      })
     );
     process.exit(EXIT_CODES.SUCCESS);
   } else if (isAppDeveloperAccount(accountConfig)) {
     logger.error(
-      i18n(`${i18nKey}.validateAccountOption.invalidPrivateAppAccount`)
+      i18n(`${i18nKey}.validateAccountOption.invalidPrivateAppAccount`, {
+        useCommand: uiCommandReference('hs accounts use'),
+      })
     );
     process.exit(EXIT_CODES.SUCCESS);
   }

--- a/packages/cli/lib/localDev.js
+++ b/packages/cli/lib/localDev.js
@@ -91,9 +91,16 @@ const checkIfAppDeveloperAccount = accountConfig => {
 };
 
 // Confirm the default account is a developer account if developing public apps
-const checkIfDeveloperTestAccount = accountConfig => {
-  if (!isDeveloperTestAccount(accountConfig)) {
-    logger.error(i18n(`${i18nKey}.checkIfDeveloperTestAccount`));
+const validateAccountOption = (accountConfig, hasPublicApps) => {
+  if (hasPublicApps && !isDeveloperTestAccount(accountConfig)) {
+    logger.error(
+      i18n(`${i18nKey}.validateAccountOption.invalidPublicAppAccount`)
+    );
+    process.exit(EXIT_CODES.SUCCESS);
+  } else if (isAppDeveloperAccount(accountConfig)) {
+    logger.error(
+      i18n(`${i18nKey}.validateAccountOption.invalidPrivateAppAccount`)
+    );
     process.exit(EXIT_CODES.SUCCESS);
   }
 };
@@ -439,7 +446,7 @@ const getAccountHomeUrl = accountId => {
 module.exports = {
   confirmDefaultAccountIsTarget,
   checkIfAppDeveloperAccount,
-  checkIfDeveloperTestAccount,
+  validateAccountOption,
   suggestRecommendedNestedAccount,
   createSandboxForLocalDev,
   createDeveloperTestAccountForLocalDev,


### PR DESCRIPTION
## Description and Context
`hs project dev` does not support local development of private apps on developer accounts, but you can currently use the `--account` flag to bypass this. The CLI will then attempt to upload your project, which will fail. This fixes that and adds a new, more helpful error message.

Note: not sure if this will affect those rare accounts that are simultaneously developer and standard accounts? But IIRC we're already not supporting those properly.

## Screenshots
Before
<img width="853" alt="Screenshot 2024-08-23 at 4 10 30 PM" src="https://github.com/user-attachments/assets/494135fc-09d4-436e-9d34-1e72fb817c59">

After
<img width="852" alt="Screenshot 2024-08-23 at 4 10 53 PM" src="https://github.com/user-attachments/assets/64391a07-e096-41d8-bfe4-5a6ef8530078">

## Who to Notify
@brandenrodgers @joe-yeager @kemmerle 
