### PR TITLE
Fix(migrate-app): project names with slashes causing download issues

### DIFF
--- a/packages/cli/commands/project/cloneApp.js
+++ b/packages/cli/commands/project/cloneApp.js
@@ -38,7 +38,7 @@ const {
   checkCloneStatus,
   downloadClonedProject,
 } = require('@hubspot/local-dev-lib/api/projects');
-const { getCwd } = require('@hubspot/local-dev-lib/path');
+const { getCwd, sanitizeFileName } = require('@hubspot/local-dev-lib/path');
 const { logger } = require('@hubspot/local-dev-lib/logger');
 const { getAccountConfig } = require('@hubspot/local-dev-lib/config');
 const { extractZipArchive } = require('@hubspot/local-dev-lib/archive');
@@ -119,10 +119,15 @@ exports.handler = async options => {
 
       // Extract zipped app files and place them in correct directory
       const zippedApp = await downloadClonedProject(accountId, exportId);
-      await extractZipArchive(zippedApp, name, absoluteDestPath, {
-        includesRootDir: true,
-        hideLogs: true,
-      });
+      await extractZipArchive(
+        zippedApp,
+        sanitizeFileName(name),
+        absoluteDestPath,
+        {
+          includesRootDir: true,
+          hideLogs: true,
+        }
+      );
 
       // Create hsproject.json file
       const configPath = path.join(baseDestPath, PROJECT_CONFIG_FILE);

--- a/packages/cli/commands/project/download.js
+++ b/packages/cli/commands/project/download.js
@@ -6,7 +6,7 @@ const {
   addUseEnvironmentOptions,
 } = require('../../lib/commonOpts');
 const { trackCommandUsage } = require('../../lib/usageTracking');
-const { getCwd } = require('@hubspot/local-dev-lib/path');
+const { getCwd, sanitizeFileName } = require('@hubspot/local-dev-lib/path');
 const {
   logApiErrorInstance,
   ApiErrorContext,
@@ -95,7 +95,7 @@ exports.handler = async options => {
 
     await extractZipArchive(
       zippedProject,
-      projectName,
+      sanitizeFileName(projectName),
       path.resolve(absoluteDestPath),
       { includesRootDir: false }
     );

--- a/packages/cli/commands/project/migrateApp.js
+++ b/packages/cli/commands/project/migrateApp.js
@@ -209,7 +209,9 @@ exports.handler = async options => {
       logger.log(
         uiLink(
           i18n(`${i18nKey}.projectDetailsLink`),
-          `${baseUrl}/developer-projects/${accountId}/project/${project.name}`
+          `${baseUrl}/developer-projects/${accountId}/project/${encodeURIComponent(
+            project.name
+          )}`
         )
       );
       process.exit(EXIT_CODES.SUCCESS);

--- a/packages/cli/commands/project/migrateApp.js
+++ b/packages/cli/commands/project/migrateApp.js
@@ -39,7 +39,7 @@ const {
   migrateApp,
   checkMigrationStatus,
 } = require('@hubspot/local-dev-lib/api/projects');
-const { getCwd } = require('@hubspot/local-dev-lib/path');
+const { getCwd, sanitizeFileName } = require('@hubspot/local-dev-lib/path');
 const { logger } = require('@hubspot/local-dev-lib/logger');
 const { getAccountConfig } = require('@hubspot/local-dev-lib/config');
 const { downloadProject } = require('@hubspot/local-dev-lib/api/projects');
@@ -186,7 +186,7 @@ exports.handler = async options => {
 
       await extractZipArchive(
         zippedProject,
-        projectName,
+        sanitizeFileName(projectName),
         path.resolve(absoluteDestPath),
         { includesRootDir: true, hideLogs: true }
       );


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
We discovered a bug with the `migrate-app` command, where we were failing to download projects with `/` in their names. To address this, I have sanitized project names when passing them to the `extractZipArchive` function. On Mitchell's request, I also ensured that we are encoding project urls correctly. 

## Screenshots
<!-- Provide images of the before and after functionality -->

Before:

<img width="1282" alt="Screenshot 2024-08-26 at 12 36 30 PM" src="https://github.com/user-attachments/assets/6d84163c-42b5-431c-96d5-bf24f007deb1">

After: 

<img width="2556" alt="Screenshot 2024-08-26 at 12 36 40 PM" src="https://github.com/user-attachments/assets/7fad1460-7afe-4202-bc24-0fa851de2f7f">

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

- [ ] Test out migrating projects with problematic characters
- [ ] Test out the project details link in the `migrate-app` command (See screenshot above)
- [ ] Address any feedback 

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@joe-yeager @brandenrodgers @camden11 
