### PR TITLE
fix: Prevent js error during initial upload for watch

### DIFF
--- a/packages/cli/commands/project/watch.js
+++ b/packages/cli/commands/project/watch.js
@@ -132,7 +132,7 @@ exports.handler = async options => {
         startWatching
       );
 
-      if (result.uploadError) {
+      if (result && result.uploadError) {
         if (
           isSpecifiedError(result.uploadError, {
             subCategory: PROJECT_ERROR_TYPES.PROJECT_LOCKED,

--- a/packages/cli/commands/project/watch.js
+++ b/packages/cli/commands/project/watch.js
@@ -132,7 +132,7 @@ exports.handler = async options => {
         startWatching
       );
 
-      if (result && result.uploadError) {
+      if (result.uploadError) {
         if (
           isSpecifiedError(result.uploadError, {
             subCategory: PROJECT_ERROR_TYPES.PROJECT_LOCKED,

--- a/packages/cli/lib/projects.js
+++ b/packages/cli/lib/projects.js
@@ -572,7 +572,7 @@ const handleProjectUpload = async (
           buildId
         );
       }
-      resolve(uploadResult);
+      resolve(uploadResult || {});
     })
   );
 


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
There's a scenario where handleProjectUpload can return undefined. It happens when the callbackFunc doesn't return anything. Now it will default to an empty object.

You can test this by running `hs project watch --initial-upload`. Currently it will throw this error: `[ERROR] A TypeError has occurred. Cannot read properties of undefined (reading 'uploadError')`

## Screenshots
<!-- Provide images of the before and after functionality -->

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
