### PR TITLE
chore: Bump node version to >=18

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Install Yarn
         run: npm install -g yarn
       - name: Install deps

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -37,7 +37,7 @@
     "mock-stdin": "^1.0.0"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "bin": {
     "hs": "./bin/hs",


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
Bumps the minimum version of node required to install the cli to `>=18` to drop support for node 16 which is now EOL.

## Who to Notify
<!-- /cc those you wish to know about the PR -->
