### PR TITLE
Exit local dev earlier for projects without components

### DIFF
--- a/packages/cli/commands/project/dev.js
+++ b/packages/cli/commands/project/dev.js
@@ -93,6 +93,9 @@ exports.handler = async options => {
   if (hasPrivateApps && hasPublicApps) {
     logger.error(i18n(`${i18nKey}.errors.invalidProjectComponents`));
     process.exit(EXIT_CODES.SUCCESS);
+  } else if (!hasPrivateApps && !hasPublicApps) {
+    logger.error(i18n(`${i18nKey}.errors.noSupportedComponents`));
+    process.exit(EXIT_CODES.SUCCESS);
   }
 
   const accounts = getConfigAccounts();

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -483,6 +483,7 @@ en:
           errors:
             noProjectConfig: "No project detected. Please run this command again from a project directory."
             invalidProjectComponents: "Projects cannot contain both private and public apps. Move your apps to separate projects before attempting local development."
+            noSupportedComponents: "This project does not contain any components that support local development. Currently, local development is only supported for private and public apps."
             parentAccountNotConfigured: "To develop this project locally, run {{ authCommand }} to authenticate the App Developer Account {{ accountId }} associated with {{ accountIdentifier }}."
           examples:
             default: "Start local dev for the current project"

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -483,7 +483,7 @@ en:
           errors:
             noProjectConfig: "No project detected. Please run this command again from a project directory."
             invalidProjectComponents: "Projects cannot contain both private and public apps. Move your apps to separate projects before attempting local development."
-            noSupportedComponents: "This project does not contain any components that support local development. Currently, local development is only supported for private and public apps."
+            noRunnableComponents: "No supported components were found in this project. Run {{ command }} to see a list of available components and add one to your project."
             parentAccountNotConfigured: "To develop this project locally, run {{ authCommand }} to authenticate the App Developer Account {{ accountId }} associated with {{ accountIdentifier }}."
           examples:
             default: "Start local dev for the current project"
@@ -985,7 +985,6 @@ en:
       failedToInitialize: "Missing required arguments to initialize Local Dev"
       noDeployedBuild: "Your project {{#bold}}{{ projectName }}{{/bold}} exists in {{ accountIdentifier }}, but has no deployed build. Projects must be successfully deployed to be developed locally. Address any build and deploy errors your project may have, then run {{ uploadCommand }} to upload and deploy your project."
       noComponents: "There are no components in this project."
-      noRunnableComponents: "No supported components were found under {{#bold}}{{ projectSourceDir }}{{/bold}}. Run {{ command }} to see a list of available components."
       betaMessage: "HubSpot projects local development"
       learnMoreLocalDevServer: "Learn more about the projects local dev server"
       running: "Running {{#bold}}{{ projectName }}{{/bold}} locally on {{ accountIdentifier }}, waiting for changes ..."

--- a/packages/cli/lib/LocalDevManager.js
+++ b/packages/cli/lib/LocalDevManager.js
@@ -63,7 +63,7 @@ class LocalDevManager {
     this.isGithubLinked = options.isGithubLinked;
     this.watcher = null;
     this.uploadWarnings = {};
-    this.runnableComponents = this.getRunnableComponents(options.components);
+    this.runnableComponents = options.runnableComponents;
     this.activeApp = null;
     this.activePublicAppData = null;
     this.env = options.env;
@@ -78,27 +78,6 @@ class LocalDevManager {
       logger.log(i18n(`${i18nKey}.failedToInitialize`));
       process.exit(EXIT_CODES.ERROR);
     }
-
-    // The project is empty, there is nothing to run locally
-    if (!options.components.length) {
-      logger.error(i18n(`${i18nKey}.noComponents`));
-      process.exit(EXIT_CODES.SUCCESS);
-    }
-
-    // The project does not contain any components that support local development
-    if (!this.runnableComponents.length) {
-      logger.error(
-        i18n(`${i18nKey}.noRunnableComponents`, {
-          projectSourceDir: this.projectSourceDir,
-          command: uiCommandReference('hs project add'),
-        })
-      );
-      process.exit(EXIT_CODES.SUCCESS);
-    }
-  }
-
-  getRunnableComponents(components) {
-    return components.filter(component => component.runnable);
   }
 
   async setActiveApp(appUid) {


### PR DESCRIPTION
## Description and Context
You can't run local dev if your project doesn't have any apps, but right now `hs project dev` doesn't tell you that until after prompting you to select a sandbox to test with. The way that the `dev` command is set up now, the `LocalDevManager` is responsible for determining runnable components, which happens _after_ a lot of prompting. A more robust solution would involve determining runnable components earlier in the `dev` process, but I think this will work fine for now and we can make things more flexible when we rethink the dev servers/dev command.

## Screenshots

Before (you get prompted)
<img width="570" alt="Screenshot 2024-08-28 at 12 55 11 PM" src="https://github.com/user-attachments/assets/37e5677b-722c-40d4-969a-7aeb2933ce56">

After (exits immediately)
<img width="565" alt="Screenshot 2024-08-28 at 2 07 45 PM" src="https://github.com/user-attachments/assets/73e28d86-b4ea-4711-a66f-484ad5bc9c26">


## Who to Notify
@brandenrodgers @kemmerle @joe-yeager 
