### PR TITLE
Fix: Interpret tilde correctly in project location

### DIFF
--- a/packages/cli/lib/prompts/createProjectPrompt.js
+++ b/packages/cli/lib/prompts/createProjectPrompt.js
@@ -4,6 +4,7 @@ const {
   getCwd,
   sanitizeFileName,
   isValidPath,
+  untildify,
 } = require('@hubspot/local-dev-lib/path');
 const { PROJECT_COMPONENT_TYPES } = require('../../lib/constants');
 const { promptUser } = require('./promptUtils');
@@ -99,6 +100,9 @@ const createProjectPrompt = async (
           return i18n(`${i18nKey}.errors.invalidCharacters`);
         }
         return true;
+      },
+      filter: input => {
+        return untildify(input);
       },
     },
     {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/HubSpot/hubspot-cms-tools"
   },
   "dependencies": {
-    "@hubspot/local-dev-lib": "1.10.0",
+    "@hubspot/local-dev-lib": "1.12.0",
     "@hubspot/serverless-dev-runtime": "5.3.0",
     "@hubspot/theme-preview-dev-server": "0.0.7",
     "@hubspot/ui-extensions-dev-server": "0.8.30",

--- a/packages/serverless-dev-runtime/package.json
+++ b/packages/serverless-dev-runtime/package.json
@@ -6,7 +6,7 @@
   "repository": "https://github.com/HubSpot/hubspot-cli",
   "license": "Apache-2.0",
   "dependencies": {
-    "@hubspot/local-dev-lib": "1.10.0",
+    "@hubspot/local-dev-lib": "1.12.0",
     "body-parser": "^1.19.0",
     "chalk": "^4.1.0",
     "chokidar": "^3.4.3",

--- a/packages/webpack-cms-plugins/package.json
+++ b/packages/webpack-cms-plugins/package.json
@@ -17,7 +17,7 @@
     "test": "echo \"Error: run tests from root\" && exit 1"
   },
   "dependencies": {
-    "@hubspot/local-dev-lib": "1.10.0"
+    "@hubspot/local-dev-lib": "1.12.0"
   },
   "gitHead": "0659fd19cabc3645af431b177c11d0c1b089e0f8"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -473,10 +473,10 @@
     express "^4.18.2"
     uuid "^9.0.1"
 
-"@hubspot/local-dev-lib@1.10.0":
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/@hubspot/local-dev-lib/-/local-dev-lib-1.10.0.tgz#08a722c0183e61d43f228d3d41c1dc7f7332c78b"
-  integrity sha512-ZBywYmrF9hZHP1gF07QXsIJJ6HwMm0GL7O1JWd8sDZJREfz2uhlIvtIF8IvD4Zj8FKuUrwQaVeYLC9FdywneIw==
+"@hubspot/local-dev-lib@1.12.0":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@hubspot/local-dev-lib/-/local-dev-lib-1.12.0.tgz#533ebd93fbe116479ebeb18cd058179d7159d92c"
+  integrity sha512-lRiBO1kuKXT+PSpv6g5w2wiXe6T22NZnychWE6H2QITF89Tl9qOUIHV3L5E8Ycoz1ZiQsLVBdxP7G2eXMVHvAQ==
   dependencies:
     address "^2.0.1"
     axios "^1.3.5"
@@ -8098,16 +8098,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -8148,7 +8139,7 @@ stringify-object@^3.2.1, stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -8161,13 +8152,6 @@ strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -8857,7 +8841,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -8870,15 +8854,6 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
## Description and Context
Depends on https://github.com/HubSpot/hubspot-local-dev-lib/pull/188

In the create project prompt, when a user is prompted to enter a project location, we are not interpreting the `~` correctly. I've added a util function that allows us to untildify the tilde. 

## Screenshots
<!-- Provide images of the before and after functionality -->

Before (Note the weird location: `/Users/akemmerle/src/~/src/test-proj828`):

<img width="2014" alt="Screenshot 2024-08-28 at 4 29 58 PM" src="https://github.com/user-attachments/assets/f6cef2b8-5e4e-4035-a836-b8338c38095c">

After:

<img width="2560" alt="Screenshot 2024-08-28 at 4 30 09 PM" src="https://github.com/user-attachments/assets/186d2f27-e8f3-47b3-9a54-e86ba5ee05ad">

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

- [ ] Address feedback
- [ ] Merge local-dev-lib PR and update version in CLI. 

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@brandenrodgers @camden11 @joe-yeager 
