### PR TITLE
chore: fix dep-check

### DIFF
--- a/packages/cli/lib/errorHandlers/index.js
+++ b/packages/cli/lib/errorHandlers/index.js
@@ -8,7 +8,7 @@ const {
 } = require('@hubspot/local-dev-lib/errors/index');
 const { shouldSuppressError } = require('./suppressError');
 const { i18n } = require('../lang');
-const util = require('node:util');
+const util = require('util');
 const { isAxiosError } = require('axios');
 
 const i18nKey = 'lib.errorHandlers.index';


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
The new style of node standard lib import is breaking the dependency check.  Switching back to the old style

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@adamawang @kemmerle @brandenrodgers @camden11 