### PR TITLE
hs project dev: don't allow selection of nonexitent dev test accounts + more cleanup

### DIFF
--- a/packages/cli/commands/project/dev.js
+++ b/packages/cli/commands/project/dev.js
@@ -123,9 +123,6 @@ exports.handler = async options => {
     }
   }
 
-  let createNewSandbox = false;
-  let createNewDeveloperTestAccount = false;
-
   // The user is targeting an account type that we recommend developing on
   if (!targetProjectAccountId && defaultAccountIsRecommendedType) {
     targetTestingAccountId = accountId;
@@ -153,6 +150,9 @@ exports.handler = async options => {
   } else if (!targetProjectAccountId && hasPublicApps) {
     checkIfAppDeveloperAccount(accountConfig);
   }
+
+  let createNewSandbox = false;
+  let createNewDeveloperTestAccount = false;
 
   if (!targetProjectAccountId) {
     const {

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -1024,7 +1024,6 @@ en:
         invalidPrivateAppAccount: "This project contains a private app. The account specified with the \"--account\" flag points to a developer account, which do not support the local development of private apps. Update the \"--account\" flag to point to a standard, sandbox, or developer test account, or change your default account by running {{ useCommand }}."
         nonSandboxWarning: "Testing in a sandbox is strongly recommended. To switch the target account, select an option below or run {{#bold}}`hs accounts use`{{/bold}} before running the command again."
         publicAppNonDeveloperTestAccountWarning: "Local development of public apps is only supported in {{#bold}}developer test accounts{{/bold}}."
-        privateAppInAppDeveloperAccountError: "Local development of private apps is not supported in {{#bold}}app developer accounts{{/bold}}"
       createNewProjectForLocalDev:
         projectMustExistExplanation: "The project {{ projectName }} does not exist in the target account {{ accountIdentifier}}. This command requires the project to exist in the target account."
         publicAppProjectMustExistExplanation: "The project {{ projectName }} does not exist in {{ accountIdentifier}}, the app developer account associated with your target account. This command requires the project to exist in this app developer account."

--- a/packages/cli/lib/localDev.js
+++ b/packages/cli/lib/localDev.js
@@ -129,13 +129,6 @@ const suggestRecommendedNestedAccount = async (
         `${i18nKey}.validateAccountOption.publicAppNonDeveloperTestAccountWarning`
       )
     );
-  } else if (isAppDeveloperAccount(accountConfig)) {
-    logger.error(
-      i18n(
-        `${i18nKey}.validateAccountOption.privateAppInAppDeveloperAccountError`
-      )
-    );
-    process.exit(EXIT_CODES.ERROR);
   } else {
     logger.log(i18n(`${i18nKey}.validateAccountOption.nonSandboxWarning`));
   }

--- a/packages/cli/lib/prompts/projectDevTargetAccountPrompt.js
+++ b/packages/cli/lib/prompts/projectDevTargetAccountPrompt.js
@@ -1,7 +1,7 @@
 const { promptUser } = require('./promptUtils');
 const { i18n } = require('../lang');
 const { uiAccountDescription, uiCommandReference } = require('../ui');
-const { isSandbox, isDeveloperTestAccount } = require('../accountTypes');
+const { isSandbox } = require('../accountTypes');
 const { getAccountId } = require('@hubspot/local-dev-lib/config');
 const { getSandboxUsageLimits } = require('@hubspot/local-dev-lib/sandboxes');
 const {
@@ -99,7 +99,6 @@ const selectDeveloperTestTargetAccountPrompt = async (
   defaultAccountConfig
 ) => {
   const defaultAccountId = getAccountId(defaultAccountConfig.name);
-  let choices = [];
   let devTestAccountsResponse = undefined;
   try {
     devTestAccountsResponse = await fetchDeveloperTestAccounts(
@@ -109,13 +108,8 @@ const selectDeveloperTestTargetAccountPrompt = async (
     logger.debug('Unable to fetch developer test account usage limits: ', err);
   }
 
-  const devTestAccounts = accounts
-    .reverse()
-    .filter(
-      config =>
-        isDeveloperTestAccount(config) &&
-        config.parentAccountId === defaultAccountId
-    );
+  const accountIds = accounts.map(account => account.portalId);
+
   let disabledMessage = false;
   if (
     devTestAccountsResponse &&
@@ -128,27 +122,24 @@ const selectDeveloperTestTargetAccountPrompt = async (
     });
   }
 
-  let devTestAccountsNotInConfig = [];
+  const devTestAccounts = [];
   if (devTestAccountsResponse && devTestAccountsResponse.results) {
-    const inConfigIds = devTestAccounts.map(d => d.portalId);
     devTestAccountsResponse.results.forEach(acct => {
-      if (inConfigIds.indexOf(acct.id) < 0) {
-        devTestAccountsNotInConfig.push({
-          name: getNonConfigDeveloperTestAccountName(acct),
-          value: {
-            targetAccountId: acct.id,
-            createdNestedAccount: false,
-            parentAccountId: defaultAccountId,
-            notInConfigAccount: acct,
-          },
-        });
-      }
+      const inConfig = accountIds.includes(acct.id);
+      devTestAccounts.push({
+        name: getNonConfigDeveloperTestAccountName(acct),
+        value: {
+          targetAccountId: acct.id,
+          createdNestedAccount: false,
+          parentAccountId: defaultAccountId,
+          notInConfigAccount: inConfig ? null : acct,
+        },
+      });
     });
   }
 
-  choices = [
-    ...devTestAccounts.map(mapNestedAccount),
-    ...devTestAccountsNotInConfig,
+  const choices = [
+    ...devTestAccounts,
     {
       name: i18n(`${i18nKey}.createNewDeveloperTestAccountOption`),
       value: {

--- a/packages/cli/lib/prompts/projectDevTargetAccountPrompt.js
+++ b/packages/cli/lib/prompts/projectDevTargetAccountPrompt.js
@@ -108,8 +108,6 @@ const selectDeveloperTestTargetAccountPrompt = async (
     logger.debug('Unable to fetch developer test account usage limits: ', err);
   }
 
-  const accountIds = accounts.map(account => account.portalId);
-
   let disabledMessage = false;
   if (
     devTestAccountsResponse &&
@@ -124,6 +122,8 @@ const selectDeveloperTestTargetAccountPrompt = async (
 
   const devTestAccounts = [];
   if (devTestAccountsResponse && devTestAccountsResponse.results) {
+    const accountIds = accounts.map(account => account.portalId);
+
     devTestAccountsResponse.results.forEach(acct => {
       const inConfig = accountIds.includes(acct.id);
       devTestAccounts.push({


### PR DESCRIPTION
## Description and Context
`hs project dev` uses your local `hs.config.json` as the source of truth for developer test account selection. This can be out of date and allow users to select previously authed dev test accounts that no longer exist. For sandboxes, there's a check for this, since the CLI checks to see if the project exists in the sandbox. But for dev test accounts, the project lives in the parent account, and we never make this check. Currently, users can go all the way through the dev flow with a nonexistent accounts.

Since the dev test account prompt already fetches developer test account data to list un-authed dev test accounts as choices, we can use your live list of test accounts from the `integrators/test-portals/v2` as the main source of truth instead. The prompt now cross references the response from the endpoint with your local config to determine which accounts already exist locally and which need to be added config. Nonexistent accounts are no longer shown.

I also cleaned up a few other things here and there

## Who to Notify
@brandenrodgers @joe-yeager @kemmerle 
