### PR TITLE
Refactor: Simplify migration tracking

### DIFF
--- a/packages/cli/commands/project/cloneApp.js
+++ b/packages/cli/commands/project/cloneApp.js
@@ -42,9 +42,6 @@ const { getCwd, sanitizeFileName } = require('@hubspot/local-dev-lib/path');
 const { logger } = require('@hubspot/local-dev-lib/logger');
 const { getAccountConfig } = require('@hubspot/local-dev-lib/config');
 const { extractZipArchive } = require('@hubspot/local-dev-lib/archive');
-const {
-  fetchPublicAppMetadata,
-} = require('@hubspot/local-dev-lib/api/appsDev');
 
 const i18nKey = 'commands.project.subcommands.cloneApp';
 
@@ -76,8 +73,6 @@ exports.handler = async options => {
   let appId;
   let name;
   let location;
-  let preventProjectMigrations;
-  let listingInfo;
   try {
     appId = options.appId;
     if (!appId) {
@@ -89,11 +84,6 @@ exports.handler = async options => {
       });
       appId = appIdResponse.appId;
     }
-    const selectedApp = await fetchPublicAppMetadata(appId, accountId);
-    // preventProjectMigrations returns true if we have not added app to allowlist config.
-    // listingInfo will only exist for marketplace apps
-    preventProjectMigrations = selectedApp.preventProjectMigrations;
-    listingInfo = selectedApp.listingInfo;
 
     const projectResponse = await createProjectPrompt('', options, true);
     name = projectResponse.name;
@@ -138,15 +128,12 @@ exports.handler = async options => {
       };
       const success = writeProjectConfig(configPath, configContent);
 
-      const isListed = Boolean(listingInfo);
       trackCommandMetadataUsage(
         'clone-app',
         {
-          projectName: name,
-          appId,
-          status,
-          preventProjectMigrations,
-          isListed,
+          type: name,
+          assetType: appId,
+          successful: success,
         },
         accountId
       );

--- a/packages/cli/commands/project/migrateApp.js
+++ b/packages/cli/commands/project/migrateApp.js
@@ -86,14 +86,12 @@ exports.handler = async options => {
         });
 
   let appName;
-  let preventProjectMigrations;
-  let listingInfo;
   try {
     const selectedApp = await fetchPublicAppMetadata(appId, accountId);
     // preventProjectMigrations returns true if we have not added app to allowlist config.
     // listingInfo will only exist for marketplace apps
-    preventProjectMigrations = selectedApp.preventProjectMigrations;
-    listingInfo = selectedApp.listingInfo;
+    const preventProjectMigrations = selectedApp.preventProjectMigrations;
+    const listingInfo = selectedApp.listingInfo;
     if (preventProjectMigrations && listingInfo) {
       logger.error(i18n(`${i18nKey}.errors.invalidApp`, { appId }));
       process.exit(EXIT_CODES.ERROR);
@@ -191,10 +189,9 @@ exports.handler = async options => {
         { includesRootDir: true, hideLogs: true }
       );
 
-      const isListed = Boolean(listingInfo);
       trackCommandMetadataUsage(
         'migrate-app',
-        { projectName, appId, status, preventProjectMigrations, isListed },
+        { type: projectName, assetType: appId, successful: status },
         accountId
       );
 


### PR DESCRIPTION
## Description and Context
We needed to refactor and simplify usage tracking for the `migrate-app` and `clone-app` commands. Only certain properties can be passed to the usage tracking API. 

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

- [ ] Address feedback

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@brandenrodgers @camden11 
