### PR TITLE
Handle case where account flag test account parent isn't authed on hs project dev

### DIFF
--- a/packages/cli/commands/project/dev.js
+++ b/packages/cli/commands/project/dev.js
@@ -21,12 +21,7 @@ const {
   validateProjectConfig,
 } = require('../../lib/projects');
 const { EXIT_CODES } = require('../../lib/enums/exitCodes');
-const {
-  uiAccountDescription,
-  uiBetaTag,
-  uiCommandReference,
-  uiLink,
-} = require('../../lib/ui');
+const { uiBetaTag, uiCommandReference, uiLink } = require('../../lib/ui');
 const SpinniesManager = require('../../lib/ui/SpinniesManager');
 const LocalDevManager = require('../../lib/LocalDevManager');
 const {
@@ -52,6 +47,7 @@ const {
   createInitialBuildForNewProject,
   useExistingDevTestAccount,
   validateAccountOption,
+  checkIfParentAccountIsAuthed,
 } = require('../../lib/localDev');
 
 const i18nKey = 'commands.project.subcommands.dev';
@@ -130,19 +126,7 @@ exports.handler = async options => {
     await confirmDefaultAccountIsTarget(accountConfig, hasPublicApps);
 
     if (hasPublicApps) {
-      // Exit if the user has not authed the parent account in the config
-      if (!getAccountConfig(accountConfig.parentAccountId)) {
-        logger.error(
-          i18n(`${i18nKey}.errors.parentAccountNotConfigured`, {
-            accountId: accountConfig.parentAccountId,
-            accountIdentifier: uiAccountDescription(targetTestingAccountId),
-            authCommand: uiCommandReference(
-              `hs auth --account=${accountConfig.parentAccountId}`
-            ),
-          })
-        );
-        process.exit(EXIT_CODES.ERROR);
-      }
+      checkIfParentAccountIsAuthed(accountConfig);
       targetProjectAccountId = accountConfig.parentAccountId;
     } else {
       targetProjectAccountId = accountId;

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -484,7 +484,6 @@ en:
             noProjectConfig: "No project detected. Please run this command again from a project directory."
             invalidProjectComponents: "Projects cannot contain both private and public apps. Move your apps to separate projects before attempting local development."
             noRunnableComponents: "No supported components were found in this project. Run {{ command }} to see a list of available components and add one to your project."
-            parentAccountNotConfigured: "To develop this project locally, run {{ authCommand }} to authenticate the App Developer Account {{ accountId }} associated with {{ accountIdentifier }}."
           examples:
             default: "Start local dev for the current project"
         create:
@@ -1023,6 +1022,8 @@ en:
       createInitialBuildForNewProject:
         initialUploadMessage: "HubSpot Local Dev Server Startup"
         projectLockedError: "Your project is locked. This may mean that another user is running the {{#bold}}`hs project watch`{{/bold}} command for this project. If this is you, unlock the project in Projects UI."
+      checkIfParentAccountIsAuthed:
+        notAuthedError: "To develop this project locally, run {{ authCommand }} to authenticate the App Developer Account {{ accountId }} associated with {{ accountIdentifier }}."
     projects:
       config:
         srcOutsideProjectDir: "Invalid value for 'srcDir' in {{ projectConfig }}: {{#bold}}srcDir: \"{{ srcDir }}\"{{/bold}}\n\t'srcDir' must be a relative path to a folder under the project root, such as \".\" or \"./src\""

--- a/packages/cli/lib/localDev.js
+++ b/packages/cli/lib/localDev.js
@@ -106,7 +106,7 @@ const checkIfParentAccountIsAuthed = accountConfig => {
         ),
       })
     );
-    process.exit(EXIT_CODES.ERROR);
+    process.exit(EXIT_CODES.SUCCESS);
   }
 };
 

--- a/packages/cli/lib/localDev.js
+++ b/packages/cli/lib/localDev.js
@@ -95,16 +95,33 @@ const checkIfAppDeveloperAccount = accountConfig => {
   }
 };
 
-// Confirm the default account is a developer account if developing public apps
-const validateAccountOption = (accountConfig, hasPublicApps) => {
-  if (hasPublicApps && !isDeveloperTestAccount(accountConfig)) {
+const checkIfParentAccountIsAuthed = accountConfig => {
+  if (!getAccountConfig(accountConfig.parentAccountId)) {
     logger.error(
-      i18n(`${i18nKey}.validateAccountOption.invalidPublicAppAccount`, {
-        useCommand: uiCommandReference('hs accounts use'),
-        devCommand: uiCommandReference('hs project dev'),
+      i18n(`${i18nKey}.checkIfParentAccountIsAuthed.notAuthedError`, {
+        accountId: accountConfig.parentAccountId,
+        accountIdentifier: uiAccountDescription(accountConfig.portalId),
+        authCommand: uiCommandReference(
+          `hs auth --account=${accountConfig.parentAccountId}`
+        ),
       })
     );
-    process.exit(EXIT_CODES.SUCCESS);
+    process.exit(EXIT_CODES.ERROR);
+  }
+};
+
+// Confirm the default account is a developer account if developing public apps
+const validateAccountOption = (accountConfig, hasPublicApps) => {
+  if (hasPublicApps) {
+    if (!isDeveloperTestAccount) {
+      logger.error(
+        i18n(`${i18nKey}.validateAccountOption.invalidPublicAppAccount`, {
+          useCommand: uiCommandReference('hs accounts use'),
+          devCommand: uiCommandReference('hs project dev'),
+        })
+      );
+    }
+    checkIfParentAccountIsAuthed(accountConfig);
   } else if (isAppDeveloperAccount(accountConfig)) {
     logger.error(
       i18n(`${i18nKey}.validateAccountOption.invalidPrivateAppAccount`, {
@@ -456,4 +473,5 @@ module.exports = {
   createNewProjectForLocalDev,
   createInitialBuildForNewProject,
   getAccountHomeUrl,
+  checkIfParentAccountIsAuthed,
 };


### PR DESCRIPTION
## Description and Context
We were only confirming that a developer test account's parent account was authed in the CLI if it was the default account. This adds that check for developer test accounts passed in via the `--account` flag

## Screenshots
Before
<img width="565" alt="Screenshot 2024-09-10 at 3 42 42 PM" src="https://github.com/user-attachments/assets/a49b6d50-df74-44e1-9a42-3e8806f7eef9">

After
<img width="569" alt="Screenshot 2024-09-10 at 3 43 16 PM" src="https://github.com/user-attachments/assets/d2bf88dc-12c1-461f-825a-21d47dffc09b">

## Who to Notify
@brandenrodgers @joe-yeager @kemmerle 
