### PR TITLE
Unhide migration and clone commands

### DIFF
--- a/packages/cli/commands/project/cloneApp.js
+++ b/packages/cli/commands/project/cloneApp.js
@@ -20,6 +20,7 @@ const {
 } = require('../../lib/prompts/createProjectPrompt');
 const { poll } = require('../../lib/polling');
 const {
+  uiBetaTag,
   uiLine,
   uiCommandReference,
   uiAccountDescription,
@@ -46,7 +47,7 @@ const { extractZipArchive } = require('@hubspot/local-dev-lib/archive');
 const i18nKey = 'commands.project.subcommands.cloneApp';
 
 exports.command = 'clone-app';
-exports.describe = null; // uiBetaTag(i18n(`${i18nKey}.describe`), false);
+exports.describe = uiBetaTag(i18n(`${i18nKey}.describe`), false);
 
 exports.handler = async options => {
   await loadAndValidateOptions(options);

--- a/packages/cli/commands/project/migrateApp.js
+++ b/packages/cli/commands/project/migrateApp.js
@@ -52,7 +52,7 @@ const {
 const i18nKey = 'commands.project.subcommands.migrateApp';
 
 exports.command = 'migrate-app';
-exports.describe = null; // uiBetaTag(i18n(`${i18nKey}.describe`), false);
+exports.describe = uiBetaTag(i18n(`${i18nKey}.describe`), false);
 
 exports.handler = async options => {
   await loadAndValidateOptions(options);


### PR DESCRIPTION
## Description and Context
We are unhiding the `hs project migrate-app` and `hs project clone-app` commands from the help menu in the lead up to I-n-b-o-u-n-d. 

## Screenshots
<!-- Provide images of the before and after functionality -->

`hs project` help menu:

<img width="2560" alt="Screenshot 2024-09-13 at 2 43 16 PM" src="https://github.com/user-attachments/assets/363e89fb-8b5a-4626-a437-0d0c69563d2c">

`hs project migrate-app` help menu:

<img width="2560" alt="Screenshot 2024-09-13 at 2 43 36 PM" src="https://github.com/user-attachments/assets/27632165-cf71-4c40-8325-0195d9d8fb4d">

`hs project clone-app` help menu:

<img width="2558" alt="Screenshot 2024-09-13 at 2 43 48 PM" src="https://github.com/user-attachments/assets/621c225f-ebdc-4273-ab23-b87e5b288577">

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

- [ ] Address any feedback

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@brandenrodgers @camden11 @joe-yeager 
