### PR TITLE
Fix account validation in hs project dev

### DIFF
--- a/packages/cli/commands/project/dev.js
+++ b/packages/cli/commands/project/dev.js
@@ -40,13 +40,13 @@ const {
 const {
   confirmDefaultAccountIsTarget,
   suggestRecommendedNestedAccount,
-  checkIfAppDeveloperAccount,
+  checkIfDefaultAccountIsSupported,
   createSandboxForLocalDev,
   createDeveloperTestAccountForLocalDev,
   createNewProjectForLocalDev,
   createInitialBuildForNewProject,
   useExistingDevTestAccount,
-  validateAccountOption,
+  checkIfAccountFlagIsSupported,
   checkIfParentAccountIsAuthed,
 } = require('../../lib/localDev');
 
@@ -111,12 +111,15 @@ exports.handler = async options => {
   // The account that we are locally testing against
   let targetTestingAccountId = options.account ? accountId : null;
 
+  // Check that the default account or flag option is valid for the type of app in this project
   if (options.account) {
-    validateAccountOption(accountConfig, hasPublicApps);
+    checkIfAccountFlagIsSupported(accountConfig, hasPublicApps);
 
     if (hasPublicApps) {
       targetProjectAccountId = accountConfig.parentAccountId;
     }
+  } else {
+    checkIfDefaultAccountIsSupported(accountConfig, hasPublicApps);
   }
 
   // The user is targeting an account type that we recommend developing on
@@ -131,8 +134,6 @@ exports.handler = async options => {
     } else {
       targetProjectAccountId = accountId;
     }
-  } else if (!targetProjectAccountId && hasPublicApps) {
-    checkIfAppDeveloperAccount(accountConfig);
   }
 
   let createNewSandbox = false;

--- a/packages/cli/lang/en.lyaml
+++ b/packages/cli/lang/en.lyaml
@@ -1008,7 +1008,9 @@ en:
     localDev:
       confirmDefaultAccountIsTarget:
         declineDefaultAccountExplanation: "To develop on a different account, run {{ useCommand }} to change your default account, then re-run {{ devCommand }}."
-      checkIfAppDevloperAccount: "This project contains a public app. Local development of public apps is only supported on developer accounts and developer test accounts. Change your default account using {{ useCommand }}, or link a new account with {{ authCommand }}."
+      checkIfDefaultAccountIsSupported:
+        publicApp: "This project contains a public app. Local development of public apps is only supported on developer accounts and developer test accounts. Change your default account using {{ useCommand }}, or link a new account with {{ authCommand }}."
+        privateApp: "This project contains a private app. Local development of private apps is not supported in developer accounts. Change your default account using {{ useCommand }}, or link a new account with {{ authCommand }}."
       validateAccountOption:
         invalidPublicAppAccount: "This project contains a public app. The \"--account\" flag must point to a developer test account to develop this project locally. Alternatively, change your default account to an App Developer Account using {{ useCommand }} and run {{ devCommand }} to set up a new Developer Test Account."
         invalidPrivateAppAccount: "This project contains a private app. The account specified with the \"--account\" flag points to a developer account, which do not support the local development of private apps. Update the \"--account\" flag to point to a standard, sandbox, or developer test account, or change your default account by running {{ useCommand }}."

--- a/packages/cli/lib/localDev.js
+++ b/packages/cli/lib/localDev.js
@@ -82,11 +82,19 @@ const confirmDefaultAccountIsTarget = async accountConfig => {
   }
 };
 
-// Confirm the default account is a developer account if developing public apps
-const checkIfAppDeveloperAccount = accountConfig => {
-  if (!isAppDeveloperAccount(accountConfig)) {
+// Confirm the default account is supported for the type of apps being developed
+const checkIfDefaultAccountIsSupported = (accountConfig, hasPublicApps) => {
+  if (hasPublicApps && !isAppDeveloperAccount(accountConfig)) {
     logger.error(
-      i18n(`${i18nKey}.checkIfAppDevloperAccount`, {
+      i18n(`${i18nKey}.checkIfDefaultAccountIsSupported.publicApp`, {
+        useCommand: uiCommandReference('hs accounts use'),
+        authCommand: uiCommandReference('hs auth'),
+      })
+    );
+    process.exit(EXIT_CODES.SUCCESS);
+  } else if (!hasPublicApps && isAppDeveloperAccount(accountConfig)) {
+    logger.error(
+      i18n(`${i18nKey}.checkIfDefaultAccountIsSupported.privateApp`, {
         useCommand: uiCommandReference('hs accounts use'),
         authCommand: uiCommandReference('hs auth'),
       })
@@ -111,7 +119,7 @@ const checkIfParentAccountIsAuthed = accountConfig => {
 };
 
 // Confirm the default account is a developer account if developing public apps
-const validateAccountOption = (accountConfig, hasPublicApps) => {
+const checkIfAccountFlagIsSupported = (accountConfig, hasPublicApps) => {
   if (hasPublicApps) {
     if (!isDeveloperTestAccount) {
       logger.error(
@@ -465,8 +473,8 @@ const getAccountHomeUrl = accountId => {
 
 module.exports = {
   confirmDefaultAccountIsTarget,
-  checkIfAppDeveloperAccount,
-  validateAccountOption,
+  checkIfDefaultAccountIsSupported,
+  checkIfAccountFlagIsSupported,
   suggestRecommendedNestedAccount,
   createSandboxForLocalDev,
   createDeveloperTestAccountForLocalDev,


### PR DESCRIPTION
## Description and Context
At some point through all of the recent `hs project dev` updates, I accidentally removed the check for developer accounts when developing private apps. This restores that check, and tries to streamline the account check logic a bit by putting it in the same place for default accounts and accounts passed in through the account flag. The whole process is still messy, but I think this is an improvement.

I also changed the error message from the previous one to make it more consistent for the public app error message.

Would appreciate if everyone could test and make sure this works as expected!
* For private apps: Developer accounts should fail, all other accounts should work
* For public accounts: Only developer accounts and developer test accounts should work

## Screenshots
The bug:
<img width="569" alt="Screenshot 2024-09-20 at 2 01 02 PM" src="https://github.com/user-attachments/assets/bb7062c9-3180-4c20-bda6-2a8dbd80a8bd">

Fixed:
<img width="569" alt="Screenshot 2024-09-20 at 2 02 14 PM" src="https://github.com/user-attachments/assets/11620933-b472-4b23-a3ec-9c9aa1bf021a">


## Who to Notify
@brandenrodgers @kemmerle @joe-yeager 
