### PR TITLE
Bump theme-preview-dev-server to 0.0.8

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@hubspot/local-dev-lib": "2.0.0",
     "@hubspot/serverless-dev-runtime": "6.1.1",
-    "@hubspot/theme-preview-dev-server": "0.0.7",
+    "@hubspot/theme-preview-dev-server": "0.0.8",
     "@hubspot/ui-extensions-dev-server": "0.8.33",
     "archiver": "^5.3.0",
     "chalk": "^4.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -497,10 +497,10 @@
     semver "^6.3.0"
     unixify "^1.0.0"
 
-"@hubspot/theme-preview-dev-server@0.0.7":
-  version "0.0.7"
-  resolved "https://registry.npmjs.org/@hubspot/theme-preview-dev-server/-/theme-preview-dev-server-0.0.7.tgz"
-  integrity sha512-po0SvzWaiijRDso7APr5NnUm0YGUd3txUJj/ftjFaI/FmhylQ5tgETTQj2H8emoG+8Nt/Y4rD0ogL+jMETWafA==
+"@hubspot/theme-preview-dev-server@0.0.8":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@hubspot/theme-preview-dev-server/-/theme-preview-dev-server-0.0.8.tgz#ee9c339a3c493b9fb40c2a29fe8c2c29068917e7"
+  integrity sha512-1hsms3qE8I++ZLQJ8IpY0rB3Pk7+7KRtBB3xX6c0PmN1+1e8oIzBnQPx2jVFyfX4Ny/SuOCkHtuMYS3K1qIOzw==
   dependencies:
     "@types/node-fetch" "^2.6.11"
     chokidar "^3.6.0"


### PR DESCRIPTION
## Description and Context
This bumps @hubspot/theme-preview-dev-server to `0.0.8` which solves the peerDependency conflict with local-dev-lib 2.0.0 and will unblock our next CLI release.

## Who to Notify
@joe-yeager @kemmerle @brandenrodgers 
