### PR TITLE
chore: add await to project build warning logs

### DIFF
--- a/packages/cli/lib/projects.js
+++ b/packages/cli/lib/projects.js
@@ -436,7 +436,7 @@ const pollProjectBuildAndDeploy = async (
         )
       );
 
-      displayWarnLogs(accountId, projectConfig.name, buildId);
+      await displayWarnLogs(accountId, projectConfig.name, buildId);
     }
 
     // autoDeployId of 0 indicates a skipped deploy
@@ -495,7 +495,7 @@ const pollProjectBuildAndDeploy = async (
   }
 
   if (result && result.deployResult) {
-    displayWarnLogs(
+    await displayWarnLogs(
       accountId,
       projectConfig.name,
       result.deployResult.deployId,
@@ -1003,10 +1003,13 @@ const displayWarnLogs = async (
     }
   }
 
-  if (result && result.logs.length) {
-    result.logs.forEach(log => {
+  if (result && result.logs) {
+    const logLength = result.logs.length;
+    result.logs.forEach((log, i) => {
       logger.warn(log.message);
-      logger.log('');
+      if (i < logLength - 1) {
+        logger.log('');
+      }
     });
   }
 };


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
This makes the build warning logs show above the "View deploy of build X in HubSpot" message where it belongs. We weren't waiting for the `displayWarnLogs` function to finish before moving on. I also removed the extra space after the warning logs (only matters when this logs above the "View deploy of build X in HubSpot" message).

## Screenshots
<!-- Provide images of the before and after functionality -->
### Before
<img width="868" alt="image" src="https://github.com/user-attachments/assets/5ec1ea05-b98e-4ed5-966f-eefd5ca471ba">

### After
<img width="870" alt="image" src="https://github.com/user-attachments/assets/536974b1-cd2d-4dd6-b4eb-f7f4d31f3b6c">

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
