### PR TITLE
fix: allow public app local dev for dev test account

### DIFF
--- a/packages/cli/lib/localDev.js
+++ b/packages/cli/lib/localDev.js
@@ -80,7 +80,13 @@ const confirmDefaultAccountIsTarget = async accountConfig => {
 
 // Confirm the default account is supported for the type of apps being developed
 const checkIfDefaultAccountIsSupported = (accountConfig, hasPublicApps) => {
-  if (hasPublicApps && !isAppDeveloperAccount(accountConfig)) {
+  if (
+    hasPublicApps &&
+    !(
+      isAppDeveloperAccount(accountConfig) ||
+      isDeveloperTestAccount(accountConfig)
+    )
+  ) {
     logger.error(
       i18n(`${i18nKey}.checkIfDefaultAccountIsSupported.publicApp`, {
         useCommand: uiCommandReference('hs accounts use'),


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
Fixes an issue where devs are unable to initiate local dev for a public app when a developer test account is selected as the default account in the CLI

## Screenshots
<!-- Provide images of the before and after functionality -->

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
