### PR TITLE
fix: Fix tests running on latest

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,13 @@
 node_modules
+.github
+.vscode
+coverage
+docs
+tmp
+.eslintignore
+.eslintrc.js
+.gitignore
+*.md
+jest.config.js
+lerna.json
+prettier.config.js

--- a/.github/workflows/latestPublish.yml
+++ b/.github/workflows/latestPublish.yml
@@ -27,14 +27,14 @@ jobs:
         run: npm install
       - name: Add package to npx cache
         run: |
-          npx --yes --package @hubspot/cli@${{ env.version }} hs
+          npm install -g @hubspot/cli@${{ env.version }}
       - name: Test Latest CLI Release
         run: |
           npm run test-cli
         env:
           PORTAL_ID: ${{ secrets.ACCEPTANCE_TEST_PORTAL_ID }}
           PERSONAL_ACCESS_KEY: ${{ secrets.ACCEPTANCE_TEST_PERSONAL_ACCESS_KEY }}
-          CLI_VERSION: ${{ env.version }}
+          USE_INSTALLED: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Release Failure Slack Report
         uses: ravsamhq/notify-slack-action@v2

--- a/.github/workflows/latestPublish.yml
+++ b/.github/workflows/latestPublish.yml
@@ -25,7 +25,7 @@ jobs:
           node-version: 18.x
       - name: Install Deps
         run: npm install
-      - name: Add package to npx cache
+      - name: Globally install the CLI
         run: |
           npm install -g @hubspot/cli@${{ env.version }}
       - name: Test Latest CLI Release

--- a/.github/workflows/latestPublish.yml
+++ b/.github/workflows/latestPublish.yml
@@ -7,9 +7,6 @@ on:
   schedule:
     - cron: '0 */5 * * *' # Run every 5 hours
 
-env:
-  version: "latest"
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -27,7 +24,7 @@ jobs:
         run: npm install
       - name: Globally install the CLI
         run: |
-          npm install -g @hubspot/cli@${{ env.version }}
+          npm install -g @hubspot/cli@latest
       - name: Test Latest CLI Release
         run: |
           npm run test-cli

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,17 @@ FROM node:18
 # Create base directory
 WORKDIR /usr/src/hubspot-cli
 
+RUN npm install -g @hubspot/cli@latest
+
 # Get all the code needed to run the app locally
-COPY . .
+COPY . ./
+
+# Expose the ports for UIE Local dev
+EXPOSE 5173
+EXPOSE 5174
+
+# Expose the port for the PortManager
+EXPOSE 8080
 
 # Install dependencies
 RUN yarn

--- a/acceptance-tests/globalSetup.ts
+++ b/acceptance-tests/globalSetup.ts
@@ -1,14 +1,23 @@
 import { existsSync, mkdirSync, rmSync } from 'fs';
 import { testOutputDir } from './lib/testState';
 import type { GlobalSetupContext } from 'vitest/node'
+import * as dotEnv from "dotenv";
+import * as path from "path";
+
 
 // Vitest docs on globalSetup modules https://vitest.dev/config/#globalsetup
 export function setup(__context: GlobalSetupContext) {
+    const dotEnvConfig = dotEnv.config({ path: path.join(__dirname, './.env') });
+    const { parsed }  = dotEnvConfig
+    if(parsed && parsed.USE_INSTALLED) {
+        console.log('Using installed version of the hs command')
+    }
     try {
         if(existsSync(testOutputDir)) {
-            console.log(`${testOutputDir} already exists, deleting it's contents\n`);
+            console.log(`The directory ${testOutputDir} already exists, deleting it's contents\n`);
             rmSync(testOutputDir, { recursive: true, force: true });
         }
+
         console.log(`Setting up ${testOutputDir} directory\n`);
         mkdirSync(testOutputDir);
     } catch (e) {

--- a/acceptance-tests/globalSetup.ts
+++ b/acceptance-tests/globalSetup.ts
@@ -7,12 +7,14 @@ import * as path from "path";
 
 // Vitest docs on globalSetup modules https://vitest.dev/config/#globalsetup
 export function setup(__context: GlobalSetupContext) {
-    const dotEnvConfig = dotEnv.config({ path: path.join(__dirname, './.env') });
-    const { parsed }  = dotEnvConfig
-    if(parsed && parsed.USE_INSTALLED) {
-        console.log('Using installed version of the hs command')
-    }
     try {
+        const dotEnvConfig = dotEnv.config({ path: path.join(__dirname, './.env') });
+        const { parsed }  = dotEnvConfig
+
+        if(parsed && parsed.USE_INSTALLED) {
+            console.log('Using installed version of the hs command')
+        }
+
         if(existsSync(testOutputDir)) {
             console.log(`The directory ${testOutputDir} already exists, deleting it's contents\n`);
             rmSync(testOutputDir, { recursive: true, force: true });

--- a/acceptance-tests/globalSetup.ts
+++ b/acceptance-tests/globalSetup.ts
@@ -3,15 +3,14 @@ import { testOutputDir } from './lib/testState';
 import type { GlobalSetupContext } from 'vitest/node'
 
 // Vitest docs on globalSetup modules https://vitest.dev/config/#globalsetup
-export function setup({ provide }: GlobalSetupContext) {
+export function setup(__context: GlobalSetupContext) {
     try {
-        if (!existsSync(testOutputDir)) {
-            console.log(`Setting up ${testOutputDir} directory\n`);
-            mkdirSync(testOutputDir);
-        } else {
+        if(existsSync(testOutputDir)) {
             console.log(`${testOutputDir} already exists, deleting it's contents\n`);
             rmSync(testOutputDir, { recursive: true, force: true });
         }
+        console.log(`Setting up ${testOutputDir} directory\n`);
+        mkdirSync(testOutputDir);
     } catch (e) {
         console.log(e)
     }

--- a/acceptance-tests/globalSetup.ts
+++ b/acceptance-tests/globalSetup.ts
@@ -1,17 +1,13 @@
 import { existsSync, mkdirSync, rmSync } from 'fs';
 import { testOutputDir } from './lib/testState';
 import type { GlobalSetupContext } from 'vitest/node'
-import * as dotEnv from "dotenv";
-import * as path from "path";
+import { getTestConfig } from "./lib/env";
 
 
 // Vitest docs on globalSetup modules https://vitest.dev/config/#globalsetup
 export function setup(__context: GlobalSetupContext) {
     try {
-        const dotEnvConfig = dotEnv.config({ path: path.join(__dirname, './.env') });
-        const { parsed }  = dotEnvConfig
-
-        if(parsed && parsed.USE_INSTALLED) {
+        if(getTestConfig().useInstalled) {
             console.log('Using installed version of the hs command')
         }
 

--- a/acceptance-tests/lib/cmd.ts
+++ b/acceptance-tests/lib/cmd.ts
@@ -20,13 +20,10 @@ export function createProcess(
   env = null
 ) {
   let processCommand: string;
-  const { cliVersion, cliPath, debug } = config;
+  const { useInstalled, cliPath, debug } = config;
 
-  if (cliVersion) {
-    processCommand = 'npx';
-    args = ['--yes', '--package', `@hubspot/cli@${cliVersion}`, 'hs'].concat(
-      args
-    );
+  if (useInstalled) {
+    processCommand = 'hs';
   } else {
     // Ensure that path exists
     if (!cliPath || !existsSync(cliPath)) {

--- a/acceptance-tests/lib/env.ts
+++ b/acceptance-tests/lib/env.ts
@@ -29,7 +29,7 @@ const envOverrides: TestConfig = getTruthyValuesOnly({
   portalId: getEnvValue('PORTAL_ID') || getEnvValue('ACCOUNT_ID'),
   cliPath: getEnvValue('CLI_PATH'),
   personalAccessKey: getEnvValue('PERSONAL_ACCESS_KEY'),
-  cliVersion: getEnvValue('CLI_VERSION'),
+  useInstalled: getEnvValue('USE_INSTALLED'),
   debug: getEnvValue('DEBUG'),
   qa: getEnvValue('QA'),
   githubToken: getEnvValue('GITHUB_TOKEN'),
@@ -45,13 +45,13 @@ export const getTestConfig = (): TestConfig => {
     );
   }
 
-  if (config.cliPath && config.cliVersion) {
+  if (config.cliPath && config.useInstalled) {
     throw new Error(
-      'You cannot specify both a cliPath and a cliVersion. Remove one and try again.'
+      'You cannot specify both a cliPath and useLatest. Remove one and try again.'
     );
   }
 
-  if (!config.cliPath && !config.cliVersion) {
+  if (!config.cliPath && !config.useInstalled) {
     const defaultPath = path.join(process.cwd(), '../packages/cli/bin/hs');
 
     if (existsSync(defaultPath)) {

--- a/acceptance-tests/lib/types.ts
+++ b/acceptance-tests/lib/types.ts
@@ -1,6 +1,6 @@
 export interface TestConfig {
   debug: boolean;
-  cliVersion: string;
+  useInstalled: boolean;
   cliPath: string;
   personalAccessKey: string;
   portalId: string;

--- a/acceptance-tests/tests/auth.spec.ts
+++ b/acceptance-tests/tests/auth.spec.ts
@@ -1,4 +1,3 @@
-import { existsSync } from 'fs';
 import { describe, beforeAll, it, expect, afterAll } from 'vitest';
 import { ENTER } from '../lib/prompt';
 

--- a/acceptance-tests/tests/create.spec.ts
+++ b/acceptance-tests/tests/create.spec.ts
@@ -118,9 +118,6 @@ describe('hs create', () => {
     ).toBe(true);
   });
 
-  // For some reason, this test is getting tripped up on the creation.
-  // I verified it's just the test though, not the code, so
-  // instead we just check for some output to make sure the command runs
   it('api-sample', async () => {
     const out = await testState.cli.execute(
       ['create', FOLDERS.apiSample.name, FOLDERS.apiSample.name],

--- a/acceptance-tests/tests/create.spec.ts
+++ b/acceptance-tests/tests/create.spec.ts
@@ -1,6 +1,5 @@
 import { ENTER } from '../lib/prompt';
 
-import { existsSync } from 'fs';
 import { describe, beforeAll, afterAll, it, expect } from 'vitest';
 import rimraf from 'rimraf';
 import { TestState } from '../lib/testState';
@@ -16,15 +15,19 @@ const FOLDERS = {
   },
   websiteTheme: {
     folder: 'website-theme',
+    name: 'website-theme',
   },
   reactApp: {
     folder: 'react-app',
+    name: 'react-app',
   },
   vueApp: {
     folder: 'vue-app',
+    name: 'vue-app',
   },
   webpackServerless: {
     folder: 'webpack-serverless',
+    name: 'webpack-serverless',
   },
   apiSample: {
     name: 'api-sample',
@@ -32,6 +35,7 @@ const FOLDERS = {
   },
   app: {
     folder: 'app',
+    name: 'app',
   },
   function: {
     folder: 'function.functions',
@@ -87,28 +91,28 @@ describe('hs create', () => {
   });
 
   it('website-theme', async () => {
-    await testState.cli.execute(['create', 'website-theme']);
+    await testState.cli.execute(['create', FOLDERS.websiteTheme.name]);
     expect(
       testState.existsInTestOutputDirectory(FOLDERS.websiteTheme.folder)
     ).toBe(true);
   });
 
   it('react-app', async () => {
-    await testState.cli.execute(['create', 'react-app']);
+    await testState.cli.execute(['create', FOLDERS.reactApp.name]);
     expect(testState.existsInTestOutputDirectory(FOLDERS.reactApp.folder)).toBe(
       true
     );
   });
 
   it('vue-app', async () => {
-    await testState.cli.execute(['create', 'vue-app']);
+    await testState.cli.execute(['create', FOLDERS.vueApp.name]);
     expect(testState.existsInTestOutputDirectory(FOLDERS.vueApp.folder)).toBe(
       true
     );
   });
 
   it('webpack-serverless', async () => {
-    await testState.cli.execute(['create', 'webpack-serverless']);
+    await testState.cli.execute(['create', FOLDERS.webpackServerless.name]);
     expect(
       testState.existsInTestOutputDirectory(FOLDERS.webpackServerless.folder)
     ).toBe(true);
@@ -119,14 +123,17 @@ describe('hs create', () => {
   // instead we just check for some output to make sure the command runs
   it('api-sample', async () => {
     const out = await testState.cli.execute(
-      ['create', 'api-sample', 'api-sample'],
+      ['create', FOLDERS.apiSample.name, FOLDERS.apiSample.name],
       [ENTER, ENTER]
     );
-    expect(out).toContain('node');
+
+    expect(
+      testState.existsInTestOutputDirectory(FOLDERS.apiSample.folder)
+    ).toBe(true);
   });
 
   it('app', async () => {
-    await testState.cli.execute(['create', 'app']);
+    await testState.cli.execute(['create', FOLDERS.app.name]);
     expect(testState.existsInTestOutputDirectory(FOLDERS.app.folder)).toBe(
       true
     );

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test-cli": "yarn --cwd 'acceptance-tests' test-ci",
     "test-cli-debug": "yarn --cwd 'acceptance-tests' test-debug",
     "test-cli-qa": "yarn --cwd 'acceptance-tests' test-qa",
-    "test-docker": "yarn build-docker && docker container run -it --rm --name=hs-cli-container hs-cli-image yarn test",
+    "test-docker": "yarn build-docker && docker container run -it --rm --name=hs-cli-container hs-cli-image yarn test-cli",
     "build-docker": "docker image build --tag hs-cli-image . && docker image prune -f",
     "circular-deps": "yarn madge --circular packages"
   },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test-cli": "yarn --cwd 'acceptance-tests' test-ci",
     "test-cli-debug": "yarn --cwd 'acceptance-tests' test-debug",
     "test-cli-qa": "yarn --cwd 'acceptance-tests' test-qa",
-    "test-docker": "yarn build-docker && docker container run -it --rm --name=hs-cli-container hs-cli-image yarn test-cli",
+    "test-cli-latest": "yarn build-docker && docker container run -it --rm --name=hs-cli-container hs-cli-image yarn test-cli",
     "build-docker": "docker image build --tag hs-cli-image . && docker image prune -f",
     "circular-deps": "yarn madge --circular packages"
   },


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
- Update the `lastestPublish` action to globally install the CLI
- Update the tests to no longer use `npx` and instead use the globally installed `hs` command.  `npx` was causing a ton of flakey behavior.
- Dockerize the tests
- Update the `test-docker` docker `npm` script to run the ATs
- Remove the `CLI_VERSION` env variable in favor of `USE_INSTALLED`.  
    - If you want to test a particular version you can do either: 
      - `npm install -g @hubspot/cli@version && npm run test-cli`
      - Update the version being installed in the Dockerfile and run `npm run test-docker`
