### PR TITLE
chore: Update module type and module resolution type

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
     "target": "esnext",
-    "module": "commonjs",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "declaration": true,
     "strict": true,
     "esModuleInterop": true,


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
The current `module` and `moduleResolution` settings don't seem to allow for importing esmodules.  [See these docs](https://www.typescriptlang.org/docs/handbook/modules/theory.html#the-module-output-format), in particular the foot section of the docs and [this doc](https://www.typescriptlang.org/docs/handbook/modules/reference.html#node16-nodenext) which has more details on the node module system.