### PR TITLE
Add registry to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "hscms": "./bin/hscms"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }


### PR DESCRIPTION
## Description and Context
Our new release setup requires specifying the npm registry (otherwise, it will default to yarn registry, which I think is due to the presence of yarn.lock)

## Who to Notify
@joe-yeager @kemmerle @brandenrodgers 
