### PR TITLE
Upgrade serverless-dev-runtime to v7.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "https://github.com/HubSpot/hubspot-cli",
   "dependencies": {
     "@hubspot/local-dev-lib": "^2.0.1",
-    "@hubspot/serverless-dev-runtime": "6.2.0",
+    "@hubspot/serverless-dev-runtime": "7.0.0",
     "@hubspot/theme-preview-dev-server": "0.0.8",
     "@hubspot/ui-extensions-dev-server": "0.8.33",
     "archiver": "^7.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -468,30 +468,6 @@
     express "^4.18.2"
     uuid "^9.0.1"
 
-"@hubspot/local-dev-lib@2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@hubspot/local-dev-lib/-/local-dev-lib-2.0.0.tgz#63384238164de40da7cc6747c7d27637a0009b7b"
-  integrity sha512-2q5WmnByqBU1JZD+iYBkYwNRf+w1I8ae/+WAhNtq99lqv+kBSUJtLegGgZENlGs+lzHnmg95sokjhPdTZE5E4w==
-  dependencies:
-    address "^2.0.1"
-    axios "^1.3.5"
-    chalk "^2.4.2"
-    chokidar "^3.5.3"
-    content-disposition "^0.5.4"
-    cors "^2.8.5"
-    debounce "^1.2.0"
-    express "^4.18.2"
-    extract-zip "^2.0.1"
-    findup-sync "^5.0.0"
-    fs-extra "^11.1.0"
-    ignore "^5.1.4"
-    js-yaml "^4.1.0"
-    moment "^2.29.4"
-    p-queue "^6.0.2"
-    prettier "^3.3.0"
-    semver "^6.3.0"
-    unixify "^1.0.0"
-
 "@hubspot/local-dev-lib@^2.0.1":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@hubspot/local-dev-lib/-/local-dev-lib-2.0.1.tgz#58736428de6c79092ee7cd80ed99a69ba65886ce"
@@ -516,12 +492,11 @@
     semver "^6.3.0"
     unixify "^1.0.0"
 
-"@hubspot/serverless-dev-runtime@6.2.0":
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/@hubspot/serverless-dev-runtime/-/serverless-dev-runtime-6.2.0.tgz#48563e8322ca98c1bf8c29e06f702da54ccbfb20"
-  integrity sha512-S1Gc0VWXKWMc6Fz1QHzTtex1tk1cRE+33VT6O8aprvflJ8DtNGdjekCH+CD8rLRq/kkzjSsWKLvfb5Ssir42pw==
+"@hubspot/serverless-dev-runtime@7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@hubspot/serverless-dev-runtime/-/serverless-dev-runtime-7.0.0.tgz#dffe8101e3a9b79fa768691daa2c9ba1f86c25d6"
+  integrity sha512-8r/Iasu4rjBDPbOpCe8GV9Wx/LY/NID2gRgRVKBsxxGlFAsekTzXS1XPIBNH7ulBOkzGkqJWirEEtDkl6xcn9w==
   dependencies:
-    "@hubspot/local-dev-lib" "2.0.0"
     body-parser "^1.19.0"
     chalk "^4.1.0"
     chokidar "^3.4.3"


### PR DESCRIPTION
## Description and Context
Upgrades to the latest serverless-dev-runtime, which uses LDL as a peerDependency to avoid conflicts.

## Who to Notify
@brandenrodgers @joe-yeager @kemmerle 
