### PR TITLE
Add build script sh

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
   },
   "scripts": {
     "build": "bash ./scripts/build.sh",
-    "copy-files": "cp -r lang dist/lang && cp bin/hs dist/bin/hs && cp bin/hscms dist/bin/hscms",
     "lint": "eslint . && prettier --list-different ./**/*.{js,json}",
     "prettier:write": "prettier --write ./**/*.{js,json}",
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "typescript": "^5.6.2"
   },
   "scripts": {
-    "build": "rm -rf ./dist/ && tsc && yarn copy-files",
+    "build": "bash ./scripts/build.sh",
     "copy-files": "cp -r lang dist/lang && cp bin/hs dist/bin/hs && cp bin/hscms dist/bin/hscms",
     "lint": "eslint . && prettier --list-different ./**/*.{js,json}",
     "prettier:write": "prettier --write ./**/*.{js,json}",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,7 @@
+rm -rf ./dist/
+yarn tsc
+cp -r lang dist/lang
+cp bin/hs dist/bin/hs
+cp bin/hscms dist/bin/hscms
+cp README.md dist/README.md
+cp LICENSE dist/LICENSE


### PR DESCRIPTION
## Description and Context
The previous build script was not copying the README and LICENSE, which should both be published to npm. This moves the build script to its own file to keep things clean.

## Who to Notify
@brandenrodgers 
