### PR TITLE
chore: install the deps before running the acceptance tests

### DIFF
--- a/.github/workflows/latestPublish.yml
+++ b/.github/workflows/latestPublish.yml
@@ -25,6 +25,8 @@ jobs:
       - name: Globally install the CLI
         run: |
           npm install -g @hubspot/cli@latest
+      - name: Install the test dependencies
+        run: yarn install --cwd='acceptance-tests'
       - name: Test Latest CLI Release
         run: |
           npm run test-cli


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
Update the `latestPublish` action to explicitly run the `yarn install` in the `acceptance-tests` directory before running the tests

[Clean action run](https://github.com/HubSpot/hubspot-cli/actions/runs/11373179154/job/31639179633)