### PR TITLE
chore: Update `latestPublish` to only sleep for 3 mins when the event is a `push`

### DIFF
--- a/.github/workflows/latestPublish.yml
+++ b/.github/workflows/latestPublish.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       # Sleep when triggered by new tag to wait for npm publish
       - name: Sleep For 3 Mins
+        if: ${{ github.event_name != 'schedule' }}
         run: sleep 180s
         shell: bash
       - name: Use Node.js

--- a/.github/workflows/latestPublish.yml
+++ b/.github/workflows/latestPublish.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       # Sleep when triggered by new tag to wait for npm publish
       - name: Sleep For 3 Mins
-        if: ${{ github.event_name != 'schedule' }}
+        if: ${{ github.event_name == 'push' }}
         run: sleep 180s
         shell: bash
       - name: Use Node.js


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
Only sleep the action for 3 mins when the triggering event type is `push`
