### PR TITLE
fix: Allow template name or label to be used for `template` flag

### DIFF
--- a/lib/prompts/createProjectPrompt.ts
+++ b/lib/prompts/createProjectPrompt.ts
@@ -55,6 +55,12 @@ const createTemplateOptions = async (templateSource, githubRef) => {
   return config[PROJECT_COMPONENT_TYPES.PROJECTS];
 };
 
+function findTemplate(projectTemplates, templateNameOrLabel) {
+  return projectTemplates.find(
+    t => t.name === templateNameOrLabel || t.label === templateNameOrLabel
+  );
+}
+
 const createProjectPrompt = async (
   githubRef,
   promptOptions = {},
@@ -71,7 +77,7 @@ const createProjectPrompt = async (
 
     selectedTemplate =
       promptOptions.template &&
-      projectTemplates.find(t => t.name === promptOptions.template);
+      findTemplate(projectTemplates, promptOptions.template);
   }
 
   const result = await promptUser([
@@ -116,7 +122,7 @@ const createProjectPrompt = async (
       name: 'template',
       message: () => {
         return promptOptions.template &&
-          !projectTemplates.find(t => t.name === promptOptions.template)
+          !findTemplate(projectTemplates, promptOptions.template)
           ? i18n(`${i18nKey}.errors.invalidTemplate`, {
               template: promptOptions.template,
             })


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
Allow either the template name or the template label to be used to lookup the template
