### PR TITLE
Fix imports from local-dev-lib

### DIFF
--- a/commands/accounts/remove.ts
+++ b/commands/accounts/remove.ts
@@ -4,7 +4,7 @@ const {
   getConfig,
   getConfigPath,
   deleteAccount,
-  getConfigDefaultAccount,
+  getDefaultAccount,
   getAccountId: getAccountIdFromConfig,
   updateDefaultAccount,
 } = require('@hubspot/local-dev-lib/config');
@@ -48,7 +48,7 @@ exports.handler = async options => {
     getAccountIdFromConfig(accountToRemove)
   );
 
-  const currentDefaultAccount = getConfigDefaultAccount();
+  const currentDefaultAccount = getDefaultAccount();
 
   await deleteAccount(accountToRemove);
   logger.success(

--- a/commands/project/dev.ts
+++ b/commands/project/dev.ts
@@ -12,7 +12,7 @@ const { handleExit } = require('../../lib/process');
 const { i18n } = require('../../lib/lang');
 const { logger } = require('@hubspot/local-dev-lib/logger');
 const {
-  getConfigAccounts,
+  getAccounts,
   getAccountConfig,
   getEnv,
 } = require('@hubspot/local-dev-lib/config');
@@ -101,7 +101,7 @@ exports.handler = async options => {
     process.exit(EXIT_CODES.SUCCESS);
   }
 
-  const accounts = getConfigAccounts();
+  const accounts = getAccounts();
 
   const defaultAccountIsRecommendedType =
     isDeveloperTestAccount(accountConfig) ||

--- a/lib/LocalDevManager.ts
+++ b/lib/LocalDevManager.ts
@@ -14,7 +14,7 @@ const {
 } = require('@hubspot/local-dev-lib/api/appsDev');
 const {
   getAccountId,
-  getConfigDefaultAccount,
+  getDefaultAccount,
 } = require('@hubspot/local-dev-lib/config');
 const { PROJECT_CONFIG_FILE } = require('./constants');
 const SpinniesManager = require('./ui/SpinniesManager');
@@ -306,7 +306,7 @@ class LocalDevManager {
   }
 
   getUploadCommand() {
-    const currentDefaultAccount = getConfigDefaultAccount();
+    const currentDefaultAccount = getDefaultAccount();
 
     return this.targetProjectAccountId !== getAccountId(currentDefaultAccount)
       ? uiCommandReference(


### PR DESCRIPTION
## Description and Context
We changed two import names as part of [this PR](https://github.com/HubSpot/hubspot-local-dev-lib/pull/172) in local-dev-lib: `getConfigAccounts` became `getAccounts` and `getConfigDefaultAccount` became `getDefaultAccount`. 

## TODO

- [ ] Address feedback

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@joe-yeager @brandenrodgers @camden11 