### PR TITLE
Prepare for release with script

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hubspot/cli",
-  "version": "6.2.2-experimental.0",
+  "version": "6.2.1",
   "description": "The official CLI for developing on HubSpot",
   "license": "Apache-2.0",
   "repository": "https://github.com/HubSpot/hubspot-cli",

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -133,16 +133,16 @@ async function handler({
   }
 
   const {
-    next: currentNextTag,
+    // next: currentNextTag,
     experimental: currentExperimentalTag,
   } = await getDistTags();
 
-  if (!isExperimental && currentNextTag !== localVersion) {
-    logger.error(
-      `Local package.json version ${localVersion} is out of sync with published version ${currentNextTag}`
-    );
-    process.exit(EXIT_CODES.ERROR);
-  }
+  // if (!isExperimental && currentNextTag !== localVersion) {
+  //   logger.error(
+  //     `Local package.json version ${localVersion} is out of sync with published version ${currentNextTag}`
+  //   );
+  //   process.exit(EXIT_CODES.ERROR);
+  // }
 
   const currentVersion = isExperimental ? currentExperimentalTag : localVersion;
   const prereleaseIdentifier = isExperimental


### PR DESCRIPTION
## Description and Context
This gets some things set up so that we can get the CLI package in the state the release script expects it to be in.
* Changes the version back to 6.2.1, since experimental versions should not ever be published from `main`
* Removes the check for the local version and next version being in sync. This _isn't_ true right now, so this check would prevent us from releasing.

Once this is in we can first release to experimental as a final test, then release to next to get things in the proper state, then add the check back

## Who to Notify
@brandenrodgers @kemmerle @joe-yeager 
