### PR TITLE
Fix bugs with build script and confirm prompt

### DIFF
--- a/lib/prompts/promptUtils.ts
+++ b/lib/prompts/promptUtils.ts
@@ -6,17 +6,15 @@ export const promptUser: any = inquirer.createPromptModule();
 
 export async function confirmPrompt(
   message: string,
-  {
-    defaultAnswer = true,
-    when,
-  }: { defaultAnswer: boolean; when?: boolean | (() => boolean) }
+  options: { defaultAnswer?: boolean; when?: boolean | (() => boolean) } = {}
 ): Promise<boolean> {
+  const { defaultAnswer, when } = options;
   const { choice } = await promptUser([
     {
       name: 'choice',
       type: 'confirm',
       message,
-      default: defaultAnswer,
+      default: defaultAnswer || true,
       when,
     },
   ]);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hubspot/cli",
-  "version": "6.2.3-experimental.0",
+  "version": "6.2.2-beta.0",
   "description": "The official CLI for developing on HubSpot",
   "license": "Apache-2.0",
   "repository": "https://github.com/HubSpot/hubspot-cli",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hubspot/cli",
-  "version": "6.2.2-beta.0",
+  "version": "6.2.3-experimental.0",
   "description": "The official CLI for developing on HubSpot",
   "license": "Apache-2.0",
   "repository": "https://github.com/HubSpot/hubspot-cli",

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1,31 +1,3 @@
-import { spawn } from 'child_process';
-import fs from 'fs';
-import { EXIT_CODES } from '../lib/enums/exitCodes';
-
-export async function build(): Promise<void> {
-  // Remove the current dist dir
-  fs.rmSync('dist', { recursive: true, force: true });
-
-  // Build typescript
-  await new Promise(resolve => {
-    const childProcess = spawn('yarn', ['tsc'], {
-      stdio: 'inherit',
-    });
-
-    childProcess.on('close', code => {
-      if (code !== EXIT_CODES.SUCCESS) {
-        process.exit(code);
-      }
-      resolve('');
-    });
-  });
-
-  // Copy remaining files
-  fs.cpSync('lang', 'dist/lang', { recursive: true });
-  fs.cpSync('bin/hs', 'dist/bin/hs');
-  fs.cpSync('bin/hscms', 'dist/bin/hscms');
-  fs.cpSync('README.md', 'dist/README.md');
-  fs.cpSync('LICENSE', 'dist/LICENSE');
-}
+import { build } from './lib/build';
 
 build();

--- a/scripts/lib/build.ts
+++ b/scripts/lib/build.ts
@@ -1,0 +1,30 @@
+import { spawn } from 'child_process';
+import fs from 'fs';
+import { EXIT_CODES } from '../../lib/enums/exitCodes';
+
+export async function build(): Promise<void> {
+  // Remove the current dist dir
+  console.log('BUILD');
+  fs.rmSync('dist', { recursive: true, force: true });
+
+  // Build typescript
+  await new Promise(resolve => {
+    const childProcess = spawn('yarn', ['tsc'], {
+      stdio: 'inherit',
+    });
+
+    childProcess.on('close', code => {
+      if (code !== EXIT_CODES.SUCCESS) {
+        process.exit(code);
+      }
+      resolve('');
+    });
+  });
+
+  // Copy remaining files
+  fs.cpSync('lang', 'dist/lang', { recursive: true });
+  fs.cpSync('bin/hs', 'dist/bin/hs');
+  fs.cpSync('bin/hscms', 'dist/bin/hscms');
+  fs.cpSync('README.md', 'dist/README.md');
+  fs.cpSync('LICENSE', 'dist/LICENSE');
+}

--- a/scripts/lib/build.ts
+++ b/scripts/lib/build.ts
@@ -1,10 +1,14 @@
 import { spawn } from 'child_process';
 import fs from 'fs';
+import { logger, setLogLevel, LOG_LEVEL } from '@hubspot/local-dev-lib/logger';
 import { EXIT_CODES } from '../../lib/enums/exitCodes';
 
 export async function build(): Promise<void> {
+  setLogLevel(LOG_LEVEL.LOG);
+  logger.log('Creating a new build...');
+  logger.log();
+
   // Remove the current dist dir
-  console.log('BUILD');
   fs.rmSync('dist', { recursive: true, force: true });
 
   // Build typescript
@@ -27,4 +31,6 @@ export async function build(): Promise<void> {
   fs.cpSync('bin/hscms', 'dist/bin/hscms');
   fs.cpSync('README.md', 'dist/README.md');
   fs.cpSync('LICENSE', 'dist/LICENSE');
+
+  logger.success('Build successful');
 }

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -201,9 +201,7 @@ async function handler({
   logger.success('Version updated successfully');
 
   logger.log();
-  logger.log('Creating a new build...');
   await build();
-  logger.success('Build successful');
 
   try {
     await publish(tag, isDryRun);

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -6,7 +6,7 @@ import semver from 'semver';
 
 import { name as packageName, version as localVersion } from '../package.json';
 import { EXIT_CODES } from '../lib/enums/exitCodes';
-import { build } from './build';
+import { build } from './lib/build';
 
 // TODO: Change to import when this is converted to TS
 const { uiLink, uiLine } = require('../lib/ui');


### PR DESCRIPTION
## Description and Context
This fixes two bugs that were affecting the release script
* The call to `build()` in the same file that the `build` function was exported from caused build to be run whenever it was imported. This moved the actual function to its own file to avoid redundant calls. It also adds logging to the build command so its more obvious if something like this happens again
* A recent change to the confirm prompt broke the prompts in the script and in one other place - this changes it to make the options object completely optional

## Who to Notify
@brandenrodgers @kemmerle @joe-yeager 
