### PR TITLE
Fix bug with updating next tag on releases to latest

### DIFF
--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -199,6 +199,9 @@ async function handler({
   }
 
   logger.log();
+  if (dryRun) {
+    logger.log('DRY RUN');
+  }
   logger.log(`Current version: ${currentVersion}`);
   logger.log(`New version to release: ${newVersion}`);
 

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -101,6 +101,31 @@ async function publish(tag: Tag, isDryRun: boolean): Promise<void> {
   });
 }
 
+async function updateNextTag(newVersion: string): Promise<void> {
+  logger.log();
+  logger.log(`Updating ${TAG.NEXT} tag...`);
+
+  const commandArgs = [
+    'dist-tag',
+    'add',
+    `${packageName}@${newVersion}`,
+    TAG.NEXT,
+  ];
+
+  return new Promise((resolve, reject) => {
+    const childProcess = spawn('npm', commandArgs, { stdio: 'inherit' });
+
+    childProcess.on('close', code => {
+      if (code !== EXIT_CODES.SUCCESS) {
+        reject();
+      } else {
+        logger.success(`${TAG.NEXT} tag updated successfully`);
+        resolve();
+      }
+    });
+  });
+}
+
 async function handler({
   versionIncrement,
   tag,
@@ -207,7 +232,7 @@ async function handler({
     await publish(tag, isDryRun);
 
     if (tag === TAG.LATEST) {
-      await publish(TAG.NEXT, isDryRun);
+      await updateNextTag(newVersion);
     }
   } catch (e) {
     logger.error(


### PR DESCRIPTION
## Description and Context
Currently, the release script errors out after publishing to `latest`, since it tries to republish the CLI to `next` when it should instead just be updating the dist tag to point to the latest published version. This fixes that.

Note: there does not appear to be any kind of `dry-run` functionality for the `dist-tag` command so there is unfortunately not a great way to fully test this without actually releasing. When the `dryRun` flag is passed in, the script will log the dist-tag command it would have run

## Who to Notify
@brandenrodgers @kemmerle @joe-yeager 
