### PR TITLE
fix: Address bug where we destructure an nullable object

### DIFF
--- a/commands/project/installDeps.ts
+++ b/commands/project/installDeps.ts
@@ -19,9 +19,10 @@ exports.command = 'install-deps [packages..]';
 exports.describe = null;
 // exports.describe = uiBetaTag(i18n(`${i18nKey}.help.describe`), false);
 
-exports.handler = async ({ packages }) => {
+exports.handler = async options => {
+  const { packages } = options || {};
   try {
-    const accountId = getAccountId({});
+    const accountId = getAccountId(options);
     trackCommandUsage('project-install-deps', null, accountId);
 
     const projectConfig = await getProjectConfig();

--- a/commands/project/installDeps.ts
+++ b/commands/project/installDeps.ts
@@ -21,7 +21,7 @@ exports.describe = null;
 
 exports.handler = async ({ packages }) => {
   try {
-    const accountId = getAccountId();
+    const accountId = getAccountId({});
     trackCommandUsage('project-install-deps', null, accountId);
 
     const projectConfig = await getProjectConfig();

--- a/commands/project/logs.ts
+++ b/commands/project/logs.ts
@@ -105,7 +105,7 @@ exports.handler = async options => {
     logPreamble();
   } catch (e) {
     logError(e, {
-      accountId: getAccountId(),
+      accountId,
       projectName: ProjectLogsManager.projectName,
     });
     return process.exit(EXIT_CODES.ERROR);

--- a/lib/commonOpts.ts
+++ b/lib/commonOpts.ts
@@ -92,9 +92,9 @@ export function getCommandName(argv: Arguments<{ _?: string[] }>): string {
 export function getAccountId(
   options: Arguments<{ portal?: number | string; account?: number | string }>
 ): number | null {
-  const { portal, account } = options;
+  const { portal, account } = options || {};
 
-  if (options.useEnv && process.env.HUBSPOT_PORTAL_ID) {
+  if (options?.useEnv && process.env.HUBSPOT_PORTAL_ID) {
     return parseInt(process.env.HUBSPOT_PORTAL_ID, 10);
   }
 


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
Fixes this bug which just appeared on main
```
🚀🚀🚀 ➜ hs project install-deps --debug
[DEBUG] TypeError: Cannot destructure property 'portal' of 'options' as it is undefined.
    at getAccountId (/Users/jyeager/.nvm/versions/node/v18.20.4/lib/node_modules/@hubspot/cli/lib/commonOpts.js:79:13)
    at exports.handler
[ERROR] Cannot destructure property 'portal' of 'options' as it is undefined.
```

