### PR TITLE
chore: Add flag to not track the hs init command

### DIFF
--- a/acceptance-tests/lib/TestState.ts
+++ b/acceptance-tests/lib/TestState.ts
@@ -45,7 +45,7 @@ export class TestState {
   async initializeAuth() {
     try {
       await this.cli.executeWithTestConfig(
-        ['init'],
+        ['init', '--disable-tracking'],
         getInitPromptSequence(this.getPAK())
       );
 

--- a/acceptance-tests/tests/workflows/accountManagementFlow.spec.ts
+++ b/acceptance-tests/tests/workflows/accountManagementFlow.spec.ts
@@ -27,7 +27,7 @@ describe('Account Management Flow', () => {
   describe('hs init', () => {
     it('should generate a config file', async () => {
       await testState.cli.executeWithTestConfig(
-        ['init'],
+        ['init', '--disable-tracking'],
         getInitPromptSequence(testState.getPAK(), accountName)
       );
 

--- a/commands/__tests__/init.test.ts
+++ b/commands/__tests__/init.test.ts
@@ -33,6 +33,11 @@ describe('commands/init', () => {
           default: 'personalaccesskey',
         }),
         account: expect.objectContaining({ type: 'string' }),
+        'disable-tracking': expect.objectContaining({
+          type: 'boolean',
+          hidden: true,
+          default: false,
+        }),
       });
 
       expect(addConfigOptions).toHaveBeenCalledTimes(1);

--- a/commands/init.ts
+++ b/commands/init.ts
@@ -133,7 +133,6 @@ exports.handler = async options => {
 
   createEmptyConfigFile({
     path: configPath,
-    allowUsageTracking: !options.disableTracking,
   });
 
   handleExit(deleteEmptyConfigFile);

--- a/commands/init.ts
+++ b/commands/init.ts
@@ -131,9 +131,7 @@ exports.handler = async options => {
     await trackAuthAction('init', authType, TRACKING_STATUS.STARTED);
   }
 
-  createEmptyConfigFile({
-    path: configPath,
-  });
+  createEmptyConfigFile({ path: configPath });
 
   handleExit(deleteEmptyConfigFile);
 

--- a/commands/init.ts
+++ b/commands/init.ts
@@ -104,12 +104,17 @@ exports.handler = async options => {
     auth: authType = PERSONAL_ACCESS_KEY_AUTH_METHOD.value,
     c,
     account: optionalAccount,
+    disableTracking,
   } = options;
   const configPath = (c && path.join(getCwd(), c)) || getConfigPath();
   setLogLevel(options);
-  trackCommandUsage('init', {
-    authType,
-  });
+
+  if (!disableTracking) {
+    trackCommandUsage('init', {
+      authType,
+    });
+  }
+
   const env = options.qa ? ENVIRONMENTS.QA : ENVIRONMENTS.PROD;
 
   if (fs.existsSync(configPath)) {
@@ -122,8 +127,15 @@ exports.handler = async options => {
     process.exit(EXIT_CODES.ERROR);
   }
 
-  trackAuthAction('init', authType, TRACKING_STATUS.STARTED);
-  createEmptyConfigFile({ path: configPath });
+  if (!disableTracking) {
+    await trackAuthAction('init', authType, TRACKING_STATUS.STARTED);
+  }
+
+  createEmptyConfigFile({
+    path: configPath,
+    allowUsageTracking: !options.disableTracking,
+  });
+
   handleExit(deleteEmptyConfigFile);
 
   try {
@@ -153,16 +165,20 @@ exports.handler = async options => {
     );
     uiFeatureHighlight(['helpCommand', 'authCommand', 'accountsListCommand']);
 
-    await trackAuthAction(
-      'init',
-      authType,
-      TRACKING_STATUS.COMPLETE,
-      accountId
-    );
+    if (!disableTracking) {
+      await trackAuthAction(
+        'init',
+        authType,
+        TRACKING_STATUS.COMPLETE,
+        accountId
+      );
+    }
     process.exit(EXIT_CODES.SUCCESS);
   } catch (err) {
     logError(err);
-    await trackAuthAction('init', authType, TRACKING_STATUS.ERROR);
+    if (!disableTracking) {
+      await trackAuthAction('init', authType, TRACKING_STATUS.ERROR);
+    }
     process.exit(EXIT_CODES.ERROR);
   }
 };
@@ -184,6 +200,11 @@ exports.builder = yargs => {
     account: {
       describe: i18n(`${i18nKey}.options.account.describe`),
       type: 'string',
+    },
+    'disable-tracking': {
+      type: 'boolean',
+      hidden: true,
+      default: false,
     },
   });
 


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
I realized that tracking still occurs on the `hs init` command, so we will still get noise from the ATs
