### PR TITLE
fix: Revert the --disable-tracking until we can publish the CLI

### DIFF
--- a/acceptance-tests/lib/TestState.ts
+++ b/acceptance-tests/lib/TestState.ts
@@ -45,7 +45,7 @@ export class TestState {
   async initializeAuth() {
     try {
       await this.cli.executeWithTestConfig(
-        ['init', '--disable-tracking'],
+        ['init'],
         getInitPromptSequence(this.getPAK())
       );
 

--- a/acceptance-tests/tests/workflows/accountManagementFlow.spec.ts
+++ b/acceptance-tests/tests/workflows/accountManagementFlow.spec.ts
@@ -27,7 +27,7 @@ describe('Account Management Flow', () => {
   describe('hs init', () => {
     it('should generate a config file', async () => {
       await testState.cli.executeWithTestConfig(
-        ['init', '--disable-tracking'],
+        ['init'],
         getInitPromptSequence(testState.getPAK(), accountName)
       );
 


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
Revert the calls to the `--disable-tracking` flag until we've had a change to publish the CLI
