### PR TITLE
fix: Add --disable-tracking flag back to hs init

### DIFF
--- a/acceptance-tests/lib/TestState.ts
+++ b/acceptance-tests/lib/TestState.ts
@@ -45,7 +45,7 @@ export class TestState {
   async initializeAuth() {
     try {
       await this.cli.executeWithTestConfig(
-        ['init'],
+        ['init', '--disable-tracking'],
         getInitPromptSequence(this.getPAK())
       );
 

--- a/acceptance-tests/tests/workflows/accountManagementFlow.spec.ts
+++ b/acceptance-tests/tests/workflows/accountManagementFlow.spec.ts
@@ -27,7 +27,7 @@ describe('Account Management Flow', () => {
   describe('hs init', () => {
     it('should generate a config file', async () => {
       await testState.cli.executeWithTestConfig(
-        ['init'],
+        ['init', '--disable-tracking'],
         getInitPromptSequence(testState.getPAK(), accountName)
       );
 


### PR DESCRIPTION
This reverts commit 64fb852e8ba97602f10cf055f2d9e0762ac943b4.

## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
Add the `--disable-tracking` flags back.  Don't merge until the CLI has been released 
