### PR TITLE
Only prompt to create release for latest releases

### DIFF
--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -324,9 +324,11 @@ async function handler({
     )
   );
 
-  logger.log();
-  logger.log('Remember to create a new release on Github!');
-  open('https://github.com/HubSpot/hubspot-cli/releases/new');
+  if (tag === TAG.LATEST) {
+    logger.log();
+    logger.log('Remember to create a new release on Github!');
+    open('https://github.com/HubSpot/hubspot-cli/releases/new');
+  }
 }
 
 async function builder(yargs: Argv): Promise<Argv> {


### PR DESCRIPTION
## Description and Context
The release script now opens your browser to create a new release on Github, but this isn't necessary for `next` and `experimental` releases

## Who to Notify
@brandenrodgers @kemmerle @joe-yeager 
