### PR TITLE
Refactor auth commands

### DIFF
--- a/commands/__tests__/auth.test.ts
+++ b/commands/__tests__/auth.test.ts
@@ -11,7 +11,7 @@ import authCommand from '../auth';
 describe('commands/auth', () => {
   describe('command', () => {
     it('should have the correct command structure', () => {
-      expect(authCommand.command).toEqual('auth [type] [--account]');
+      expect(authCommand.command).toEqual('auth');
     });
   });
 
@@ -22,25 +22,16 @@ describe('commands/auth', () => {
   });
 
   describe('builder', () => {
-    it('should support the correct positional arguments', () => {
-      authCommand.builder(yargs);
-
-      expect(yargs.positional).toHaveBeenCalledTimes(1);
-      expect(yargs.positional).toHaveBeenCalledWith(
-        'type',
-        expect.objectContaining({
-          type: 'string',
-          choices: ['personalaccesskey', 'oauth2'],
-          default: 'personalaccesskey',
-        })
-      );
-    });
-
     it('should support the correct options', () => {
       authCommand.builder(yargs);
 
       expect(yargs.options).toHaveBeenCalledTimes(1);
       expect(yargs.options).toHaveBeenCalledWith({
+        'auth-type': expect.objectContaining({
+          type: 'string',
+          choices: ['personalaccesskey', 'oauth2'],
+          default: 'personalaccesskey',
+        }),
         account: expect.objectContaining({ type: 'string' }),
       });
 

--- a/commands/__tests__/init.test.ts
+++ b/commands/__tests__/init.test.ts
@@ -16,7 +16,7 @@ describe('commands/init', () => {
 
   describe('command', () => {
     it('should have the correct command structure', () => {
-      expect(initCommand.command).toEqual('init [--account]');
+      expect(initCommand.command).toEqual('init');
     });
   });
 
@@ -32,7 +32,7 @@ describe('commands/init', () => {
 
       expect(yargs.options).toHaveBeenCalledTimes(1);
       expect(yargs.options).toHaveBeenCalledWith({
-        auth: expect.objectContaining({
+        'auth-type': expect.objectContaining({
           type: 'string',
           choices: ['personalaccesskey', 'oauth2'],
           default: 'personalaccesskey',

--- a/commands/auth.ts
+++ b/commands/auth.ts
@@ -64,24 +64,30 @@ const SUPPORTED_AUTHENTICATION_PROTOCOLS_TEXT = commaSeparatedValues(
   ALLOWED_AUTH_METHODS
 );
 
-exports.command = 'auth [type] [--account]';
+exports.command = 'auth';
 exports.describe = i18n(`${i18nKey}.describe`, {
   supportedProtocols: SUPPORTED_AUTHENTICATION_PROTOCOLS_TEXT,
 });
 
 exports.handler = async options => {
-  const { type, config: c, qa, account } = options;
+  const {
+    authType: authTypeFlagValue,
+    config: configFlagValue,
+    qa,
+    account,
+  } = options;
   const authType =
-    (type && type.toLowerCase()) || PERSONAL_ACCESS_KEY_AUTH_METHOD.value;
+    (authTypeFlagValue && authTypeFlagValue.toLowerCase()) ||
+    PERSONAL_ACCESS_KEY_AUTH_METHOD.value;
   setLogLevel(options);
 
-  if (!getConfigPath(c)) {
+  if (!getConfigPath(configFlagValue)) {
     logger.error(i18n(`${i18nKey}.errors.noConfigFileFound`));
     process.exit(EXIT_CODES.ERROR);
   }
 
   const env = qa ? ENVIRONMENTS.QA : ENVIRONMENTS.PROD;
-  loadConfig(c);
+  loadConfig(configFlagValue);
   checkAndWarnGitInclusion(getConfigPath());
 
   trackCommandUsage('auth');
@@ -195,23 +201,26 @@ exports.handler = async options => {
 };
 
 exports.builder = yargs => {
-  yargs.positional('type', {
-    describe: i18n(`${i18nKey}.positionals.type.describe`),
-    type: 'string',
-    choices: [
-      `${PERSONAL_ACCESS_KEY_AUTH_METHOD.value}`,
-      `${OAUTH_AUTH_METHOD.value}`,
-    ],
-    default: PERSONAL_ACCESS_KEY_AUTH_METHOD.value,
-    defaultDescription: i18n(`${i18nKey}.positionals.type.defaultDescription`, {
-      authMethod: PERSONAL_ACCESS_KEY_AUTH_METHOD.value,
-    }),
-  });
-
   yargs.options({
+    'auth-type': {
+      describe: i18n(`${i18nKey}.options.authType.describe`),
+      type: 'string',
+      choices: [
+        `${PERSONAL_ACCESS_KEY_AUTH_METHOD.value}`,
+        `${OAUTH_AUTH_METHOD.value}`,
+      ],
+      default: PERSONAL_ACCESS_KEY_AUTH_METHOD.value,
+      defaultDescription: i18n(
+        `${i18nKey}.options.authType.defaultDescription`,
+        {
+          authMethod: PERSONAL_ACCESS_KEY_AUTH_METHOD.value,
+        }
+      ),
+    },
     account: {
       describe: i18n(`${i18nKey}.options.account.describe`),
       type: 'string',
+      alias: 'a',
     },
   });
 

--- a/commands/init.ts
+++ b/commands/init.ts
@@ -94,19 +94,25 @@ const AUTH_TYPE_NAMES = {
   [OAUTH_AUTH_METHOD.value]: OAUTH_AUTH_METHOD.name,
 };
 
-exports.command = 'init [--account]';
+exports.command = 'init';
 exports.describe = i18n(`${i18nKey}.describe`, {
   configName: DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME,
 });
 
 exports.handler = async options => {
   const {
-    auth: authType = PERSONAL_ACCESS_KEY_AUTH_METHOD.value,
-    c,
-    account: optionalAccount,
+    auth: authTypeFlagValue,
+    c: configFlagValue,
+    account: accountFlagValue,
     disableTracking,
   } = options;
-  const configPath = (c && path.join(getCwd(), c)) || getConfigPath();
+  const authType =
+    (authTypeFlagValue && authTypeFlagValue.toLowerCase()) ||
+    PERSONAL_ACCESS_KEY_AUTH_METHOD.value;
+
+  const configPath =
+    (configFlagValue && path.join(getCwd(), configFlagValue)) ||
+    getConfigPath();
   setLogLevel(options);
 
   if (!disableTracking) {
@@ -138,7 +144,7 @@ exports.handler = async options => {
   try {
     const { accountId, name } = await CONFIG_CREATION_FLOWS[authType](
       env,
-      optionalAccount
+      accountFlagValue
     );
     const configPath = getConfigPath();
 
@@ -182,21 +188,25 @@ exports.handler = async options => {
 
 exports.builder = yargs => {
   yargs.options({
-    auth: {
-      describe: i18n(`${i18nKey}.options.auth.describe`),
+    'auth-type': {
+      describe: i18n(`${i18nKey}.options.authType.describe`),
       type: 'string',
       choices: [
         `${PERSONAL_ACCESS_KEY_AUTH_METHOD.value}`,
         `${OAUTH_AUTH_METHOD.value}`,
       ],
       default: PERSONAL_ACCESS_KEY_AUTH_METHOD.value,
-      defaultDescription: i18n(`${i18nKey}.options.auth.defaultDescription`, {
-        defaultType: PERSONAL_ACCESS_KEY_AUTH_METHOD.value,
-      }),
+      defaultDescription: i18n(
+        `${i18nKey}.options.authType.defaultDescription`,
+        {
+          defaultType: PERSONAL_ACCESS_KEY_AUTH_METHOD.value,
+        }
+      ),
     },
     account: {
       describe: i18n(`${i18nKey}.options.account.describe`),
       type: 'string',
+      alias: 'a',
     },
     'disable-tracking': {
       type: 'boolean',

--- a/commands/init.ts
+++ b/commands/init.ts
@@ -204,37 +204,39 @@ exports.handler = async options => {
 };
 
 exports.builder = yargs => {
-  yargs.options({
-    'auth-type': {
-      describe: i18n(`${i18nKey}.options.authType.describe`),
-      type: 'string',
-      choices: [
-        `${PERSONAL_ACCESS_KEY_AUTH_METHOD.value}`,
-        `${OAUTH_AUTH_METHOD.value}`,
-      ],
-      default: PERSONAL_ACCESS_KEY_AUTH_METHOD.value,
-      defaultDescription: i18n(
-        `${i18nKey}.options.authType.defaultDescription`,
-        {
-          defaultType: PERSONAL_ACCESS_KEY_AUTH_METHOD.value,
-        }
-      ),
-    },
-    account: {
-      describe: i18n(`${i18nKey}.options.account.describe`),
-      type: 'string',
-      alias: 'a',
-    },
-    'disable-tracking': {
-      type: 'boolean',
-      hidden: true,
-      default: false,
-    },
-    'use-hidden-config': {
-      describe: i18n(`${i18nKey}.options.useHiddenConfig.describe`),
-      type: 'boolean',
-    },
-  });
+  yargs
+    .options({
+      'auth-type': {
+        describe: i18n(`${i18nKey}.options.authType.describe`),
+        type: 'string',
+        choices: [
+          `${PERSONAL_ACCESS_KEY_AUTH_METHOD.value}`,
+          `${OAUTH_AUTH_METHOD.value}`,
+        ],
+        default: PERSONAL_ACCESS_KEY_AUTH_METHOD.value,
+        defaultDescription: i18n(
+          `${i18nKey}.options.authType.defaultDescription`,
+          {
+            defaultType: PERSONAL_ACCESS_KEY_AUTH_METHOD.value,
+          }
+        ),
+      },
+      account: {
+        describe: i18n(`${i18nKey}.options.account.describe`),
+        type: 'string',
+        alias: 'a',
+      },
+      'disable-tracking': {
+        type: 'boolean',
+        hidden: true,
+        default: false,
+      },
+      'use-hidden-config': {
+        describe: i18n(`${i18nKey}.options.useHiddenConfig.describe`),
+        type: 'boolean',
+      },
+    })
+    .conflicts('use-hidden-config', 'config');
 
   addConfigOptions(yargs);
   addTestingOptions(yargs);

--- a/lang/en.lyaml
+++ b/lang/en.lyaml
@@ -87,11 +87,10 @@ en:
       errors:
         noConfigFileFound: "No config file was found. To create a new config file, use the \"hs init\" command."
         unsupportedAuthType: "Unsupported auth type: {{ type }}. The only supported authentication protocols are {{ supportedProtocols }}."
-      positionals:
-        type:
-          describe: "Authentication mechanism"
-          defaultDescription: "\"{{ authMethod }}\": \nAn access token tied to a specific user account. This is the recommended way of authenticating with local development tools."
       options:
+        authType:
+          describe: "Authentication mechanism"
+          defaultDescription: "\"{{ authMethod }}\": An access token tied to a specific user account. This is the recommended way of authenticating with local development tools."
         account:
           describe: "HubSpot account to authenticate"
       success:
@@ -417,9 +416,9 @@ en:
     init:
       describe: "Initialize {{ configName }} for a HubSpot account."
       options:
-        auth:
-          describe: "Specify auth method to use [\"personalaccesskey\", \"oauth2\"]"
-          defaultDescription: "\"{{ defaultType }}\": \nAn access token tied to a specific user account. This is the recommended way of authenticating with local development tools."
+        authType:
+          describe: "Authentication mechanism"
+          defaultDescription: "\"{{ authMethod }}\":  An access token tied to a specific user account. This is the recommended way of authenticating with local development tools."
         account:
           describe: "HubSpot account to authenticate"
       success:


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
Refactoring the auth commands to follow our new guidelines. Major change in here is that we're now using a standardized `auth-type` flag to represent the type of auth used for account authorization.

#### hs auth
- [x] Update description to: "Configure authentication for a HubSpot account."
- [ ] Remove `--version` flag because it's unnecessary
- [x] The `type` positional should be converted to a flag and renamed to `--auth-type`
- [x] The `account` positional should be a flag, and it should support the short-hand `-a` option

#### hs init
- [x] Update description to: "Initialize the CLI config file and authenticate a HubSpot account."
- [ ] Remove `--version` flag because it's unnecessary
- [x] The `account` positional should be a flag, and it should support the short-hand `-a` option
- [x] The `--auth` flag should become `--auth-type`

## Screenshots
<!-- Provide images of the before and after functionality -->

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
