### PR TITLE
feat: Update secrets commands to match design guidelines

### DIFF
--- a/acceptance-tests/tests/workflows/secretsFlow.spec.ts
+++ b/acceptance-tests/tests/workflows/secretsFlow.spec.ts
@@ -54,11 +54,10 @@ describe('Secrets Flow', () => {
 
   describe('hs secrets delete', () => {
     it('should delete the secret', async () => {
-      await testState.cli.executeWithTestConfig([
-        'secrets',
-        'delete',
-        SECRET.name,
-      ]);
+      await testState.cli.executeWithTestConfig(
+        ['secrets', 'delete', SECRET.name],
+        ['Y', ENTER]
+      );
     });
   });
 

--- a/commands/secrets.ts
+++ b/commands/secrets.ts
@@ -1,5 +1,4 @@
 // @ts-nocheck
-const { addConfigOptions, addAccountOptions } = require('../lib/commonOpts');
 
 const addSecretCommand = require('./secrets/addSecret');
 const listSecretsCommand = require('./secrets/listSecrets');
@@ -9,12 +8,10 @@ const { i18n } = require('../lib/lang');
 
 const i18nKey = 'commands.secrets';
 
-exports.command = 'secrets';
+exports.command = ['secret', 'secrets'];
 exports.describe = i18n(`${i18nKey}.describe`);
 
 exports.builder = yargs => {
-  addConfigOptions(yargs);
-  addAccountOptions(yargs);
   yargs
     .command(listSecretsCommand)
     .command(addSecretCommand)

--- a/commands/secrets/addSecret.ts
+++ b/commands/secrets/addSecret.ts
@@ -1,4 +1,8 @@
 // @ts-nocheck
+import { EXIT_CODES } from '../../lib/enums/exitCodes';
+import { fetchSecrets } from '@hubspot/local-dev-lib/api/secrets';
+import { uiCommandReference } from '../../lib/ui';
+
 const { logger } = require('@hubspot/local-dev-lib/logger');
 const { logError, ApiErrorContext } = require('../../lib/errorHandlers/index');
 const { addSecret } = require('@hubspot/local-dev-lib/api/secrets');
@@ -13,23 +17,45 @@ const {
   getAccountId,
 } = require('../../lib/commonOpts');
 const { uiAccountDescription } = require('../../lib/ui');
-const { secretValuePrompt } = require('../../lib/prompts/secretPrompt');
+const {
+  secretValuePrompt,
+  secretNamePrompt,
+} = require('../../lib/prompts/secretPrompt');
 const { i18n } = require('../../lib/lang');
 
 const i18nKey = 'commands.secrets.subcommands.add';
 
-exports.command = 'add <name>';
+exports.command = 'add [name]';
 exports.describe = i18n(`${i18nKey}.describe`);
 
 exports.handler = async options => {
-  const { name: secretName } = options;
-
+  const { name } = options;
+  let secretName = name;
   await loadAndValidateOptions(options);
 
   const accountId = getAccountId(options);
   trackCommandUsage('secrets-add', null, accountId);
 
   try {
+    if (!secretName) {
+      const { secretName: name } = await secretNamePrompt();
+      secretName = name;
+    }
+
+    const {
+      data: { results: secrets },
+    } = await fetchSecrets(accountId);
+
+    if (secrets.includes(secretName)) {
+      logger.error(
+        i18n(`${i18nKey}.errors.alreadyExists`, {
+          secretName,
+          command: uiCommandReference('hs secret update'),
+        })
+      );
+      process.exit(EXIT_CODES.ERROR);
+    }
+
     const { secretValue } = await secretValuePrompt();
 
     await addSecret(accountId, secretName, secretValue);

--- a/commands/secrets/deleteSecret.ts
+++ b/commands/secrets/deleteSecret.ts
@@ -1,7 +1,14 @@
 // @ts-nocheck
+import { secretListPrompt } from '../../lib/prompts/secretPrompt';
+import { confirmPrompt } from '../../lib/prompts/promptUtils';
+import { EXIT_CODES } from '../../lib/enums/exitCodes';
+
 const { logger } = require('@hubspot/local-dev-lib/logger');
 const { ApiErrorContext, logError } = require('../../lib/errorHandlers/index');
-const { deleteSecret } = require('@hubspot/local-dev-lib/api/secrets');
+const {
+  deleteSecret,
+  fetchSecrets,
+} = require('@hubspot/local-dev-lib/api/secrets');
 
 const { loadAndValidateOptions } = require('../../lib/validation');
 const { trackCommandUsage } = require('../../lib/usageTracking');
@@ -17,11 +24,12 @@ const { i18n } = require('../../lib/lang');
 
 const i18nKey = 'commands.secrets.subcommands.delete';
 
-exports.command = 'delete <name>';
+exports.command = 'delete [name]';
 exports.describe = i18n(`${i18nKey}.describe`);
 
 exports.handler = async options => {
-  const { name: secretName } = options;
+  const { name, force } = options;
+  let secretName = name;
 
   await loadAndValidateOptions(options);
 
@@ -29,6 +37,34 @@ exports.handler = async options => {
   trackCommandUsage('secrets-delete', null, accountId);
 
   try {
+    const {
+      data: { results: secrets },
+    } = await fetchSecrets(accountId);
+
+    if (secretName && !secrets.includes(secretName)) {
+      logger.error(i18n(`${i18nKey}.errors.noSecret`, { secretName }));
+      process.exit(EXIT_CODES.ERROR);
+    }
+
+    if (!secretName) {
+      const { secretToModify } = await secretListPrompt(
+        secrets,
+        i18n(`${i18nKey}.selectSecret`)
+      );
+      secretName = secretToModify;
+    }
+
+    const confirmDelete =
+      force ||
+      (await confirmPrompt(i18n(`${i18nKey}.confirmDelete`, { secretName }), {
+        defaultAnswer: false,
+      }));
+
+    if (!confirmDelete) {
+      logger.success(i18n(`${i18nKey}.deleteCanceled`));
+      process.exit(EXIT_CODES.SUCCESS);
+    }
+
     await deleteSecret(accountId, secretName);
     logger.success(
       i18n(`${i18nKey}.success.delete`, {
@@ -56,9 +92,14 @@ exports.builder = yargs => {
   addConfigOptions(yargs);
   addAccountOptions(yargs);
   addUseEnvironmentOptions(yargs);
-  yargs.positional('name', {
-    describe: i18n(`${i18nKey}.positionals.name.describe`),
-    type: 'string',
-  });
+  yargs
+    .positional('name', {
+      describe: i18n(`${i18nKey}.positionals.name.describe`),
+      type: 'string',
+    })
+    .options('force', {
+      describe: 'Force the deletion',
+      type: 'boolean',
+    });
   return yargs;
 };

--- a/commands/secrets/updateSecret.ts
+++ b/commands/secrets/updateSecret.ts
@@ -1,7 +1,12 @@
 // @ts-nocheck
+import { EXIT_CODES } from '../../lib/enums/exitCodes';
+
 const { logger } = require('@hubspot/local-dev-lib/logger');
 const { ApiErrorContext, logError } = require('../../lib/errorHandlers/index');
-const { updateSecret } = require('@hubspot/local-dev-lib/api/secrets');
+const {
+  updateSecret,
+  fetchSecrets,
+} = require('@hubspot/local-dev-lib/api/secrets');
 
 const { loadAndValidateOptions } = require('../../lib/validation');
 const { trackCommandUsage } = require('../../lib/usageTracking');
@@ -13,23 +18,43 @@ const {
   addUseEnvironmentOptions,
   getAccountId,
 } = require('../../lib/commonOpts');
-const { secretValuePrompt } = require('../../lib/prompts/secretPrompt');
+const {
+  secretValuePrompt,
+  secretListPrompt,
+} = require('../../lib/prompts/secretPrompt');
 const { i18n } = require('../../lib/lang');
 
 const i18nKey = 'commands.secrets.subcommands.update';
 
-exports.command = 'update <name>';
+exports.command = 'update [name]';
 exports.describe = i18n(`${i18nKey}.describe`);
 
 exports.handler = async options => {
-  const { name: secretName } = options;
-
+  const { name } = options;
+  let secretName = name;
   await loadAndValidateOptions(options);
 
   const accountId = getAccountId(options);
   trackCommandUsage('secrets-update', null, accountId);
 
   try {
+    const {
+      data: { results: secrets },
+    } = await fetchSecrets(accountId);
+
+    if (secretName && !secrets.includes(secretName)) {
+      logger.error(i18n(`${i18nKey}.errors.noSecret`, { secretName }));
+      process.exit(EXIT_CODES.ERROR);
+    }
+
+    if (!secretName) {
+      const { secretToModify } = await secretListPrompt(
+        secrets,
+        i18n(`${i18nKey}.selectSecret`)
+      );
+      secretName = secretToModify;
+    }
+
     const { secretValue } = await secretValuePrompt();
 
     await updateSecret(accountId, secretName, secretValue);

--- a/lang/en.lyaml
+++ b/lang/en.lyaml
@@ -795,35 +795,42 @@ en:
             account:
               describe: "Account name or id to delete"
     secrets:
-      describe: "Manage HubSpot secrets."
+      describe: "Commands for managing secrets."
       subcommands:
         add:
-          describe: "Add a HubSpot secret"
+          describe: "Create a new secret."
           errors:
             add: "The secret \"{{ secretName }}\" was not added"
+            alreadyExists: "The secret \"{{ secretName }}\" already exists, it's value can be modified with {{ command }}"
           positionals:
             name:
               describe: "Name of the secret"
           success:
             add: "The secret \"{{ secretName }}\" was added to the HubSpot account: {{ accountIdentifier }}"
         delete:
-          describe: "Delete a HubSpot secret"
+          describe: "Delete a secret."
+          selectSecret: "Select the secret you want to delete"
+          deleteCanceled: "Delete canceled"
+          confirmDelete: "Are you sure you want to delete the secret \"{{ secretName }}\"?"
           errors:
             delete: "The secret \"{{ secretName }}\" was not deleted"
+            noSecret: "Unable to delete secret with name \"{{ secretName }}\", it does not exist"
           positionals:
             name:
               describe: "Name of the secret"
           success:
             delete: "The secret \"{{ secretName }}\" was deleted from the HubSpot account: {{ accountIdentifier }}"
         list:
-          describe: "List all HubSpot secrets"
+          describe: "List all secrets."
           errors:
             list: "The secrets could not be listed"
           groupLabel: "Secrets for account {{ accountIdentifier }}:"
         update:
-          describe: "Update an existing HubSpot secret"
+          describe: "Update an existing secret."
+          selectSecret: "Select the secret you want to update"
           errors:
             update: "The secret \"{{ secretName }}\" was not updated"
+            noSecret: "Unable to update secret with name \"{{ secretName }}\", it does not exist"
           positionals:
             name:
               describe: "Name of the secret to be updated"
@@ -1269,6 +1276,9 @@ en:
           invalidType: "[--type] Could not find type {{ type }}. Please choose an available type."
       secretPrompt:
         enterValue: "Enter a value for your secret: "
+        enterName: "Enter a name for your secret: "
+        selectSecretUpdate: "Select the secret you want to update"
+        selectSecretDelete: "Select the secret you want to delete"
         errors:
           invalidValue: "You entered an invalid value. Please try again."
       sandboxesPrompt:

--- a/lib/prompts/promptUtils.ts
+++ b/lib/prompts/promptUtils.ts
@@ -8,13 +8,13 @@ export async function confirmPrompt(
   message: string,
   options: { defaultAnswer?: boolean; when?: boolean | (() => boolean) } = {}
 ): Promise<boolean> {
-  const { defaultAnswer, when } = options;
+  const { defaultAnswer = true, when } = options;
   const { choice } = await promptUser([
     {
       name: 'choice',
       type: 'confirm',
       message,
-      default: defaultAnswer || true,
+      default: defaultAnswer,
       when,
     },
   ]);

--- a/lib/prompts/secretPrompt.ts
+++ b/lib/prompts/secretPrompt.ts
@@ -1,26 +1,36 @@
-// @ts-nocheck
-const { promptUser } = require('./promptUtils');
-const { i18n } = require('../lang');
+import { promptUser } from './promptUtils';
+import { i18n } from '../lang';
 
 const i18nKey = 'lib.prompts.secretPrompt';
 
-const SECRET_VALUE_PROMPT = {
-  name: 'secretValue',
-  type: 'password',
-  mask: '*',
-  message: i18n(`${i18nKey}.enterValue`),
-  validate(val) {
-    if (typeof val !== 'string') {
-      return i18n(`${i18nKey}.errors.invalidValue`);
-    }
-    return true;
-  },
-};
-
-function secretValuePrompt() {
-  return promptUser([SECRET_VALUE_PROMPT]);
+export function secretValuePrompt() {
+  return promptUser([
+    {
+      name: 'secretValue',
+      type: 'password',
+      mask: '*',
+      message: i18n(`${i18nKey}.enterValue`),
+    },
+  ]);
 }
 
-module.exports = {
-  secretValuePrompt,
-};
+export function secretNamePrompt() {
+  return promptUser([
+    {
+      name: 'secretName',
+      type: 'input',
+      message: i18n(`${i18nKey}.enterName`),
+    },
+  ]);
+}
+
+export function secretListPrompt(secrets: string, message: string) {
+  return promptUser([
+    {
+      name: 'secretToModify',
+      type: 'list',
+      choices: secrets,
+      message,
+    },
+  ]);
+}


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
#### hs secrets
-  [x] Update description to: "Commands for managing secrets."
- [x] Remove all flags except for the `--help` flag because they don't do anything
- [x] Change primary command to `hs secret`, but continue to support `hs secrets` as a plural alias

#### hs secrets list
- [x] Update description to: "List all secrets."

#### hs secrets add
- [x] Update description to: "Create a new secret."
- [x] Name input should fall back to an input prompt when not specified
- [x] Add a check to see if the secret already exists before prompting for value and creating

#### hs secrets update
- [x] Add a period to the end of the description
- [x] Name input should fall back to a list of available secrets when not specified
- [x] Add a check to see if the secret exists before prompting for value and attempting to update

#### hs secrets delete
- [x] Add a period to the end of the description
- [x] Name input should fall back to a list of available secrets when not specified
- [x] Prompt for confirmation before delete. Support `--force` flag to bypass this
- [x] Add a check to see if the secret exists before attempting to delete