### PR TITLE
restructure the open command

### DIFF
--- a/commands/open.ts
+++ b/commands/open.ts
@@ -1,4 +1,5 @@
 // @ts-nocheck
+import { EXIT_CODES } from '../lib/enums/exitCodes';
 const {
   addAccountOptions,
   addConfigOptions,
@@ -38,12 +39,12 @@ exports.handler = async options => {
   if (shortcut === undefined && !list) {
     const choice = await createListPrompt(derivedAccountId);
     openLink(derivedAccountId, choice.open);
-  } else if (list || shortcut === 'list') {
+  } else if (list) {
     logSiteLinks(derivedAccountId);
-    return;
   } else {
     openLink(derivedAccountId, shortcut);
   }
+  process.exit(EXIT_CODES.SUCCESS);
 };
 
 exports.builder = yargs => {

--- a/lang/en.lyaml
+++ b/lang/en.lyaml
@@ -476,7 +476,7 @@ en:
         moveFailed: "Moving \"{{ srcPath }}\" to \"{{ destPath }}\" in account {{ accountId }} failed"
       move: "Moved \"{{ srcPath }}\" to \"{{ destPath }}\" in account {{ accountId }}"
     open:
-      describe: "Open a HubSpot page in your browser. Run \"hs open list\" to see all available shortcuts."
+      describe: "Open a HubSpot page in your browser."
       options:
         list:
           describe: "List all supported shortcuts"


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
Some small changes to the `hs open` command. Mainly removing `hs open list` as a special-cased positional argument.

#### hs open
- [x] Update description to: "Open a HubSpot page in your browser."
- [ ] Remove --version flag because it's unnecessary
- [x] list should only exist as a flag and not as a special-cased positional argument
- [ ] Project and app related shortcuts should be added to the command

## Screenshots
<!-- Provide images of the before and after functionality -->

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
