### PR TITLE
feat: Restructure custom-object commands to match design guidelines

### DIFF
--- a/commands/customObject.ts
+++ b/commands/customObject.ts
@@ -1,5 +1,4 @@
 // @ts-nocheck
-const { addConfigOptions, addAccountOptions } = require('../lib/commonOpts');
 const schemaCommand = require('./customObject/schema');
 const createCommand = require('./customObject/create');
 const { i18n } = require('../lib/lang');
@@ -8,7 +7,7 @@ const { uiBetaTag, uiLink } = require('../lib/ui');
 
 const i18nKey = 'commands.customObject';
 
-exports.command = ['custom-object', 'custom', 'co'];
+exports.command = ['custom-object', 'custom-objects', 'co'];
 exports.describe = uiBetaTag(i18n(`${i18nKey}.describe`), false);
 
 const logBetaMessage = () => {
@@ -23,9 +22,6 @@ const logBetaMessage = () => {
 };
 
 exports.builder = yargs => {
-  addConfigOptions(yargs);
-  addAccountOptions(yargs);
-
   yargs
     .middleware([logBetaMessage])
     .command(schemaCommand)

--- a/commands/customObject/create.ts
+++ b/commands/customObject/create.ts
@@ -15,7 +15,7 @@ const { i18n } = require('../../lib/lang');
 const i18nKey = 'commands.customObject.subcommands.create';
 const { EXIT_CODES } = require('../../lib/enums/exitCodes');
 
-exports.command = 'create <name> <definition>';
+exports.command = 'create [name]';
 exports.describe = i18n(`${i18nKey}.describe`);
 
 exports.handler = async options => {
@@ -33,6 +33,9 @@ exports.handler = async options => {
   }
 
   try {
+    if (!name) {
+      // TODO prompt for the name
+    }
     await batchCreateObjects(derivedAccountId, name, objectJson);
     logger.success(i18n(`${i18nKey}.success.objectsCreated`));
   } catch (e) {
@@ -46,13 +49,13 @@ exports.handler = async options => {
 };
 
 exports.builder = yargs => {
-  yargs.positional('name', {
-    describe: i18n(`${i18nKey}.positionals.name.describe`),
-    type: 'string',
-  });
-
-  yargs.positional('definition', {
-    describe: i18n(`${i18nKey}.positionals.definition.describe`),
-    type: 'string',
-  });
+  yargs
+    .positional('name', {
+      describe: i18n(`${i18nKey}.positionals.name.describe`),
+      type: 'string',
+    })
+    .option('path', {
+      describe: i18n(`${i18nKey}.options.path.describe`),
+      type: 'string',
+    });
 };

--- a/commands/customObject/schema.ts
+++ b/commands/customObject/schema.ts
@@ -9,7 +9,7 @@ const { i18n } = require('../../lib/lang');
 
 const i18nKey = 'commands.customObject.subcommands.schema';
 
-exports.command = 'schema';
+exports.command = ['schema', 'schemas'];
 exports.describe = i18n(`${i18nKey}.describe`);
 exports.builder = yargs => {
   yargs

--- a/commands/customObject/schema/create.ts
+++ b/commands/customObject/schema/create.ts
@@ -28,7 +28,7 @@ const { i18n } = require('../../../lib/lang');
 const i18nKey = 'commands.customObject.subcommands.schema.subcommands.create';
 const { EXIT_CODES } = require('../../../lib/enums/exitCodes');
 
-exports.command = 'create <definition>';
+exports.command = 'create';
 exports.describe = i18n(`${i18nKey}.describe`);
 
 exports.handler = async options => {
@@ -75,8 +75,8 @@ exports.handler = async options => {
 exports.builder = yargs => {
   addTestingOptions(yargs);
 
-  yargs.positional('definition', {
-    describe: i18n(`${i18nKey}.positionals.definition.describe`),
+  yargs.option('path', {
+    describe: i18n(`${i18nKey}.options.definition.describe`),
     type: 'string',
   });
 };

--- a/commands/customObject/schema/delete.ts
+++ b/commands/customObject/schema/delete.ts
@@ -1,4 +1,6 @@
 // @ts-nocheck
+import { EXIT_CODES } from '../../../lib/enums/exitCodes';
+
 const { logger } = require('@hubspot/local-dev-lib/logger');
 const { loadAndValidateOptions } = require('../../../lib/validation');
 const { trackCommandUsage } = require('../../../lib/usageTracking');
@@ -10,17 +12,27 @@ const { logError } = require('../../../lib/errorHandlers');
 
 const i18nKey = 'commands.customObject.subcommands.schema.subcommands.delete';
 
-exports.command = 'delete <name>';
+exports.command = 'delete [name]';
 exports.describe = i18n(`${i18nKey}.describe`);
 
 exports.handler = async options => {
-  const { name, derivedAccountId } = options;
+  const { name, force, derivedAccountId } = options;
 
   await loadAndValidateOptions(options);
 
   trackCommandUsage('custom-object-schema-delete', null, derivedAccountId);
 
   try {
+    if (!name) {
+      // TODO: fetch all the schemas and prompt for the name
+    }
+    const shouldDelete = force; // TODO: prompt for confirmation
+
+    if (!shouldDelete) {
+      logger.success('Delete cancelled');
+      return process.exit(EXIT_CODES.SUCCESS);
+    }
+
     await deleteObjectSchema(derivedAccountId, name);
     logger.success(
       i18n(`${i18nKey}.success.delete`, {
@@ -38,12 +50,16 @@ exports.handler = async options => {
 };
 
 exports.builder = yargs => {
-  yargs.example([
-    ['$0 schema delete schemaName', i18n(`${i18nKey}.examples.default`)],
-  ]);
-
-  yargs.positional('name', {
-    describe: i18n(`${i18nKey}.positionals.name.describe`),
-    type: 'string',
-  });
+  yargs
+    .example([
+      ['$0 schema delete schemaName', i18n(`${i18nKey}.examples.default`)],
+    ])
+    .positional('name', {
+      describe: i18n(`${i18nKey}.positionals.name.describe`),
+      type: 'string',
+    })
+    .option('force', {
+      describe: i18n(`${i18nKey}.options.force.describe`),
+      type: 'boolean',
+    });
 };

--- a/commands/customObject/schema/fetch-all.ts
+++ b/commands/customObject/schema/fetch-all.ts
@@ -18,12 +18,15 @@ exports.describe = i18n(`${i18nKey}.describe`);
 exports.handler = async options => {
   await loadAndValidateOptions(options);
 
-  const { derivedAccountId } = options;
+  const { derivedAccountId, dest } = options;
 
   trackCommandUsage('custom-object-schema-fetch-all', null, derivedAccountId);
 
   try {
-    const schemas = await downloadSchemas(derivedAccountId, options.dest);
+    if (!dest) {
+      // TODO: prompt for the dest
+    }
+    const schemas = await downloadSchemas(derivedAccountId, options);
     logSchemas(schemas);
     logger.success(
       i18n(`${i18nKey}.success.fetch`, {

--- a/commands/customObject/schema/fetch.ts
+++ b/commands/customObject/schema/fetch.ts
@@ -17,11 +17,19 @@ const { logError } = require('../../../lib/errorHandlers');
 
 const i18nKey = 'commands.customObject.subcommands.schema.subcommands.fetch';
 
-exports.command = 'fetch <name> [dest]';
+exports.command = 'fetch [name] [dest]';
 exports.describe = i18n(`${i18nKey}.describe`);
 
 exports.handler = async options => {
   const { name, dest, derivedAccountId } = options;
+
+  if (!name) {
+    // TODO: prompt for the name
+  }
+
+  if (!dest) {
+    // TODO: prompt for the dest
+  }
 
   await loadAndValidateOptions(options);
 
@@ -56,24 +64,23 @@ exports.handler = async options => {
 };
 
 exports.builder = yargs => {
-  yargs.example([
-    [
-      '$0 custom-object schema fetch schemaName',
-      i18n(`${i18nKey}.examples.default`),
-    ],
-    [
-      '$0 custom-object schema fetch schemaName my/folder',
-      i18n(`${i18nKey}.examples.specifyPath`),
-    ],
-  ]);
-
-  yargs.positional('name', {
-    describe: i18n(`${i18nKey}.positionals.name.describe`),
-    type: 'string',
-  });
-
-  yargs.positional('dest', {
-    describe: i18n(`${i18nKey}.positionals.dest.describe`),
-    type: 'string',
-  });
+  yargs
+    .example([
+      [
+        '$0 custom-object schema fetch schemaName',
+        i18n(`${i18nKey}.examples.default`),
+      ],
+      [
+        '$0 custom-object schema fetch schemaName my/folder',
+        i18n(`${i18nKey}.examples.specifyPath`),
+      ],
+    ])
+    .positional('name', {
+      describe: i18n(`${i18nKey}.positionals.name.describe`),
+      type: 'string',
+    })
+    .positional('dest', {
+      describe: i18n(`${i18nKey}.positionals.dest.describe`),
+      type: 'string',
+    });
 };

--- a/commands/customObject/schema/update.ts
+++ b/commands/customObject/schema/update.ts
@@ -28,7 +28,7 @@ const { i18n } = require('../../../lib/lang');
 const i18nKey = 'commands.customObject.subcommands.schema.subcommands.update';
 const { EXIT_CODES } = require('../../../lib/enums/exitCodes');
 
-exports.command = 'update <name> <definition>';
+exports.command = 'update <name>';
 exports.describe = i18n(`${i18nKey}.describe`);
 
 exports.handler = async options => {
@@ -79,13 +79,13 @@ exports.handler = async options => {
 exports.builder = yargs => {
   addTestingOptions(yargs);
 
-  yargs.positional('name', {
-    describe: i18n(`${i18nKey}.positionals.name.describe`),
-    type: 'string',
-  });
-
-  yargs.positional('definition', {
-    describe: i18n(`${i18nKey}.positionals.definition.describe`),
-    type: 'string',
-  });
+  yargs
+    .positional('name', {
+      describe: i18n(`${i18nKey}.positionals.name.describe`),
+      type: 'string',
+    })
+    .option('path', {
+      describe: i18n(`${i18nKey}.options.definition.describe`),
+      type: 'string',
+    });
 };

--- a/lang/en.lyaml
+++ b/lang/en.lyaml
@@ -196,35 +196,36 @@ en:
             nameRequired: "The \"name\" argument is required when creating a Template."
     customObject:
       betaMessage: "The Custom Object CLI is currently in beta and is subject to change."
-      describe: "Manage Custom Objects. This feature is currently in beta and the CLI contract is subject to change."
+      describe: "Commands for managing custom objects."
       seeMoreLink: "View our docs to find out more."
       subcommands:
         create:
-          describe: "Create custom object instances"
+          describe: "Create custom object instances."
           errors:
             creationFailed: "Object creation from {{ definition }} failed"
-          positionals:
-            definition:
+          options:
+            path:
               describe: "Local path to the JSON file containing an array of object definitions"
+          positionals:
             name:
               describe: "Schema name to add the object instance to"
           success:
             objectsCreated: "Objects created"
         schema:
-          describe: "Manage custom object schemas"
+          describe: "Commands for managing custom object schemas."
           subcommands:
             create:
-              describe: "Create a custom object schema"
+              describe: "Create a custom object schema."
               errors:
                 creationFailed: "Schema creation from {{ definition }} failed"
-              positionals:
+              options:
                 definition:
                   describe: "Local path to the JSON file containing the schema definition"
               success:
                 schemaCreated: "Your schema has been created in account \"{{ accountId }}\""
                 schemaViewable: "Schema can be viewed at {{ url }}"
             delete:
-              describe: "Delete a custom object schema"
+              describe: "Delete a custom object schema."
               errors:
                 delete: "Unable to delete {{ name }}"
               examples:
@@ -232,10 +233,13 @@ en:
               positionals:
                 name:
                   describe: "Name of the target schema"
+              options:
+                force:
+                  describe: "Force the deletion of the schema."
               success:
                 delete: "Successfully initiated deletion of {{ name }}"
             fetchAll:
-              describe: "Fetch all custom object schemas for an account"
+              describe: "Fetch all custom object schemas for an account."
               errors:
                 fetch: "Unable to fetch schemas"
               examples:
@@ -247,7 +251,7 @@ en:
               success:
                 fetch: "Saved schemas to {{ path }}"
             fetch:
-              describe: "Fetch a custom object schema"
+              describe: "Fetch a custom object schema."
               errors:
                 fetch: "Unable to fetch {{ name }}"
               examples:
@@ -262,16 +266,17 @@ en:
                 save: "The schema \"{{ name }}\" has been saved to \"{{ path }}\""
                 savedToPath: "Saved schema to {{ path }}"
             list:
-              describe: "List schemas available on your account"
+              describe: "List custom object schemas."
               errors:
                 list: "Unable to list schemas"
             update:
-              describe: "Update an existing custom object schema"
+              describe: "Update an existing custom object schema."
               errors:
                 update: "Schema update from {{ definition }} failed"
-              positionals:
+              options:
                 definition:
                   describe: "Local path to the JSON file containing the schema definition"
+              positionals:
                 name:
                   describe: "Name of the target schema"
               success:


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
#### hs custom-object
- [x] Update description to: "[BETA] Commands for managing custom objects."
- [x] Remove all flags except for the `--help` flag because they don't do anything
- [x]  Fix duplicate argument issue for config and account in nested commands
- [x] Support the plural as an alias: `hs custom-objects`
- [x] Remove support for the `custom` alias (too generic)

#### hs custom-object schema
- [x] Update description to: "Commands for managing custom object schemas."
- [x] support custom-object schemas as an alias

#### hs custom-object schema list
- [x] Update description to: "List custom object schemas."
- [ ] Remove `--version` flag because it's unnecessary

#### hs custom-object schema fetch
- [x] Update description to: "Fetch a custom object schema."
- [ ] Remove `--version` flag because it's unnecessary
- [x] Name should fall back to a prompt when not specified
- [x] dest should fall back to a prompt when not specified

#### hs custom-object schema fetch-all
- [x] dest should fall back to a prompt when not specified

#### hs custom-object schema create
- [x] Add a period to the end of the description
- [ ] Remove `--version` flag because it's unnecessary
- [x] definition should be renamed to `path` and should be moved to be a flag instead of a positional

#### hs custom-object schema update
- [x]  Add a period to the end of the description
- [x] definition should be renamed to `path` and should be moved to be a flag instead of a positional

#### hs custom-object schema delete
- [x] Add a period to the end of the description
- [ ] Remove `--version` flag because it's unnecessary
- [x] Should list available schemas in a prompt when name is not included
- [x] should prompt for confirmation before deleting and support a `--force` flag to bypass the prompt

#### hs custom-object create
- [x] Add a period to the end of the description
- [x] definition should be renamed to `path` and should be moved to be a flag instead of a positional
- [ ] Remove `--version` flag because it's unnecessary
- [x] Name should fall back to a prompt when not specified
