### PR TITLE
feat!: Restructure config commands to match design guidelines

### DIFF
--- a/commands/__tests__/config.test.ts
+++ b/commands/__tests__/config.test.ts
@@ -1,11 +1,9 @@
 // @ts-nocheck
 import yargs from 'yargs';
 import set from '../config/set';
-import { addAccountOptions, addConfigOptions } from '../../lib/commonOpts';
 
 jest.mock('yargs');
 jest.mock('../config/set');
-jest.mock('../../lib/commonOpts');
 yargs.command.mockReturnValue(yargs);
 yargs.demandCommand.mockReturnValue(yargs);
 
@@ -33,16 +31,6 @@ describe('commands/config', () => {
 
       expect(yargs.demandCommand).toHaveBeenCalledTimes(1);
       expect(yargs.demandCommand).toHaveBeenCalledWith(1, '');
-    });
-
-    it('should support the correct options', () => {
-      configCommand.builder(yargs);
-
-      expect(addConfigOptions).toHaveBeenCalledTimes(1);
-      expect(addConfigOptions).toHaveBeenCalledWith(yargs);
-
-      expect(addAccountOptions).toHaveBeenCalledTimes(1);
-      expect(addAccountOptions).toHaveBeenCalledWith(yargs);
     });
 
     it('should add the correct number of sub commands', () => {

--- a/commands/__tests__/config.test.ts
+++ b/commands/__tests__/config.test.ts
@@ -1,9 +1,11 @@
 // @ts-nocheck
 import yargs from 'yargs';
 import set from '../config/set';
+import { addConfigOptions } from '../../lib/commonOpts';
 
 jest.mock('yargs');
 jest.mock('../config/set');
+jest.mock('../../lib/commonOpts');
 yargs.command.mockReturnValue(yargs);
 yargs.demandCommand.mockReturnValue(yargs);
 
@@ -31,6 +33,13 @@ describe('commands/config', () => {
 
       expect(yargs.demandCommand).toHaveBeenCalledTimes(1);
       expect(yargs.demandCommand).toHaveBeenCalledWith(1, '');
+    });
+
+    it('should support the correct options', () => {
+      configCommand.builder(yargs);
+
+      expect(addConfigOptions).toHaveBeenCalledTimes(1);
+      expect(addConfigOptions).toHaveBeenCalledWith(yargs);
     });
 
     it('should add the correct number of sub commands', () => {

--- a/commands/config.ts
+++ b/commands/config.ts
@@ -1,4 +1,6 @@
 // @ts-nocheck
+const { addConfigOptions } = require('../lib/commonOpts');
+
 const { i18n } = require('../lib/lang');
 const set = require('./config/set');
 
@@ -8,6 +10,7 @@ exports.command = 'config';
 exports.describe = i18n(`${i18nKey}.describe`);
 
 exports.builder = yargs => {
+  addConfigOptions(yargs);
   yargs.command(set).demandCommand(1, '');
 
   return yargs;

--- a/commands/config.ts
+++ b/commands/config.ts
@@ -1,5 +1,4 @@
 // @ts-nocheck
-const { addConfigOptions, addAccountOptions } = require('../lib/commonOpts');
 const { i18n } = require('../lib/lang');
 const set = require('./config/set');
 
@@ -9,9 +8,6 @@ exports.command = 'config';
 exports.describe = i18n(`${i18nKey}.describe`);
 
 exports.builder = yargs => {
-  addConfigOptions(yargs);
-  addAccountOptions(yargs);
-
   yargs.command(set).demandCommand(1, '');
 
   return yargs;

--- a/commands/config/set.ts
+++ b/commands/config/set.ts
@@ -72,27 +72,23 @@ exports.handler = async options => {
 exports.builder = yargs => {
   yargs
     .options({
-      defaultMode: {
+      'default-mode': {
         describe: i18n(`${i18nKey}.options.defaultMode.describe`),
         type: 'string',
       },
-      allowUsageTracking: {
+      'allow-usage-tracking': {
         describe: i18n(`${i18nKey}.options.allowUsageTracking.describe`),
         type: 'boolean',
       },
-      httpTimeout: {
+      'http-timeout': {
         describe: i18n(`${i18nKey}.options.httpTimeout.describe`),
         type: 'string',
       },
     })
     .conflicts('defaultMode', 'allowUsageTracking')
     .conflicts('defaultMode', 'httpTimeout')
-    .conflicts('allowUsageTracking', 'httpTimeout');
-
-  yargs.example([['$0 config set', i18n(`${i18nKey}.examples.default`)]]);
-
-  //TODO remove this when "hs accounts use" is fully rolled out
-  yargs.strict(false);
+    .conflicts('allowUsageTracking', 'httpTimeout')
+    .example([['$0 config set', i18n(`${i18nKey}.examples.default`)]]);
 
   return yargs;
 };

--- a/lang/en.lyaml
+++ b/lang/en.lyaml
@@ -99,10 +99,10 @@ en:
       success:
         configFileUpdated: "Account \"{{ accountName }}\" updated in {{ configFilename }} using \"{{ authType }}\""
     config:
-      describe: "Commands for working with the config file."
+      describe: "Commands for managing the CLI config file."
       subcommands:
         set:
-          describe: "Commands for modifying the CLI configuration"
+          describe: "Commands for modifying the CLI configuration."
           promptMessage: "Select a config option to update"
           examples:
             default: "Opens a prompt to select a config item to modify"


### PR DESCRIPTION
## Description and Context
#### hs config
- Update description to: "Commands for managing the CLI config file."
- Remove all flags except for the `--help` flag because they don't do anything

#### hs config set
- Add a period to the description
- flags should be kebab case
- Remove --version flag
