### PR TITLE
feat!: Restructure account commands to meet the new design guidelines

### DIFF
--- a/commands/__tests__/accounts.test.ts
+++ b/commands/__tests__/accounts.test.ts
@@ -14,6 +14,7 @@ jest.mock('../accounts/use');
 jest.mock('../accounts/info');
 jest.mock('../accounts/remove');
 jest.mock('../accounts/clean');
+jest.mock('../../lib/commonOpts');
 yargs.command.mockReturnValue(yargs);
 yargs.demandCommand.mockReturnValue(yargs);
 
@@ -56,6 +57,7 @@ describe('commands/accounts', () => {
     });
 
     it.each(subcommands)('should attach the %s subcommand', (name, module) => {
+      console.log(name, module);
       accountsCommand.builder(yargs);
       expect(yargs.command).toHaveBeenCalledWith(module);
     });

--- a/commands/__tests__/accounts.test.ts
+++ b/commands/__tests__/accounts.test.ts
@@ -6,7 +6,6 @@ import use from '../accounts/use';
 import info from '../accounts/info';
 import remove from '../accounts/remove';
 import clean from '../accounts/clean';
-import { addAccountOptions, addConfigOptions } from '../../lib/commonOpts';
 
 jest.mock('yargs');
 jest.mock('../accounts/list');
@@ -15,7 +14,6 @@ jest.mock('../accounts/use');
 jest.mock('../accounts/info');
 jest.mock('../accounts/remove');
 jest.mock('../accounts/clean');
-jest.mock('../../lib/commonOpts');
 yargs.command.mockReturnValue(yargs);
 yargs.demandCommand.mockReturnValue(yargs);
 
@@ -25,7 +23,7 @@ import accountsCommand from '../accounts';
 describe('commands/accounts', () => {
   describe('command', () => {
     it('should have the correct command structure', () => {
-      expect(accountsCommand.command).toEqual('accounts');
+      expect(accountsCommand.command).toEqual(['account', 'accounts']);
     });
   });
 
@@ -37,7 +35,7 @@ describe('commands/accounts', () => {
 
   describe('builder', () => {
     const subcommands = [
-      ['list', { ...list, aliases: 'ls' }],
+      ['list', list],
       ['rename', rename],
       ['use', use],
       ['info', info],
@@ -50,16 +48,6 @@ describe('commands/accounts', () => {
 
       expect(yargs.demandCommand).toHaveBeenCalledTimes(1);
       expect(yargs.demandCommand).toHaveBeenCalledWith(1, '');
-    });
-
-    it('should support the correct options', () => {
-      accountsCommand.builder(yargs);
-
-      expect(addConfigOptions).toHaveBeenCalledTimes(1);
-      expect(addConfigOptions).toHaveBeenCalledWith(yargs);
-
-      expect(addAccountOptions).toHaveBeenCalledTimes(1);
-      expect(addAccountOptions).toHaveBeenCalledWith(yargs);
     });
 
     it('should add the correct number of sub commands', () => {

--- a/commands/__tests__/accounts.test.ts
+++ b/commands/__tests__/accounts.test.ts
@@ -57,7 +57,6 @@ describe('commands/accounts', () => {
     });
 
     it.each(subcommands)('should attach the %s subcommand', (name, module) => {
-      console.log(name, module);
       accountsCommand.builder(yargs);
       expect(yargs.command).toHaveBeenCalledWith(module);
     });

--- a/commands/accounts.ts
+++ b/commands/accounts.ts
@@ -1,5 +1,4 @@
 // @ts-nocheck
-const { addConfigOptions, addAccountOptions } = require('../lib/commonOpts');
 const { i18n } = require('../lib/lang');
 const list = require('./accounts/list');
 const rename = require('./accounts/rename');
@@ -10,18 +9,12 @@ const clean = require('./accounts/clean');
 
 const i18nKey = 'commands.accounts';
 
-exports.command = 'accounts';
+exports.command = ['account', 'accounts'];
 exports.describe = i18n(`${i18nKey}.describe`);
 
 exports.builder = yargs => {
-  addConfigOptions(yargs);
-  addAccountOptions(yargs);
-
   yargs
-    .command({
-      ...list,
-      aliases: 'ls',
-    })
+    .command(list)
     .command(rename)
     .command(use)
     .command(info)

--- a/commands/accounts/clean.ts
+++ b/commands/accounts/clean.ts
@@ -1,4 +1,6 @@
 // @ts-nocheck
+import { addConfigOptions } from '../../lib/commonOpts';
+
 const { logger } = require('@hubspot/local-dev-lib/logger');
 const {
   accessTokenForPersonalAccessKey,
@@ -131,6 +133,7 @@ exports.handler = async options => {
 };
 
 exports.builder = yargs => {
+  addConfigOptions(yargs);
   addTestingOptions(yargs);
 
   yargs.example([['$0 accounts clean']]);

--- a/commands/accounts/clean.ts
+++ b/commands/accounts/clean.ts
@@ -8,12 +8,7 @@ const { trackCommandUsage } = require('../../lib/usageTracking');
 const { i18n } = require('../../lib/lang');
 const { loadAndValidateOptions } = require('../../lib/validation');
 const { EXIT_CODES } = require('../../lib/enums/exitCodes');
-const {
-  addConfigOptions,
-  addAccountOptions,
-  addUseEnvironmentOptions,
-  addTestingOptions,
-} = require('../../lib/commonOpts');
+const { addTestingOptions } = require('../../lib/commonOpts');
 const { promptUser } = require('../../lib/prompts/promptUtils');
 const { getTableContents } = require('../../lib/ui/table');
 const SpinniesManager = require('../../lib/ui/SpinniesManager');
@@ -136,9 +131,6 @@ exports.handler = async options => {
 };
 
 exports.builder = yargs => {
-  addConfigOptions(yargs);
-  addAccountOptions(yargs);
-  addUseEnvironmentOptions(yargs);
   addTestingOptions(yargs);
 
   yargs.example([['$0 accounts clean']]);

--- a/commands/accounts/clean.ts
+++ b/commands/accounts/clean.ts
@@ -1,6 +1,4 @@
 // @ts-nocheck
-import { addConfigOptions } from '../../lib/commonOpts';
-
 const { logger } = require('@hubspot/local-dev-lib/logger');
 const {
   accessTokenForPersonalAccessKey,
@@ -10,7 +8,7 @@ const { trackCommandUsage } = require('../../lib/usageTracking');
 const { i18n } = require('../../lib/lang');
 const { loadAndValidateOptions } = require('../../lib/validation');
 const { EXIT_CODES } = require('../../lib/enums/exitCodes');
-const { addTestingOptions } = require('../../lib/commonOpts');
+const { addTestingOptions, addConfigOptions } = require('../../lib/commonOpts');
 const { promptUser } = require('../../lib/prompts/promptUtils');
 const { getTableContents } = require('../../lib/ui/table');
 const SpinniesManager = require('../../lib/ui/SpinniesManager');

--- a/commands/accounts/info.ts
+++ b/commands/accounts/info.ts
@@ -43,11 +43,8 @@ exports.builder = yargs => {
 
   yargs.example([
     ['$0 accounts info', i18n(`${i18nKey}.examples.default`)],
-    [
-      '$0 accounts info --account=MyAccount',
-      i18n(`${i18nKey}.examples.nameBased`),
-    ],
-    ['$0 accounts info --account=1234567', i18n(`${i18nKey}.examples.idBased`)],
+    ['$0 accounts info MyAccount', i18n(`${i18nKey}.examples.nameBased`)],
+    ['$0 accounts info 1234567', i18n(`${i18nKey}.examples.idBased`)],
   ]);
 
   return yargs;

--- a/commands/accounts/info.ts
+++ b/commands/accounts/info.ts
@@ -2,7 +2,7 @@
 const { logger } = require('@hubspot/local-dev-lib/logger');
 const { getAccountConfig } = require('@hubspot/local-dev-lib/config');
 const { getAccessToken } = require('@hubspot/local-dev-lib/personalAccessKey');
-const { addAccountOptions, addConfigOptions } = require('../../lib/commonOpts');
+const { addConfigOptions } = require('../../lib/commonOpts');
 const { loadAndValidateOptions } = require('../../lib/validation');
 const { i18n } = require('../../lib/lang');
 const { getTableContents } = require('../../lib/ui/table');
@@ -10,7 +10,7 @@ const { getTableContents } = require('../../lib/ui/table');
 const i18nKey = 'commands.accounts.subcommands.info';
 exports.describe = i18n(`${i18nKey}.describe`);
 
-exports.command = 'info [--account]';
+exports.command = 'info [account]';
 
 exports.handler = async options => {
   await loadAndValidateOptions(options);
@@ -40,7 +40,6 @@ exports.handler = async options => {
 
 exports.builder = yargs => {
   addConfigOptions(yargs);
-  addAccountOptions(yargs);
 
   yargs.example([
     ['$0 accounts info', i18n(`${i18nKey}.examples.default`)],

--- a/commands/accounts/list.ts
+++ b/commands/accounts/list.ts
@@ -1,4 +1,6 @@
 // @ts-nocheck
+import { addConfigOptions } from '../../lib/commonOpts';
+
 const { logger } = require('@hubspot/local-dev-lib/logger');
 const {
   getConfig,
@@ -111,6 +113,7 @@ exports.handler = async options => {
 };
 
 exports.builder = yargs => {
+  addConfigOptions(yargs);
   yargs.example([['$0 accounts list']]);
   return yargs;
 };

--- a/commands/accounts/list.ts
+++ b/commands/accounts/list.ts
@@ -11,7 +11,6 @@ const {
 } = require('@hubspot/local-dev-lib/config/getAccountIdentifier');
 const { getTableContents, getTableHeader } = require('../../lib/ui/table');
 
-const { addConfigOptions, addAccountOptions } = require('../../lib/commonOpts');
 const { trackCommandUsage } = require('../../lib/usageTracking');
 const { loadAndValidateOptions } = require('../../lib/validation');
 const { isSandbox, isDeveloperTestAccount } = require('../../lib/accountTypes');
@@ -24,7 +23,7 @@ const {
 
 const i18nKey = 'commands.accounts.subcommands.list';
 
-exports.command = 'list';
+exports.command = ['list', 'ls'];
 exports.describe = i18n(`${i18nKey}.describe`);
 
 const sortAndMapPortals = portals => {
@@ -112,10 +111,6 @@ exports.handler = async options => {
 };
 
 exports.builder = yargs => {
-  addConfigOptions(yargs);
-  addAccountOptions(yargs);
-
   yargs.example([['$0 accounts list']]);
-
   return yargs;
 };

--- a/commands/accounts/list.ts
+++ b/commands/accounts/list.ts
@@ -1,6 +1,4 @@
 // @ts-nocheck
-import { addConfigOptions } from '../../lib/commonOpts';
-
 const { logger } = require('@hubspot/local-dev-lib/logger');
 const {
   getConfig,
@@ -11,6 +9,7 @@ const {
 const {
   getAccountIdentifier,
 } = require('@hubspot/local-dev-lib/config/getAccountIdentifier');
+const { addConfigOptions } = require('../../lib/commonOpts');
 const { getTableContents, getTableHeader } = require('../../lib/ui/table');
 
 const { trackCommandUsage } = require('../../lib/usageTracking');

--- a/commands/accounts/remove.ts
+++ b/commands/accounts/remove.ts
@@ -75,10 +75,7 @@ exports.builder = yargs => {
   });
   yargs.example([
     ['$0 accounts remove', i18n(`${i18nKey}.examples.default`)],
-    [
-      '$0 accounts remove --account=MyAccount',
-      i18n(`${i18nKey}.examples.byName`),
-    ],
+    ['$0 accounts remove MyAccount', i18n(`${i18nKey}.examples.byName`)],
   ]);
 
   return yargs;

--- a/commands/accounts/remove.ts
+++ b/commands/accounts/remove.ts
@@ -1,4 +1,5 @@
 // @ts-nocheck
+const { addConfigOptions } = require('../../lib/commonOpts');
 const { logger } = require('@hubspot/local-dev-lib/logger');
 const {
   getConfig,
@@ -69,6 +70,7 @@ exports.handler = async options => {
 };
 
 exports.builder = yargs => {
+  addConfigOptions(yargs);
   yargs.positional('account', {
     describe: i18n(`${i18nKey}.options.account.describe`),
     type: 'string',

--- a/commands/accounts/remove.ts
+++ b/commands/accounts/remove.ts
@@ -16,15 +16,15 @@ const { loadAndValidateOptions } = require('../../lib/validation');
 
 const i18nKey = 'commands.accounts.subcommands.remove';
 
-exports.command = 'remove [--account]';
+exports.command = 'remove <account>';
 exports.describe = i18n(`${i18nKey}.describe`);
 
 exports.handler = async options => {
   await loadAndValidateOptions(options, false);
+  const { account } = options;
+  let accountToRemove = account;
 
   let config = getConfig();
-
-  let accountToRemove = options.providedAccountId;
 
   if (accountToRemove && !getAccountIdFromConfig(accountToRemove)) {
     logger.error(
@@ -69,7 +69,7 @@ exports.handler = async options => {
 };
 
 exports.builder = yargs => {
-  yargs.option('account', {
+  yargs.positional('account', {
     describe: i18n(`${i18nKey}.options.account.describe`),
     type: 'string',
   });

--- a/commands/accounts/remove.ts
+++ b/commands/accounts/remove.ts
@@ -16,7 +16,7 @@ const { loadAndValidateOptions } = require('../../lib/validation');
 
 const i18nKey = 'commands.accounts.subcommands.remove';
 
-exports.command = 'remove <account>';
+exports.command = 'remove [account]';
 exports.describe = i18n(`${i18nKey}.describe`);
 
 exports.handler = async options => {

--- a/commands/accounts/use.ts
+++ b/commands/accounts/use.ts
@@ -58,11 +58,8 @@ exports.builder = yargs => {
   });
   yargs.example([
     ['$0 accounts use', i18n(`${i18nKey}.examples.default`)],
-    [
-      '$0 accounts use --account=MyAccount',
-      i18n(`${i18nKey}.examples.nameBased`),
-    ],
-    ['$0 accounts use --account=1234567', i18n(`${i18nKey}.examples.idBased`)],
+    ['$0 accounts use MyAccount', i18n(`${i18nKey}.examples.nameBased`)],
+    ['$0 accounts use 1234567', i18n(`${i18nKey}.examples.idBased`)],
   ]);
 
   return yargs;

--- a/commands/accounts/use.ts
+++ b/commands/accounts/use.ts
@@ -14,7 +14,7 @@ const { loadAndValidateOptions } = require('../../lib/validation');
 
 const i18nKey = 'commands.accounts.subcommands.use';
 
-exports.command = 'use [--account]';
+exports.command = 'use [account]';
 exports.describe = i18n(`${i18nKey}.describe`);
 
 exports.handler = async options => {

--- a/commands/accounts/use.ts
+++ b/commands/accounts/use.ts
@@ -52,7 +52,7 @@ exports.handler = async options => {
 };
 
 exports.builder = yargs => {
-  yargs.option('account', {
+  yargs.positional('account', {
     describe: i18n(`${i18nKey}.options.account.describe`),
     type: 'string',
   });

--- a/lang/en.lyaml
+++ b/lang/en.lyaml
@@ -10,7 +10,7 @@ en:
       loadConfigMiddleware:
         configFileExists: "A configuration file already exists at {{ configPath }}. To specify a new configuration file, delete the existing one and try again."
     accounts:
-      describe: "Commands for working with accounts."
+      describe: "Commands for managing configured accounts."
       subcommands:
         list:
           accounts: "{{#bold}}Accounts{{/bold}}:"
@@ -22,7 +22,7 @@ en:
             authType: "Auth Type"
             name: "Name"
         rename:
-          describe: "Rename account in config."
+          describe: "Rename an account in the config."
           positionals:
             accountName:
               describe: "Name of account to be renamed."
@@ -63,7 +63,7 @@ en:
             accountRemoved: "Account \"{{ accountName }}\" removed from the config"
         info:
           accountId: "{{#bold}}Account ID{{/bold}}: {{ accountId }}"
-          describe: "Print information about the default account, or about the account specified with the \"--account\" option."
+          describe: "Print information about the default account, or about the account specified with the \"account\" option."
           errors:
             notUsingPersonalAccessKey: "This command currently only supports fetching scopes for the personal access key auth type."
           examples:


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
#### hs accounts
- [x] Update description to: "Commands for managing configured accounts."
- [x] Remove all flags except for the `--help` flag because they don't do anything
- [x] Support `hs account` as the primary and accounts as the plural alias

#### hs accounts list
- [x] Remove --version flag and --account flag

#### hs accounts rename
- [x] Description should be `Rename an account in the config.`
- [x] Remove --version flag and --account flag

#### hs accounts use
- [x] Remove --version flag and --account flag

#### hs accounts info
- [x] Description should be `Print information about the default account, or about the account specified with the
"account" option.`
- [x] Remove --version flag and --account flags

#### hs accounts remove
- [x] Remove --version flag and --account flag

#### hs accounts clean
- [x] Remove --version flag, use-env flag,  and --account flag