### PR TITLE
fix: `getConfigDefaultAccount`

### DIFF
--- a/commands/accounts/list.ts
+++ b/commands/accounts/list.ts
@@ -1,7 +1,6 @@
 // @ts-nocheck
 const { logger } = require('@hubspot/local-dev-lib/logger');
 const {
-  getConfig,
   getConfigPath,
   getConfigDefaultAccount,
   getConfigAccounts,
@@ -88,7 +87,6 @@ exports.handler = async options => {
 
   trackCommandUsage('accounts-list', null, derivedAccountId);
 
-  const config = getConfig();
   const configPath = getConfigPath();
   const accountsList = getConfigAccounts();
   const mappedPortalData = sortAndMapPortals(accountsList);
@@ -104,7 +102,7 @@ exports.handler = async options => {
   logger.log(i18n(`${i18nKey}.configPath`, { configPath }));
   logger.log(
     i18n(`${i18nKey}.defaultAccount`, {
-      account: getConfigDefaultAccount(config),
+      account: getConfigDefaultAccount(),
     })
   );
   logger.log(i18n(`${i18nKey}.accounts`));

--- a/commands/accounts/remove.ts
+++ b/commands/accounts/remove.ts
@@ -25,8 +25,6 @@ exports.handler = async options => {
   const { account } = options;
   let accountToRemove = account;
 
-  let config = getConfig();
-
   if (accountToRemove && !getAccountIdFromConfig(accountToRemove)) {
     logger.error(
       i18n(`${i18nKey}.errors.accountNotFound`, {
@@ -38,7 +36,6 @@ exports.handler = async options => {
 
   if (!accountToRemove || !getAccountIdFromConfig(accountToRemove)) {
     accountToRemove = await selectAccountFromConfig(
-      config,
       i18n(`${i18nKey}.prompts.selectAccountToRemove`)
     );
   }
@@ -59,12 +56,12 @@ exports.handler = async options => {
   );
 
   // Get updated version of the config
-  config = getConfig();
+  getConfig();
 
   if (accountToRemove === currentDefaultAccount) {
     logger.log();
     logger.log(i18n(`${i18nKey}.logs.replaceDefaultAccount`));
-    const newDefaultAccount = await selectAccountFromConfig(config);
+    const newDefaultAccount = await selectAccountFromConfig();
     updateDefaultAccount(newDefaultAccount);
   }
 };

--- a/commands/accounts/use.ts
+++ b/commands/accounts/use.ts
@@ -1,7 +1,6 @@
 // @ts-nocheck
 const { logger } = require('@hubspot/local-dev-lib/logger');
 const {
-  getConfig,
   getConfigPath,
   updateDefaultAccount,
   getAccountId: getAccountIdFromConfig,
@@ -20,12 +19,10 @@ exports.describe = i18n(`${i18nKey}.describe`);
 exports.handler = async options => {
   await loadAndValidateOptions(options, false);
 
-  const config = getConfig();
-
   let newDefaultAccount = options.account;
 
   if (!newDefaultAccount) {
-    newDefaultAccount = await selectAccountFromConfig(config);
+    newDefaultAccount = await selectAccountFromConfig();
   } else if (!getAccountIdFromConfig(newDefaultAccount)) {
     logger.error(
       i18n(`${i18nKey}.errors.accountNotFound`, {
@@ -33,7 +30,7 @@ exports.handler = async options => {
         configPath: getConfigPath(),
       })
     );
-    newDefaultAccount = await selectAccountFromConfig(config);
+    newDefaultAccount = await selectAccountFromConfig();
   }
 
   trackCommandUsage(

--- a/commands/auth.ts
+++ b/commands/auth.ts
@@ -19,7 +19,6 @@ const {
 const {
   updateAccountConfig,
   writeConfig,
-  getConfig,
   getConfigPath,
   loadConfig,
   getConfigDefaultAccount,
@@ -180,10 +179,9 @@ exports.handler = async options => {
       })
     );
   } else {
-    const config = getConfig();
     logger.info(
       i18n(`lib.prompts.setAsDefaultAccountPrompt.keepingCurrentDefault`, {
-        accountName: getConfigDefaultAccount(config),
+        accountName: getConfigDefaultAccount(),
       })
     );
   }

--- a/commands/sandbox/delete.ts
+++ b/commands/sandbox/delete.ts
@@ -15,7 +15,6 @@ const { deleteSandbox } = require('@hubspot/local-dev-lib/api/sandboxHubs');
 const { i18n } = require('../../lib/lang');
 const { deleteSandboxPrompt } = require('../../lib/prompts/sandboxesPrompt');
 const {
-  getConfig,
   getEnv,
   removeSandboxAccountFromConfig,
   updateDefaultAccount,
@@ -45,14 +44,13 @@ exports.handler = async options => {
   await loadAndValidateOptions(options, false);
 
   const { providedAccountId, force } = options;
-  const config = getConfig();
 
   trackCommandUsage('sandbox-delete', null);
 
   let accountPrompt;
   if (!providedAccountId) {
     if (!force) {
-      accountPrompt = await deleteSandboxPrompt(config);
+      accountPrompt = await deleteSandboxPrompt();
     } else {
       // Account is required, throw error if force flag is present and no account is specified
       logger.log('');
@@ -70,7 +68,7 @@ exports.handler = async options => {
     account: providedAccountId || accountPrompt.account,
   });
   const isDefaultAccount =
-    sandboxAccountId === getAccountId(getConfigDefaultAccount(config));
+    sandboxAccountId === getAccountId(getConfigDefaultAccount());
 
   const baseUrl = getHubSpotWebsiteOrigin(
     getValidEnv(getEnv(sandboxAccountId))
@@ -83,7 +81,7 @@ exports.handler = async options => {
       if (portal.parentAccountId) {
         parentAccountId = portal.parentAccountId;
       } else if (!force) {
-        const parentAccountPrompt = await deleteSandboxPrompt(config, true);
+        const parentAccountPrompt = await deleteSandboxPrompt(true);
         parentAccountId = getAccountId({
           account: parentAccountPrompt.account,
         });
@@ -161,7 +159,7 @@ exports.handler = async options => {
       sandboxAccountId
     );
     if (promptDefaultAccount && !force) {
-      const newDefaultAccount = await selectAccountFromConfig(getConfig());
+      const newDefaultAccount = await selectAccountFromConfig();
       updateDefaultAccount(newDefaultAccount);
     } else {
       // If force is specified, skip prompt and set the parent account id as the default account
@@ -214,7 +212,7 @@ exports.handler = async options => {
         sandboxAccountId
       );
       if (promptDefaultAccount && !force) {
-        const newDefaultAccount = await selectAccountFromConfig(getConfig());
+        const newDefaultAccount = await selectAccountFromConfig();
         updateDefaultAccount(newDefaultAccount);
       } else {
         // If force is specified, skip prompt and set the parent account id as the default account

--- a/lib/prompts/accountsPrompt.ts
+++ b/lib/prompts/accountsPrompt.ts
@@ -18,9 +18,9 @@ const mapAccountChoices = portals =>
 
 const i18nKey = 'commands.accounts.subcommands.use';
 
-const selectAccountFromConfig = async (config, prompt) => {
+const selectAccountFromConfig = async (prompt = '') => {
   const accountsList = getConfigAccounts();
-  const defaultAccount = getConfigDefaultAccount(config);
+  const defaultAccount = getConfigDefaultAccount();
 
   const { default: selectedDefault } = await promptUser([
     {

--- a/lib/prompts/sandboxesPrompt.ts
+++ b/lib/prompts/sandboxesPrompt.ts
@@ -58,7 +58,7 @@ const sandboxTypePrompt = () => {
   ]);
 };
 
-const deleteSandboxPrompt = (config, promptParentAccount = false) => {
+const deleteSandboxPrompt = (promptParentAccount = false) => {
   const accountsList = getConfigAccounts();
   const choices = promptParentAccount
     ? mapNonSandboxAccountChoices(accountsList)
@@ -78,7 +78,7 @@ const deleteSandboxPrompt = (config, promptParentAccount = false) => {
       look: false,
       pageSize: 20,
       choices,
-      default: getConfigDefaultAccount(config),
+      default: getConfigDefaultAccount(),
     },
   ]);
 };


### PR DESCRIPTION
## Description and Context
While working on https://github.com/HubSpot/hubspot-cli/pull/1273, I discovered that `getConfigDefaultAccount` was mistakenly being passed a `config` argument in a number of places. In fact, it takes zero arguments. This also had implications for the `selectAccountFromConfig` and `deleteSandboxPrompt` functions, both of which were being passed `config` unnecessarily to pass to `getConfigDefaultAccount`. 

This PR removes a bunch of code. If you'd like to test out the changes, the impacted commands are:

`hs accounts use`
`hs accounts list`
`hs accounts remove`
`hs auth`
`hs sandbox delete`

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

- [ ] Address feedback

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@brandenrodgers @camden11 @joe-yeager 
