### PR TITLE
fix: Make doctor aware of the next tag

### DIFF
--- a/lib/__tests__/dependencyManagement.test.ts
+++ b/lib/__tests__/dependencyManagement.test.ts
@@ -47,13 +47,14 @@ describe('lib/dependencyManagement', () => {
   describe('getLatestCliVersion', () => {
     it('should return the version correctly', async () => {
       const latest = '1.0.0';
+      const next = '1.0.0.beta.1';
       execMock = jest
         .fn()
-        .mockResolvedValueOnce({ stdout: JSON.stringify({ latest }) });
+        .mockResolvedValueOnce({ stdout: JSON.stringify({ latest, next }) });
 
       util.promisify = jest.fn().mockReturnValueOnce(execMock);
       const actual = await getLatestCliVersion();
-      expect(actual).toBe(latest);
+      expect(actual).toEqual({ latest, next });
     });
 
     it('should throw any errors that encounter with the check', async () => {

--- a/lib/dependencyManagement.ts
+++ b/lib/dependencyManagement.ts
@@ -38,11 +38,11 @@ export async function isGloballyInstalled(command) {
   }
 }
 
-export async function getLatestCliVersion(): string {
+export async function getLatestCliVersion(): { latest: string; next: string } {
   const exec = util.promisify(execAsync);
   const { stdout } = await exec(`npm info ${pkg.name} dist-tags --json`);
-  const { latest } = JSON.parse(stdout);
-  return latest;
+  const { latest, next } = JSON.parse(stdout);
+  return { latest, next };
 }
 
 async function installPackages({ packages, installLocations }) {

--- a/lib/doctor/Doctor.ts
+++ b/lib/doctor/Doctor.ts
@@ -226,8 +226,12 @@ export class Doctor {
 
   private async checkCLIVersion(): Promise<void> {
     let latestCLIVersion;
+    let nextCliVersion;
+
     try {
-      latestCLIVersion = await getLatestCliVersion();
+      const { latest, next } = await getLatestCliVersion();
+      latestCLIVersion = latest;
+      nextCliVersion = next;
     } catch (e) {
       return this.diagnosis?.addCliSection({
         type: 'error',
@@ -245,14 +249,15 @@ export class Doctor {
       });
     }
 
-    if (latestCLIVersion !== pkg.version) {
+    if (latestCLIVersion !== pkg.version && nextCliVersion !== pkg.version) {
+      const onNextTag = pkg.version.includes('beta');
       this.diagnosis?.addCliSection({
         type: 'warning',
         message: i18n(`${i18nKey}.hsChecks.notLatest`, {
           hsVersion: pkg.version,
         }),
         secondaryMessaging: i18n(`${i18nKey}.hsChecks.notLatestSecondary`, {
-          hsVersion: pkg.version,
+          hsVersion: onNextTag ? nextCliVersion : latestCLIVersion,
           command: uiCommandReference(`npm install -g ${pkg.name}`),
         }),
       });


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
The doctor command will now see if the user is on the most up to date version of `latest` or `next`
