### PR TITLE
chore: Silence deprecation warnings

### DIFF
--- a/acceptance-tests/lib/cmd.ts
+++ b/acceptance-tests/lib/cmd.ts
@@ -64,7 +64,7 @@ function executeWithInput(
   const { env, timeout = 1000, maxTimeout = 30000 } = opts;
 
   const childProcess = createProcess(config, args, env);
-  childProcess.stdin.setEncoding('utf-8');
+  childProcess.stdin!.setEncoding('utf-8');
 
   let currentInputTimeout: NodeJS.Timeout;
   let killIOTimeout: NodeJS.Timeout;
@@ -78,7 +78,7 @@ function executeWithInput(
     }
 
     if (!inputs.length) {
-      childProcess.stdin.end();
+      childProcess.stdin!.end();
 
       // Set a timeout to wait for CLI response. If CLI takes longer than
       // maxTimeout to respond, kill the childProcess and notify user
@@ -94,7 +94,7 @@ function executeWithInput(
       if (typeof inputs[0] === 'function') {
         await inputs[0]();
       } else {
-        childProcess.stdin.write(inputs[0]);
+        childProcess.stdin!.write(inputs[0]);
       }
 
       if (config.debug) {
@@ -106,14 +106,14 @@ function executeWithInput(
   };
 
   // Get errors from CLI for debugging
-  childProcess.stderr.on('data', (err: unknown) => {
+  childProcess.stderr!.on('data', (err: unknown) => {
     if (config.debug) {
       console.log('error:', String(err));
     }
   });
 
   // Get output from CLI for debugging
-  childProcess.stdout.on('data', (data: unknown) => {
+  childProcess.stdout!.on('data', (data: unknown) => {
     if (config.debug) {
       console.log('output:', String(data));
     }
@@ -123,7 +123,6 @@ function executeWithInput(
     const handleStderr = (err: unknown) => {
       // Ignore any allowed errors so tests can continue
       const allowedErrors = [
-        'DeprecationWarning', // Ignore package deprecation warnings.
         '[WARNING]', // Ignore our own CLI warning messages
       ];
 
@@ -134,12 +133,12 @@ function executeWithInput(
         }
 
         // Resubscribe if we ignored this error
-        childProcess.stderr.once('data', handleStderr);
+        childProcess.stderr!.once('data', handleStderr);
         return;
       }
 
       // If the childProcess errors out, stop all the pending inputs
-      childProcess.stdin.end();
+      childProcess.stdin!.end();
 
       if (currentInputTimeout) {
         clearTimeout(currentInputTimeout);
@@ -149,10 +148,10 @@ function executeWithInput(
       reject(error);
     };
 
-    childProcess.stderr.once('data', handleStderr);
+    childProcess.stderr!.once('data', handleStderr);
     childProcess.on('error', reject);
 
-    childProcess.stdout.pipe(
+    childProcess.stdout!.pipe(
       concat((result: unknown) => {
         if (killIOTimeout) {
           clearTimeout(killIOTimeout);

--- a/bin/hs
+++ b/bin/hs
@@ -1,3 +1,5 @@
 #!/usr/bin/env node
 
+require('./silenceErrors')
+
 require('./cli');

--- a/bin/hscms
+++ b/bin/hscms
@@ -1,3 +1,5 @@
 #!/usr/bin/env node
 
+require('./silenceErrors')
+
 require('./cli');

--- a/bin/silenceErrors.js
+++ b/bin/silenceErrors.js
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+
+const SILENCED_ERRORS = ['DeprecationWarning:'];
+
+const originalConsoleError = console.error;
+
+console.error = msg => {
+  const isSilencedError = SILENCED_ERRORS.some(
+    error => typeof msg === 'string' && msg.includes(error)
+  );
+  if (isSilencedError) {
+    return;
+  }
+  originalConsoleError(msg);
+};
+// test

--- a/bin/silenceErrors.js
+++ b/bin/silenceErrors.js
@@ -13,4 +13,3 @@ console.error = msg => {
   }
   originalConsoleError(msg);
 };
-// test

--- a/commands/secret/addSecret.ts
+++ b/commands/secret/addSecret.ts
@@ -22,7 +22,7 @@ const {
 } = require('../../lib/prompts/secretPrompt');
 const { i18n } = require('../../lib/lang');
 
-const i18nKey = 'commands.secrets.subcommands.add';
+const i18nKey = 'commands.secret.subcommands.add';
 
 exports.command = 'add [name]';
 exports.describe = i18n(`${i18nKey}.describe`);

--- a/commands/secret/deleteSecret.ts
+++ b/commands/secret/deleteSecret.ts
@@ -21,7 +21,7 @@ const {
 } = require('../../lib/commonOpts');
 const { i18n } = require('../../lib/lang');
 
-const i18nKey = 'commands.secrets.subcommands.delete';
+const i18nKey = 'commands.secret.subcommands.delete';
 
 exports.command = 'delete [name]';
 exports.describe = i18n(`${i18nKey}.describe`);

--- a/commands/secret/listSecrets.ts
+++ b/commands/secret/listSecrets.ts
@@ -14,7 +14,7 @@ const {
 } = require('../../lib/commonOpts');
 const { i18n } = require('../../lib/lang');
 
-const i18nKey = 'commands.secrets.subcommands.list';
+const i18nKey = 'commands.secret.subcommands.list';
 
 exports.command = 'list';
 exports.describe = i18n(`${i18nKey}.describe`);

--- a/commands/secret/updateSecret.ts
+++ b/commands/secret/updateSecret.ts
@@ -23,7 +23,7 @@ const {
 } = require('../../lib/prompts/secretPrompt');
 const { i18n } = require('../../lib/lang');
 
-const i18nKey = 'commands.secrets.subcommands.update';
+const i18nKey = 'commands.secret.subcommands.update';
 
 exports.command = 'update [name]';
 exports.describe = i18n(`${i18nKey}.describe`);


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
This should remove the punycode deprecation warnings that show when you're using node v22. We had a [previous solution](https://github.com/HubSpot/hubspot-cli/pull/1067/files) using the `--no-deprecation` flag, but we had to remove it because it didn't work on Linux (linux only supports passing a single argument to the node invocation).

I found this solution [here](https://github.com/vercel/vercel/pull/12306). I poked around for a bit and this seems like the cleanest way to fix it. The only other reasonable alternative that I found was to use `process.removeAllListeners('warning')`, but that can have negative downstream impact because we'd be suppressing the warning event for all packages.

I made a few changes in [acceptance-tests/lib/cmd.ts](https://github.com/HubSpot/hubspot-cli/compare/next...br/silence-deprecation-warning?expand=1#diff-b9c21d6e5cd73999f464b328bef1ddc55f625c027d0ca1f5845e32d6f7ec3b80) because I wanted to remove our special case handling for deprecation warnings (tests _should_ fail if they're surfacing) and there were some easy TS-related fixes.

## Screenshots
<!-- Provide images of the before and after functionality -->

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
