### PR TITLE
Chore: Convert prompts to TS p.2

### DIFF
--- a/lang/en.lyaml
+++ b/lang/en.lyaml
@@ -1291,7 +1291,6 @@ en:
         errors:
           apiSampleAppRequired: "Please select API sample app"
           languageRequired: "Please select API sample app's language"
-          sampleNotFound: "A sample app matching your selection could not be found"
       createProjectPrompt:
         enterName: "[--name] Give your project a name: "
         enterDest: "[--dest] Enter the folder to create the project in:"

--- a/lang/en.lyaml
+++ b/lang/en.lyaml
@@ -1317,6 +1317,7 @@ en:
         selectProject: "Select a project to download:"
         errors:
           projectNotFound: "Your project {{ projectName }} could not be found in {{ accountId }}. Please select a valid project:"
+          accountIdRequired: "An account ID is required to download a project."
       projectAddPrompt:
         selectType: "[--type] Select your component type:"
         enterName: "[--name] Give your component a name: "

--- a/lang/en.lyaml
+++ b/lang/en.lyaml
@@ -1291,6 +1291,7 @@ en:
         errors:
           apiSampleAppRequired: "Please select API sample app"
           languageRequired: "Please select API sample app's language"
+          sampleNotFound: "A sample app matching your selection could not be found"
       createProjectPrompt:
         enterName: "[--name] Give your project a name: "
         enterDest: "[--dest] Enter the folder to create the project in:"

--- a/lib/prompts/accountsPrompt.ts
+++ b/lib/prompts/accountsPrompt.ts
@@ -7,10 +7,11 @@ import { promptUser } from './promptUtils';
 import { i18n } from '../lang';
 import { uiAccountDescription } from '../ui';
 import { CLIAccount } from '@hubspot/local-dev-lib/types/Accounts';
+import { PromptChoices } from '../../types/prompts';
 
 function mapAccountChoices(
   portals: CLIAccount[] | null | undefined
-): { name: string | undefined; value: string }[] | [] {
+): PromptChoices | [] {
   return portals
     ? portals.map(p => ({
         name: uiAccountDescription(getAccountIdentifier(p), false),
@@ -28,12 +29,11 @@ export async function selectAccountFromConfig(prompt = ''): Promise<string> {
   const { default: selectedDefault } = await promptUser([
     {
       type: 'list',
-      look: false,
       name: 'default',
       pageSize: 20,
       message: prompt || i18n(`${i18nKey}.promptMessage`),
       choices: mapAccountChoices(accountsList),
-      default: defaultAccount,
+      default: defaultAccount ?? undefined,
     },
   ]);
 

--- a/lib/prompts/accountsPrompt.ts
+++ b/lib/prompts/accountsPrompt.ts
@@ -1,24 +1,27 @@
-// @ts-nocheck
-const {
+import {
   getConfigDefaultAccount,
   getConfigAccounts,
-} = require('@hubspot/local-dev-lib/config');
-const {
-  getAccountIdentifier,
-} = require('@hubspot/local-dev-lib/config/getAccountIdentifier');
-const { promptUser } = require('./promptUtils');
-const { i18n } = require('../lang');
-const { uiAccountDescription } = require('../ui');
+} from '@hubspot/local-dev-lib/config';
+import { getAccountIdentifier } from '@hubspot/local-dev-lib/config/getAccountIdentifier';
+import { promptUser } from './promptUtils';
+import { i18n } from '../lang';
+import { uiAccountDescription } from '../ui';
+import { CLIAccount } from '@hubspot/local-dev-lib/types/Accounts';
 
-const mapAccountChoices = portals =>
-  portals.map(p => ({
-    name: uiAccountDescription(getAccountIdentifier(p), false),
-    value: p.name || getAccountIdentifier(p),
-  }));
+function mapAccountChoices(
+  portals: CLIAccount[] | null | undefined
+): { name: string | undefined; value: string }[] | [] {
+  return portals
+    ? portals.map(p => ({
+        name: uiAccountDescription(getAccountIdentifier(p), false),
+        value: String(p.name || getAccountIdentifier(p)),
+      }))
+    : [];
+}
 
 const i18nKey = 'commands.account.subcommands.use';
 
-const selectAccountFromConfig = async (prompt = '') => {
+export async function selectAccountFromConfig(prompt = ''): Promise<string> {
   const accountsList = getConfigAccounts();
   const defaultAccount = getConfigDefaultAccount();
 
@@ -35,8 +38,4 @@ const selectAccountFromConfig = async (prompt = '') => {
   ]);
 
   return selectedDefault;
-};
-
-module.exports = {
-  selectAccountFromConfig,
-};
+}

--- a/lib/prompts/accountsPrompt.ts
+++ b/lib/prompts/accountsPrompt.ts
@@ -12,12 +12,12 @@ import { PromptChoices } from '../../types/prompts';
 function mapAccountChoices(
   portals: CLIAccount[] | null | undefined
 ): PromptChoices {
-  return portals
-    ? portals.map(p => ({
-        name: uiAccountDescription(getAccountIdentifier(p), false),
-        value: String(p.name || getAccountIdentifier(p)),
-      }))
-    : [];
+  return (
+    portals?.map(p => ({
+      name: uiAccountDescription(getAccountIdentifier(p), false),
+      value: String(p.name || getAccountIdentifier(p)),
+    })) || []
+  );
 }
 
 const i18nKey = 'commands.account.subcommands.use';

--- a/lib/prompts/accountsPrompt.ts
+++ b/lib/prompts/accountsPrompt.ts
@@ -11,7 +11,7 @@ import { PromptChoices } from '../../types/prompts';
 
 function mapAccountChoices(
   portals: CLIAccount[] | null | undefined
-): PromptChoices | [] {
+): PromptChoices {
   return portals
     ? portals.map(p => ({
         name: uiAccountDescription(getAccountIdentifier(p), false),
@@ -26,7 +26,7 @@ export async function selectAccountFromConfig(prompt = ''): Promise<string> {
   const accountsList = getConfigAccounts();
   const defaultAccount = getConfigDefaultAccount();
 
-  const { default: selectedDefault } = await promptUser([
+  const { default: selectedDefault } = await promptUser<{ default: string }>([
     {
       type: 'list',
       name: 'default',

--- a/lib/prompts/cmsFieldPrompt.ts
+++ b/lib/prompts/cmsFieldPrompt.ts
@@ -34,7 +34,7 @@ export async function fieldsJsPrompt(
     value: fileChoice,
   }));
 
-  const promptVal = await promptUser([
+  const promptVal = await promptUser<{ filePathChoice: string }>([
     {
       message: i18n(`${i18nKey}.fieldsPrompt`, { dir: fileDir }),
       type: 'list',

--- a/lib/prompts/cmsFieldPrompt.ts
+++ b/lib/prompts/cmsFieldPrompt.ts
@@ -1,13 +1,17 @@
-// @ts-nocheck
-const path = require('path');
-const fs = require('fs');
-const { promptUser } = require('./promptUtils');
-const { i18n } = require('../lang');
-const escapeRegExp = require('@hubspot/local-dev-lib/escapeRegExp');
+import path from 'path';
+import fs from 'fs';
+import { promptUser } from './promptUtils';
+import { i18n } from '../lang';
+import { escapeRegExp } from '@hubspot/local-dev-lib/escapeRegExp';
+
 const i18nKey = 'lib.prompts.uploadPrompt';
 const FIELDS_FILES = ['fields.json', 'fields.js', 'fields.cjs', 'fields.mjs'];
 
-const fieldsJsPrompt = async (filePath, projectDir, skipFiles = []) => {
+export async function fieldsJsPrompt(
+  filePath: string,
+  projectDir: string,
+  skipFiles: string[] = []
+): Promise<[string, string[]]> {
   const dirName = path.dirname(filePath);
 
   // Get a list of all field files in the directory, resolve their absolute path, and remove the ones that we already skipped.
@@ -18,20 +22,18 @@ const fieldsJsPrompt = async (filePath, projectDir, skipFiles = []) => {
     .filter(file => !skipFiles.includes(file));
 
   if (!fileChoices.length) return [filePath, []];
-  if (fileChoices.length == 1) return [fileChoices[0], []];
+  if (fileChoices.length === 1) return [fileChoices[0], []];
 
   // We get the directory above the project one so that relative paths are printed with the root of the project dir attached.
   projectDir = projectDir.substring(0, projectDir.lastIndexOf('/'));
   const projectDirRegex = new RegExp(`^${escapeRegExp(projectDir)}`);
   const fileDir = path.dirname(fileChoices[0]).replace(projectDirRegex, '');
 
-  const selection = [];
-  fileChoices.forEach(fileChoice => {
-    selection.push({
-      name: fileChoice.replace(projectDirRegex, ''),
-      value: fileChoice,
-    });
-  });
+  const selection = fileChoices.map(fileChoice => ({
+    name: fileChoice.replace(projectDirRegex, ''),
+    value: fileChoice,
+  }));
+
   const promptVal = await promptUser([
     {
       message: i18n(`${i18nKey}.fieldsPrompt`, { dir: fileDir }),
@@ -40,12 +42,11 @@ const fieldsJsPrompt = async (filePath, projectDir, skipFiles = []) => {
       choices: selection,
     },
   ]);
+
   const choice = promptVal.filePathChoice;
 
   // Add the ones that were not picked to skip files array.
   const notPicked = fileChoices.filter(item => item !== choice);
   skipFiles.push(...notPicked);
   return [choice, skipFiles];
-};
-
-module.exports = { fieldsJsPrompt };
+}

--- a/lib/prompts/createApiSamplePrompt.ts
+++ b/lib/prompts/createApiSamplePrompt.ts
@@ -1,52 +1,85 @@
-// @ts-nocheck
-const { promptUser } = require('./promptUtils');
-const { i18n } = require('../lang');
+import { promptUser } from './promptUtils';
+import { i18n } from '../lang';
+import { logger } from '@hubspot/local-dev-lib/logger';
+import { EXIT_CODES } from '../enums/exitCodes';
+import { PromptOperand, PromptConfig } from '../../types/prompts';
 
 const i18nKey = 'lib.prompts.createApiSamplePrompt';
 
-const getSampleTypesPrompt = choices => ({
-  type: 'rawlist',
-  name: 'sampleType',
-  message: i18n(`${i18nKey}.selectApiSampleApp`),
-  choices: choices.map(choice => ({
-    name: `${choice.name} - ${choice.description}`,
-    value: choice.id,
-  })),
-  validate: input => {
-    return new Promise(function(resolve, reject) {
-      if (input.length > 0) {
-        resolve(true);
-      }
-      reject(i18n(`${i18nKey}.errors.apiSampleAppRequired`));
-    });
-  },
-});
+type SampleChoice = {
+  name: string;
+  description: string;
+  id: string;
+  languages: string[];
+};
 
-const getLanguagesPrompt = choices => ({
-  type: 'rawlist',
-  name: 'sampleLanguage',
-  message: i18n(`${i18nKey}.selectLanguage`),
-  choices: choices.map(choice => ({
-    name: choice,
-    value: choice,
-  })),
-  validate: input => {
-    return new Promise(function(resolve, reject) {
-      if (input.length > 0) {
-        resolve(true);
-      }
-      reject(i18n(`${i18nKey}.errors.languageRequired`));
-    });
-  },
-});
+type SampleConfig = {
+  samples: SampleChoice[];
+};
 
-const createApiSamplePrompt = async samplesConfig => {
+type createApiSamplePromptResponse = {
+  sampleType?: string;
+  sampleLanguage?: string;
+};
+
+function getSampleTypesPrompt(
+  choices: SampleChoice[]
+): PromptConfig<createApiSamplePromptResponse> {
+  return {
+    type: 'rawlist',
+    name: 'sampleType',
+    message: i18n(`${i18nKey}.selectApiSampleApp`),
+    choices: choices.map(choice => ({
+      name: `${choice.name} - ${choice.description}`,
+      value: choice.id,
+    })),
+    validate: function(input?: string): Promise<PromptOperand> {
+      return new Promise<PromptOperand>(function(resolve, reject) {
+        if (input && input.length > 0) {
+          resolve(true);
+        } else {
+          reject(i18n(`${i18nKey}.errors.apiSampleAppRequired`));
+        }
+      });
+    },
+  };
+}
+
+function getLanguagesPrompt(
+  choices: string[]
+): PromptConfig<createApiSamplePromptResponse> {
+  return {
+    type: 'rawlist',
+    name: 'sampleLanguage',
+    message: i18n(`${i18nKey}.selectLanguage`),
+    choices: choices.map(choice => ({
+      name: choice,
+      value: choice,
+    })),
+    validate: function(input: string | undefined): Promise<PromptOperand> {
+      return new Promise<PromptOperand>(function(resolve, reject) {
+        if (input && input.length > 0) {
+          resolve(true);
+        }
+        reject(i18n(`${i18nKey}.errors.languageRequired`));
+      });
+    },
+  };
+}
+
+export async function createApiSamplePrompt(
+  samplesConfig: SampleConfig
+): Promise<createApiSamplePromptResponse> {
   try {
     const { samples } = samplesConfig;
     const sampleTypeAnswer = await promptUser(getSampleTypesPrompt(samples));
     const chosenSample = samples.find(
       sample => sample.id === sampleTypeAnswer.sampleType
     );
+    if (!chosenSample) {
+      logger.log(i18n(`${i18nKey}.errors.sampleNotFound`));
+      process.exit(EXIT_CODES.ERROR);
+    }
     const { languages } = chosenSample;
     const languagesAnswer = await promptUser(getLanguagesPrompt(languages));
     return {
@@ -56,8 +89,4 @@ const createApiSamplePrompt = async samplesConfig => {
   } catch (e) {
     return {};
   }
-};
-
-module.exports = {
-  createApiSamplePrompt,
-};
+}

--- a/lib/prompts/createApiSamplePrompt.ts
+++ b/lib/prompts/createApiSamplePrompt.ts
@@ -1,6 +1,6 @@
 import { promptUser } from './promptUtils';
 import { i18n } from '../lang';
-import { PromptOperand, PromptConfig } from '../../types/prompts';
+import { PromptConfig } from '../../types/prompts';
 
 const i18nKey = 'lib.prompts.createApiSamplePrompt';
 
@@ -15,14 +15,20 @@ type SampleConfig = {
   samples: SampleChoice[];
 };
 
-type CreateApiSamplePromptResponse = {
+type SampleTypePromptResponse = {
   sampleType?: string;
+};
+
+type LanguagePromptResponse = {
   sampleLanguage?: string;
 };
 
+type CreateApiSamplePromptResponse = SampleTypePromptResponse &
+  LanguagePromptResponse;
+
 function getSampleTypesPrompt(
   choices: SampleChoice[]
-): PromptConfig<CreateApiSamplePromptResponse> {
+): PromptConfig<SampleTypePromptResponse> {
   return {
     type: 'rawlist',
     name: 'sampleType',
@@ -32,7 +38,7 @@ function getSampleTypesPrompt(
       value: choice.id,
     })),
     validate: function(input?: string) {
-      return new Promise<PromptOperand>(function(resolve, reject) {
+      return new Promise<boolean>(function(resolve, reject) {
         if (input && input.length > 0) {
           resolve(true);
         } else {
@@ -45,7 +51,7 @@ function getSampleTypesPrompt(
 
 function getLanguagesPrompt(
   choices: string[]
-): PromptConfig<CreateApiSamplePromptResponse> {
+): PromptConfig<LanguagePromptResponse> {
   return {
     type: 'rawlist',
     name: 'sampleLanguage',
@@ -55,7 +61,7 @@ function getLanguagesPrompt(
       value: choice,
     })),
     validate: function(input: string | undefined) {
-      return new Promise<PromptOperand>(function(resolve, reject) {
+      return new Promise<boolean>(function(resolve, reject) {
         if (input && input.length > 0) {
           resolve(true);
         }
@@ -70,14 +76,14 @@ export async function createApiSamplePrompt(
 ): Promise<CreateApiSamplePromptResponse> {
   try {
     const { samples } = samplesConfig;
-    const sampleTypeAnswer = await promptUser<CreateApiSamplePromptResponse>(
+    const sampleTypeAnswer = await promptUser<SampleTypePromptResponse>(
       getSampleTypesPrompt(samples)
     );
     const chosenSample = samples.find(
       sample => sample.id === sampleTypeAnswer.sampleType
     );
     const { languages } = chosenSample!;
-    const languagesAnswer = await promptUser<CreateApiSamplePromptResponse>(
+    const languagesAnswer = await promptUser<LanguagePromptResponse>(
       getLanguagesPrompt(languages)
     );
     return {

--- a/lib/prompts/createApiSamplePrompt.ts
+++ b/lib/prompts/createApiSamplePrompt.ts
@@ -1,7 +1,5 @@
 import { promptUser } from './promptUtils';
 import { i18n } from '../lang';
-import { logger } from '@hubspot/local-dev-lib/logger';
-import { EXIT_CODES } from '../enums/exitCodes';
 import { PromptOperand, PromptConfig } from '../../types/prompts';
 
 const i18nKey = 'lib.prompts.createApiSamplePrompt';
@@ -17,14 +15,14 @@ type SampleConfig = {
   samples: SampleChoice[];
 };
 
-type createApiSamplePromptResponse = {
+type CreateApiSamplePromptResponse = {
   sampleType?: string;
   sampleLanguage?: string;
 };
 
 function getSampleTypesPrompt(
   choices: SampleChoice[]
-): PromptConfig<createApiSamplePromptResponse> {
+): PromptConfig<CreateApiSamplePromptResponse> {
   return {
     type: 'rawlist',
     name: 'sampleType',
@@ -33,7 +31,7 @@ function getSampleTypesPrompt(
       name: `${choice.name} - ${choice.description}`,
       value: choice.id,
     })),
-    validate: function(input?: string): Promise<PromptOperand> {
+    validate: function(input?: string) {
       return new Promise<PromptOperand>(function(resolve, reject) {
         if (input && input.length > 0) {
           resolve(true);
@@ -47,7 +45,7 @@ function getSampleTypesPrompt(
 
 function getLanguagesPrompt(
   choices: string[]
-): PromptConfig<createApiSamplePromptResponse> {
+): PromptConfig<CreateApiSamplePromptResponse> {
   return {
     type: 'rawlist',
     name: 'sampleLanguage',
@@ -56,7 +54,7 @@ function getLanguagesPrompt(
       name: choice,
       value: choice,
     })),
-    validate: function(input: string | undefined): Promise<PromptOperand> {
+    validate: function(input: string | undefined) {
       return new Promise<PromptOperand>(function(resolve, reject) {
         if (input && input.length > 0) {
           resolve(true);
@@ -69,19 +67,19 @@ function getLanguagesPrompt(
 
 export async function createApiSamplePrompt(
   samplesConfig: SampleConfig
-): Promise<createApiSamplePromptResponse> {
+): Promise<CreateApiSamplePromptResponse> {
   try {
     const { samples } = samplesConfig;
-    const sampleTypeAnswer = await promptUser(getSampleTypesPrompt(samples));
+    const sampleTypeAnswer = await promptUser<CreateApiSamplePromptResponse>(
+      getSampleTypesPrompt(samples)
+    );
     const chosenSample = samples.find(
       sample => sample.id === sampleTypeAnswer.sampleType
     );
-    if (!chosenSample) {
-      logger.log(i18n(`${i18nKey}.errors.sampleNotFound`));
-      process.exit(EXIT_CODES.ERROR);
-    }
-    const { languages } = chosenSample;
-    const languagesAnswer = await promptUser(getLanguagesPrompt(languages));
+    const { languages } = chosenSample!;
+    const languagesAnswer = await promptUser<CreateApiSamplePromptResponse>(
+      getLanguagesPrompt(languages)
+    );
     return {
       ...sampleTypeAnswer,
       ...languagesAnswer,

--- a/lib/prompts/createProjectPrompt.ts
+++ b/lib/prompts/createProjectPrompt.ts
@@ -48,7 +48,7 @@ function hasAllProperties(projectList: ProjectProperties[]): boolean {
 }
 
 async function createTemplateOptions(
-  templateSource: string,
+  templateSource: RepoPath,
   githubRef: string
 ): Promise<ProjectProperties[]> {
   const hasCustomTemplateSource = Boolean(templateSource);
@@ -57,7 +57,7 @@ async function createTemplateOptions(
     : githubRef;
 
   const config: ProjectsConfig = await fetchFileFromRepository(
-    (templateSource as RepoPath) || HUBSPOT_PROJECT_COMPONENTS_GITHUB_PATH,
+    templateSource || HUBSPOT_PROJECT_COMPONENTS_GITHUB_PATH,
     'config.json',
     branch
   );
@@ -90,7 +90,7 @@ export async function createProjectPrompt(
     name: string;
     dest: string;
     template: string;
-    templateSource: string;
+    templateSource: RepoPath;
   },
   skipTemplatePrompt = false
 ): Promise<CreateProjectPromptResponse> {
@@ -108,7 +108,7 @@ export async function createProjectPrompt(
       findTemplate(projectTemplates, promptOptions.template);
   }
 
-  const result = await promptUser([
+  const result = await promptUser<CreateProjectPromptResponse>([
     {
       name: 'name',
       message: i18n(`${i18nKey}.enterName`),
@@ -173,7 +173,3 @@ export async function createProjectPrompt(
 
   return result;
 }
-
-module.exports = {
-  createProjectPrompt,
-};

--- a/lib/prompts/createProjectPrompt.ts
+++ b/lib/prompts/createProjectPrompt.ts
@@ -1,43 +1,63 @@
-// @ts-nocheck
-const fs = require('fs');
-const path = require('path');
-const {
+import fs from 'fs';
+import path from 'path';
+import {
   getCwd,
   sanitizeFileName,
   isValidPath,
   untildify,
-} = require('@hubspot/local-dev-lib/path');
-const { PROJECT_COMPONENT_TYPES } = require('../constants');
-const { promptUser } = require('./promptUtils');
-const { fetchFileFromRepository } = require('@hubspot/local-dev-lib/github');
-const { i18n } = require('../lang');
-const { logger } = require('@hubspot/local-dev-lib/logger');
-const { EXIT_CODES } = require('../enums/exitCodes');
-const {
+} from '@hubspot/local-dev-lib/path';
+import {
+  PROJECT_COMPONENT_TYPES,
   HUBSPOT_PROJECT_COMPONENTS_GITHUB_PATH,
   DEFAULT_PROJECT_TEMPLATE_BRANCH,
-} = require('../constants');
+} from '../constants';
+import { promptUser } from './promptUtils';
+import { fetchFileFromRepository } from '@hubspot/local-dev-lib/github';
+import { i18n } from '../lang';
+import { logger } from '@hubspot/local-dev-lib/logger';
+import { EXIT_CODES } from '../enums/exitCodes';
+import { RepoPath } from '@hubspot/local-dev-lib/types/Github';
 
 const i18nKey = 'lib.prompts.createProjectPrompt';
 
 const PROJECT_PROPERTIES = ['name', 'label', 'path', 'insertPath'];
 
-const hasAllProperties = projectList => {
+type ProjectsConfig = {
+  projects?: ProjectProperties[];
+};
+
+type ProjectProperties = {
+  name: string;
+  label: string;
+  path: string;
+  insertPath: string;
+};
+
+type CreateProjectPromptResponse = {
+  name: string;
+  dest: string;
+  template: ProjectProperties;
+};
+
+function hasAllProperties(projectList: ProjectProperties[]): boolean {
   return projectList.every(config =>
     PROJECT_PROPERTIES.every(p =>
       Object.prototype.hasOwnProperty.call(config, p)
     )
   );
-};
+}
 
-const createTemplateOptions = async (templateSource, githubRef) => {
+async function createTemplateOptions(
+  templateSource: string,
+  githubRef: string
+): Promise<ProjectProperties[]> {
   const hasCustomTemplateSource = Boolean(templateSource);
   const branch = hasCustomTemplateSource
     ? DEFAULT_PROJECT_TEMPLATE_BRANCH
     : githubRef;
 
-  const config = await fetchFileFromRepository(
-    templateSource || HUBSPOT_PROJECT_COMPONENTS_GITHUB_PATH,
+  const config: ProjectsConfig = await fetchFileFromRepository(
+    (templateSource as RepoPath) || HUBSPOT_PROJECT_COMPONENTS_GITHUB_PATH,
     'config.json',
     branch
   );
@@ -47,26 +67,34 @@ const createTemplateOptions = async (templateSource, githubRef) => {
     process.exit(EXIT_CODES.ERROR);
   }
 
-  if (!hasAllProperties(config[PROJECT_COMPONENT_TYPES.PROJECTS])) {
+  if (!hasAllProperties(config[PROJECT_COMPONENT_TYPES.PROJECTS]!)) {
     logger.error(i18n(`${i18nKey}.errors.missingPropertiesInConfig`));
     process.exit(EXIT_CODES.ERROR);
   }
 
-  return config[PROJECT_COMPONENT_TYPES.PROJECTS];
-};
+  return config[PROJECT_COMPONENT_TYPES.PROJECTS]!;
+}
 
-function findTemplate(projectTemplates, templateNameOrLabel) {
+function findTemplate(
+  projectTemplates: ProjectProperties[],
+  templateNameOrLabel: string
+): ProjectProperties | undefined {
   return projectTemplates.find(
     t => t.name === templateNameOrLabel || t.label === templateNameOrLabel
   );
 }
 
-const createProjectPrompt = async (
-  githubRef,
-  promptOptions = {},
+export async function createProjectPrompt(
+  githubRef: string,
+  promptOptions: {
+    name: string;
+    dest: string;
+    template: string;
+    templateSource: string;
+  },
   skipTemplatePrompt = false
-) => {
-  let projectTemplates = [];
+): Promise<CreateProjectPromptResponse> {
+  let projectTemplates: ProjectProperties[] = [];
   let selectedTemplate;
 
   if (!skipTemplatePrompt) {
@@ -85,7 +113,7 @@ const createProjectPrompt = async (
       name: 'name',
       message: i18n(`${i18nKey}.enterName`),
       when: !promptOptions.name,
-      validate: input => {
+      validate: (input?: string) => {
         if (!input) {
           return i18n(`${i18nKey}.errors.nameRequired`);
         }
@@ -102,7 +130,7 @@ const createProjectPrompt = async (
         );
         return path.resolve(getCwd(), projectName);
       },
-      validate: input => {
+      validate: (input?: string) => {
         if (!input) {
           return i18n(`${i18nKey}.errors.destRequired`);
         }
@@ -144,7 +172,7 @@ const createProjectPrompt = async (
   }
 
   return result;
-};
+}
 
 module.exports = {
   createProjectPrompt,

--- a/lib/prompts/downloadProjectPrompt.ts
+++ b/lib/prompts/downloadProjectPrompt.ts
@@ -2,6 +2,7 @@ import { promptUser } from './promptUtils';
 import { getAccountId } from '@hubspot/local-dev-lib/config';
 import { fetchProjects } from '@hubspot/local-dev-lib/api/projects';
 import { logError, ApiErrorContext } from '../errorHandlers/index';
+import { logger } from '@hubspot/local-dev-lib/logger';
 import { EXIT_CODES } from '../enums/exitCodes';
 import { i18n } from '../lang';
 import { Project } from '@hubspot/local-dev-lib/types/Project';
@@ -20,7 +21,8 @@ async function createProjectsList(
       const { data: projects } = await fetchProjects(accountId);
       return projects.results;
     }
-    return [];
+    logger.error(i18n(`${i18nKey}.errors.accountIdRequired`));
+    process.exit(EXIT_CODES.ERROR);
   } catch (e) {
     if (accountId) {
       logError(e, new ApiErrorContext({ accountId }));

--- a/lib/prompts/downloadProjectPrompt.ts
+++ b/lib/prompts/downloadProjectPrompt.ts
@@ -24,11 +24,7 @@ async function createProjectsList(
     logger.error(i18n(`${i18nKey}.errors.accountIdRequired`));
     process.exit(EXIT_CODES.ERROR);
   } catch (e) {
-    if (accountId) {
-      logError(e, new ApiErrorContext({ accountId }));
-    } else {
-      logError(e);
-    }
+    logError(e, accountId ? new ApiErrorContext({ accountId }) : undefined);
     process.exit(EXIT_CODES.ERROR);
   }
 }

--- a/lib/prompts/installPublicAppPrompt.ts
+++ b/lib/prompts/installPublicAppPrompt.ts
@@ -1,21 +1,20 @@
-// @ts-nocheck
-const open = require('open');
-const { getHubSpotWebsiteOrigin } = require('@hubspot/local-dev-lib/urls');
-const { logger } = require('@hubspot/local-dev-lib/logger');
-const { promptUser } = require('./promptUtils');
-const { i18n } = require('../lang');
-const { EXIT_CODES } = require('../enums/exitCodes');
+import open from 'open';
+import { getHubSpotWebsiteOrigin } from '@hubspot/local-dev-lib/urls';
+import { logger } from '@hubspot/local-dev-lib/logger';
+import { promptUser } from './promptUtils';
+import { i18n } from '../lang';
+import { EXIT_CODES } from '../enums/exitCodes';
 
 const i18nKey = 'lib.prompts.installPublicAppPrompt';
 
-const installPublicAppPrompt = async (
-  env,
-  targetAccountId,
-  clientId,
-  scopes,
-  redirectUrls,
+export async function installPublicAppPrompt(
+  env: string,
+  targetAccountId: number,
+  clientId: number,
+  scopes: string[],
+  redirectUrls: string[],
   isReinstall = false
-) => {
+): Promise<void> {
   logger.log('');
   if (isReinstall) {
     logger.log(i18n(`${i18nKey}.reinstallExplanation`));
@@ -47,6 +46,4 @@ const installPublicAppPrompt = async (
     `&redirect_uri=${encodeURIComponent(redirectUrls[0])}`;
 
   open(url);
-};
-
-module.exports = { installPublicAppPrompt };
+}

--- a/lib/prompts/installPublicAppPrompt.ts
+++ b/lib/prompts/installPublicAppPrompt.ts
@@ -22,7 +22,9 @@ export async function installPublicAppPrompt(
     logger.log(i18n(`${i18nKey}.explanation`));
   }
 
-  const { shouldOpenBrowser } = await promptUser({
+  const { shouldOpenBrowser } = await promptUser<{
+    shouldOpenBrowser: boolean;
+  }>({
     name: 'shouldOpenBrowser',
     type: 'confirm',
     message: i18n(

--- a/lib/ui/index.ts
+++ b/lib/ui/index.ts
@@ -54,7 +54,10 @@ export function uiLink(linkText: string, url: string): string {
     : `${linkText}: ${encodedUrl}`;
 }
 
-export function uiAccountDescription(accountId: number, bold = true): string {
+export function uiAccountDescription(
+  accountId: number | undefined,
+  bold = true
+): string {
   const account = getAccountConfig(accountId);
   let message;
   if (account && account.accountType) {

--- a/lib/ui/index.ts
+++ b/lib/ui/index.ts
@@ -54,10 +54,7 @@ export function uiLink(linkText: string, url: string): string {
     : `${linkText}: ${encodedUrl}`;
 }
 
-export function uiAccountDescription(
-  accountId: number | undefined,
-  bold = true
-): string {
+export function uiAccountDescription(accountId?: number, bold = true): string {
   const account = getAccountConfig(accountId);
   let message;
   if (account && account.accountType) {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": "https://github.com/HubSpot/hubspot-cli",
   "dependencies": {
-    "@hubspot/local-dev-lib": "3.0.0",
+    "@hubspot/local-dev-lib": "3.0.1",
     "@hubspot/serverless-dev-runtime": "7.0.0",
     "@hubspot/theme-preview-dev-server": "0.0.9",
     "@hubspot/ui-extensions-dev-server": "0.8.33",

--- a/types/prompts.ts
+++ b/types/prompts.ts
@@ -3,22 +3,30 @@ export type GenericPromptResponse = {
   [key: string]: any;
 };
 
-type PromptType = 'confirm' | 'list' | 'checkbox' | 'input' | 'password';
+type PromptType =
+  | 'confirm'
+  | 'list'
+  | 'checkbox'
+  | 'input'
+  | 'password'
+  | 'rawlist';
 
-export type PromptChoices = string[] | Array<{ name: string; value: string }>;
+export type PromptChoices =
+  | string[]
+  | Array<{ name: string; value: string | { [key: string]: string } }>;
 
 export type PromptWhen = boolean | (() => boolean);
 
-type PromptOperand = string | number | boolean | string[] | boolean[];
+export type PromptOperand = string | number | boolean | string[] | boolean[];
 
 export type PromptConfig<T extends GenericPromptResponse> = {
   name: keyof T;
   type?: PromptType;
-  message?: string;
+  message?: string | ((answers: T) => string);
   choices?: PromptChoices;
   when?: PromptWhen;
   pageSize?: number;
-  default?: PromptOperand;
+  default?: PromptOperand | ((answers: T) => PromptOperand);
   validate?:
     | ((answer?: string) => PromptOperand | Promise<PromptOperand>)
     | ((answer: string[]) => PromptOperand | Promise<PromptOperand>);

--- a/types/prompts.ts
+++ b/types/prompts.ts
@@ -9,7 +9,7 @@ export type PromptChoices = string[] | Array<{ name: string; value: string }>;
 
 export type PromptWhen = boolean | (() => boolean);
 
-type PromptOperand = string | boolean | string[] | boolean[];
+type PromptOperand = string | number | boolean | string[] | boolean[];
 
 export type PromptConfig<T extends GenericPromptResponse> = {
   name: keyof T;
@@ -17,6 +17,7 @@ export type PromptConfig<T extends GenericPromptResponse> = {
   message?: string;
   choices?: PromptChoices;
   when?: PromptWhen;
+  pageSize?: number;
   default?: PromptOperand;
   validate?:
     | ((answer?: string) => PromptOperand | Promise<PromptOperand>)

--- a/types/prompts.ts
+++ b/types/prompts.ts
@@ -17,7 +17,7 @@ export type PromptChoices =
 
 export type PromptWhen = boolean | (() => boolean);
 
-export type PromptOperand = string | number | boolean | string[] | boolean[];
+type PromptOperand = string | number | boolean | string[] | boolean[];
 
 export type PromptConfig<T extends GenericPromptResponse> = {
   name: keyof T;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1463,10 +1463,10 @@
     semver "^6.3.0"
     unixify "^1.0.0"
 
-"@hubspot/local-dev-lib@3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@hubspot/local-dev-lib/-/local-dev-lib-3.0.0.tgz#2530a9b8567e5078e282caf3f136a6f2cc03c4e1"
-  integrity sha512-PDyeh2qDZeQFhcIJIVasQKwU0rs7jhRzzMRgk0uQi2SI4HWsSWvDYmTq+Gk16R4K4s9q2Tf/VsN5/Vdo7G1m6Q==
+"@hubspot/local-dev-lib@3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@hubspot/local-dev-lib/-/local-dev-lib-3.0.1.tgz#1dd22f439d6e262353f14915a354115bbc1f5f76"
+  integrity sha512-h1jOmZJNdHZFbrOA5Gn815YCsix8eY81A4dkrUuDZI4MzVaJH3o4RoRalMl+Hr2e35nDrbrbcIR1RMQADPSmwg==
   dependencies:
     address "^2.0.1"
     axios "^1.3.5"
@@ -11539,6 +11539,7 @@ wordwrap@^1.0.0:
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
 "wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+  name wrap-ansi-cjs
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
## Description and Context
Dependent on https://github.com/HubSpot/hubspot-local-dev-lib/pull/217 (PR merged, and now tests are passing 🥳 ). 

This PR continues our work to convert prompts to TypeScript. The prompts in this PR include:

`accountsPrompt`
`cmsFieldPrompt`
`createApiSamplePrompt`
`createProjectPrompt`
`downloadProjectPrompt`
`installPublicAppPrompt`

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

- [x] Address feedback

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@camden11 @brandenrodgers @joe-yeager 
