### PR TITLE
feat: Unhide the function server and function deploy commands

### DIFF
--- a/commands/function/deploy.ts
+++ b/commands/function/deploy.ts
@@ -22,7 +22,7 @@ const { isHubSpotHttpError } = require('@hubspot/local-dev-lib/errors/index');
 const i18nKey = 'commands.function.subcommands.deploy';
 
 exports.command = 'deploy <path>';
-exports.describe = false;
+exports.describe = i18n(`${i18nKey}.describe`);
 
 exports.handler = async options => {
   await loadAndValidateOptions(options);

--- a/commands/function/server.ts
+++ b/commands/function/server.ts
@@ -13,7 +13,7 @@ const { i18n } = require('../../lib/lang');
 const i18nKey = 'commands.function.subcommands.server';
 
 exports.command = 'server <path>';
-exports.describe = false;
+exports.describe = i18n(`${i18nKey}.describe`);
 
 exports.handler = async options => {
   await loadAndValidateOptions(options);

--- a/lang/en.lyaml
+++ b/lang/en.lyaml
@@ -353,6 +353,7 @@ en:
       describe: "Commands for managing CMS serverless functions."
       subcommands:
         deploy:
+          describe: "Deploy a CMS serverless function."
           debug:
             startingBuildAndDeploy: "Starting build and deploy for .functions folder with path: {{ functionPath }}"
           errors:
@@ -378,6 +379,7 @@ en:
             json:
               describe: "output raw json data"
         server:
+          describe: "Start local development for a CMS serverless function."
           debug:
             startingServer: "Starting local test server for .functions folder with path: {{ functionPath }}"
           examples:


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
The `hs function server` and `hs function deploy` commands have been hidden for quite some time and are getting usage, after talking with the CMS team @TanyaScales was ok with unhiding them.

## Screenshot

Help output after adding descriptions:

![Screenshot 2024-12-04 at 2 47 26 PM](https://github.com/user-attachments/assets/e6bd6490-1361-4fa2-8971-b08ec858fcc7)
