### PR TITLE
Fix public app local dev prompts

### DIFF
--- a/lib/LocalDevManager.ts
+++ b/lib/LocalDevManager.ts
@@ -108,9 +108,9 @@ class LocalDevManager {
       return;
     }
 
-    const { data: portalPublicApps } = await fetchPublicAppsForPortal(
-      this.targetProjectAccountId
-    );
+    const {
+      data: { results: portalPublicApps },
+    } = await fetchPublicAppsForPortal(this.targetProjectAccountId);
 
     const activePublicAppData = portalPublicApps.find(
       ({ sourceId }) => sourceId === this.activeApp.config.uid


### PR DESCRIPTION
## Description and Context
I'm not entirely sure how this happened, but at some point we stopped pulling `results` off this API response, which caused the next line to run `.find()` on undefined. This error ended up getting caught and swallowed up somewhere else, and the side effect was skipping both the active install and install public app prompts.

Fixes https://git.hubteam.com/HubSpot/hubspot-cli-issues/issues/743

## TODO
* It's not necessarily going to be straightforward, but at some point we need to figure out a better way to test the local dev flow and catch things like this. A lot of things have broken lately and flown under the radar.

## Who to Notify
@kemmerle @brandenrodgers @joe-yeager 
