### PR TITLE
Fix: two bugs in `hs project dev` 

### DIFF
--- a/commands/project/dev.ts
+++ b/commands/project/dev.ts
@@ -110,7 +110,7 @@ exports.handler = async options => {
   // The account that we are locally testing against
   let targetTestingAccountId;
 
-  // Check that the default account or flag option is valid for the type of app in this projec
+  // Check that the default account or flag option is valid for the type of app in this project
   checkIfDefaultAccountIsSupported(accountConfig, hasPublicApps);
 
   // The user is targeting an account type that we recommend developing on

--- a/commands/project/dev.ts
+++ b/commands/project/dev.ts
@@ -46,7 +46,6 @@ const {
   createNewProjectForLocalDev,
   createInitialBuildForNewProject,
   useExistingDevTestAccount,
-  checkIfAccountFlagIsSupported,
   checkIfParentAccountIsAuthed,
 } = require('../../lib/localDev');
 
@@ -107,23 +106,15 @@ exports.handler = async options => {
     (!hasPublicApps && isSandbox(accountConfig));
 
   // The account that the project must exist in
-  let targetProjectAccountId = derivedAccountId;
+  let targetProjectAccountId;
   // The account that we are locally testing against
-  let targetTestingAccountId = derivedAccountId;
+  let targetTestingAccountId;
 
-  // Check that the default account or flag option is valid for the type of app in this project
-  if (derivedAccountId) {
-    checkIfAccountFlagIsSupported(accountConfig, hasPublicApps);
-
-    if (hasPublicApps) {
-      targetProjectAccountId = accountConfig.parentAccountId;
-    }
-  } else {
-    checkIfDefaultAccountIsSupported(accountConfig, hasPublicApps);
-  }
+  // Check that the default account or flag option is valid for the type of app in this projec
+  checkIfDefaultAccountIsSupported(accountConfig, hasPublicApps);
 
   // The user is targeting an account type that we recommend developing on
-  if (!targetProjectAccountId && defaultAccountIsRecommendedType) {
+  if (defaultAccountIsRecommendedType) {
     targetTestingAccountId = derivedAccountId;
 
     await confirmDefaultAccountIsTarget(accountConfig, hasPublicApps);

--- a/lib/commonOpts.ts
+++ b/lib/commonOpts.ts
@@ -85,7 +85,6 @@ export function addUseEnvironmentOptions(yargs: Argv): Argv {
     .option('use-env', {
       describe: i18n(`${i18nKey}.options.useEnv.describe`),
       type: 'boolean',
-      default: false,
     })
     .conflicts('use-env', 'account');
 }

--- a/lib/localDev.ts
+++ b/lib/localDev.ts
@@ -121,29 +121,6 @@ const checkIfParentAccountIsAuthed = accountConfig => {
   }
 };
 
-// Confirm the default account is a developer account if developing public apps
-const checkIfAccountFlagIsSupported = (accountConfig, hasPublicApps) => {
-  if (hasPublicApps) {
-    if (!isDeveloperTestAccount(accountConfig)) {
-      logger.error(
-        i18n(`${i18nKey}.validateAccountOption.invalidPublicAppAccount`, {
-          useCommand: uiCommandReference('hs accounts use'),
-          devCommand: uiCommandReference('hs project dev'),
-        })
-      );
-      process.exit(EXIT_CODES.SUCCESS);
-    }
-    checkIfParentAccountIsAuthed(accountConfig);
-  } else if (isAppDeveloperAccount(accountConfig)) {
-    logger.error(
-      i18n(`${i18nKey}.validateAccountOption.invalidPrivateAppAccount`, {
-        useCommand: uiCommandReference('hs accounts use'),
-      })
-    );
-    process.exit(EXIT_CODES.SUCCESS);
-  }
-};
-
 // If the user isn't using the recommended account type, prompt them to use or create one
 const suggestRecommendedNestedAccount = async (
   accounts,
@@ -480,7 +457,6 @@ const getAccountHomeUrl = accountId => {
 module.exports = {
   confirmDefaultAccountIsTarget,
   checkIfDefaultAccountIsSupported,
-  checkIfAccountFlagIsSupported,
   suggestRecommendedNestedAccount,
   createSandboxForLocalDev,
   createDeveloperTestAccountForLocalDev,

--- a/lib/localDev.ts
+++ b/lib/localDev.ts
@@ -124,7 +124,7 @@ const checkIfParentAccountIsAuthed = accountConfig => {
 // Confirm the default account is a developer account if developing public apps
 const checkIfAccountFlagIsSupported = (accountConfig, hasPublicApps) => {
   if (hasPublicApps) {
-    if (!isDeveloperTestAccount) {
+    if (!isDeveloperTestAccount(accountConfig)) {
       logger.error(
         i18n(`${i18nKey}.validateAccountOption.invalidPublicAppAccount`, {
           useCommand: uiCommandReference('hs accounts use'),


### PR DESCRIPTION
## Description and Context
In the process of tracking down one bug in `hs project dev`, I discovered three:

1) Using the `--account` flag in any command that used the `addUseEnvironmentOptions` middleware resulted in the error: `Arguments use-env and account are mutually exclusive`. This was because we were setting both a `conflicts` and a `default` for `use-env`. 

2) We were not correctly handling the scenario where a customer was passing the `--account` flag. We no longer need to perform a separate check for the account flag value, because we already do so in the middleware. This allows us to eliminate and simplify code. 

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

- [ ] Address any feedback 

## Who to Notify
<!-- /cc those you wish to know about the PR -->

@camden11 @brandenrodgers @joe-yeager 
