### PR TITLE
Refactor `loadAndValidateOptions` into middleware p.1

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -27,6 +27,7 @@ const pkg = require('../package.json');
 const { i18n } = require('../lib/lang');
 const { EXIT_CODES } = require('../lib/enums/exitCodes');
 const { UI_COLORS, uiCommandReference } = require('../lib/ui');
+const { checkAndWarnGitInclusion } = require('../lib/ui/git');
 
 const removeCommand = require('../commands/remove');
 const initCommand = require('../commands/init');
@@ -168,6 +169,10 @@ const loadConfigMiddleware = async options => {
   }
 };
 
+const checkAndWarnGitInclusionMiddleware = () => {
+  checkAndWarnGitInclusion(getConfigPath());
+};
+
 const argv = yargs
   .usage('The command line interface to interact with HubSpot.')
   // loadConfigMiddleware loads the new hidden config for all commands
@@ -176,6 +181,7 @@ const argv = yargs
     setRequestHeaders,
     loadConfigMiddleware,
     injectAccountIdMiddleware,
+    checkAndWarnGitInclusionMiddleware,
   ])
   .exitProcess(false)
   .fail(handleFailure)

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -27,13 +27,11 @@ const {
 } = require('@hubspot/local-dev-lib/path');
 const { getAccountId, getCmsPublishMode } = require('./commonOpts');
 const { EXIT_CODES } = require('./enums/exitCodes');
-const { checkAndWarnGitInclusion } = require('./ui/git');
 const { logError } = require('./errorHandlers/index');
 
 async function loadAndValidateOptions(options, shouldValidateAccount = true) {
   const { config: configPath } = options;
   loadConfig(configPath, options);
-  checkAndWarnGitInclusion(getConfigPath());
 
   let validAccount = true;
   if (shouldValidateAccount) {

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -25,17 +25,12 @@ const {
   getCwd,
   getExt,
 } = require('@hubspot/local-dev-lib/path');
-const {
-  getAccountId,
-  getCmsPublishMode,
-  setLogLevel,
-} = require('./commonOpts');
+const { getAccountId, getCmsPublishMode } = require('./commonOpts');
 const { EXIT_CODES } = require('./enums/exitCodes');
 const { checkAndWarnGitInclusion } = require('./ui/git');
 const { logError } = require('./errorHandlers/index');
 
 async function loadAndValidateOptions(options, shouldValidateAccount = true) {
-  setLogLevel(options);
   const { config: configPath } = options;
   loadConfig(configPath, options);
   checkAndWarnGitInclusion(getConfigPath());


### PR DESCRIPTION
## Description and Context
This is the first of three PRs to refactor `loadAndValidateOptions` and divide its functionality in middleware functions. You can read full details in this [Canvas](https://hubspot.enterprise.slack.com/docs/T024G0P55/F084D9R14S0) I wrote up. 

Here, I've deleted `setLogLevel` (which is already in middleware) and moved `checkAndWarnGitInclusion` to middleware.

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

- [ ] Address feedback

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@camden11 @brandenrodgers @joe-yeager 
