### PR TITLE
Fix: local dev bugs (main branch)

### DIFF
--- a/lib/commonOpts.ts
+++ b/lib/commonOpts.ts
@@ -70,7 +70,6 @@ export function addUseEnvironmentOptions(yargs: Argv): Argv {
   return yargs.option('use-env', {
     describe: i18n(`${i18nKey}.options.useEnv.describe`),
     type: 'boolean',
-    default: false,
   });
 }
 

--- a/lib/localDev.ts
+++ b/lib/localDev.ts
@@ -124,7 +124,7 @@ const checkIfParentAccountIsAuthed = accountConfig => {
 // Confirm the default account is a developer account if developing public apps
 const checkIfAccountFlagIsSupported = (accountConfig, hasPublicApps) => {
   if (hasPublicApps) {
-    if (!isDeveloperTestAccount) {
+    if (!isDeveloperTestAccount(accountConfig)) {
       logger.error(
         i18n(`${i18nKey}.validateAccountOption.invalidPublicAppAccount`, {
           useCommand: uiCommandReference('hs accounts use'),


### PR DESCRIPTION
## Description and Context
In the process of tracking down one bug in `hs project dev`, I discovered two:

1) On the `next` branch, Using the `--account` flag in any command that used the `addUseEnvironmentOptions` middleware resulted in the error: `Arguments use-env and account are mutually exclusive`. This was because we were setting both a `conflicts` and a `default` for `use-env` in that function. Removed the `default` here to avoid any heartaches. 

2) In the `checkIfAccountFlagIsSupported` function, we were checking for `!isDeveloperTestAccount` and not `!isDeveloperTestAccount(accountConfig)`. 

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

- [ ] Address bugs 

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@camden11 @brandenrodgers @joe-yeager 