### PR TITLE
Fix bug with account middleware in `hs project dev`

### DIFF
--- a/commands/project/dev.ts
+++ b/commands/project/dev.ts
@@ -13,7 +13,6 @@ const { logger } = require('@hubspot/local-dev-lib/logger');
 const {
   getConfigAccounts,
   getAccountConfig,
-  getAccountId: getAccountIdFromConfig,
   getEnv,
 } = require('@hubspot/local-dev-lib/config');
 const {
@@ -59,8 +58,6 @@ exports.describe = uiBetaTag(i18n(`${i18nKey}.describe`), false);
 exports.handler = async options => {
   await loadAndValidateOptions(options);
   const { derivedAccountId, providedAccountId } = options;
-  const parsedProvidedAccountId = getAccountIdFromConfig(providedAccountId);
-  const providedAccountConfig = getAccountConfig(parsedProvidedAccountId);
   const accountConfig = getAccountConfig(derivedAccountId);
   const env = getValidEnv(getEnv(derivedAccountId));
 
@@ -110,20 +107,16 @@ exports.handler = async options => {
     (!hasPublicApps && isSandbox(accountConfig));
 
   // The account that the project must exist in
-  let targetProjectAccountId = providedAccountId
-    ? parsedProvidedAccountId
-    : null;
+  let targetProjectAccountId = providedAccountId ? derivedAccountId : null;
   // The account that we are locally testing against
-  let targetTestingAccountId = providedAccountId
-    ? parsedProvidedAccountId
-    : null;
+  let targetTestingAccountId = providedAccountId ? derivedAccountId : null;
 
   // Check that the default account or flag option is valid for the type of app in this project
   if (providedAccountId) {
-    checkIfAccountFlagIsSupported(providedAccountConfig, hasPublicApps);
+    checkIfAccountFlagIsSupported(accountConfig, hasPublicApps);
 
     if (hasPublicApps) {
-      targetProjectAccountId = providedAccountConfig.parentAccountId;
+      targetProjectAccountId = accountConfig.parentAccountId;
     }
   } else {
     checkIfDefaultAccountIsSupported(accountConfig, hasPublicApps);

--- a/commands/project/dev.ts
+++ b/commands/project/dev.ts
@@ -106,7 +106,8 @@ exports.handler = async options => {
     isDeveloperTestAccount(accountConfig) ||
     (!hasPublicApps && isSandbox(accountConfig));
 
-  // The account that the project must exist in
+  // targetProjectAccountId and targetTestingAccountId are set to null if --account flag is not provided.
+  // By setting them to null, we can later check if they need to be assigned based on the default account configuration and the type of app.
   let targetProjectAccountId = providedAccountId ? derivedAccountId : null;
   // The account that we are locally testing against
   let targetTestingAccountId = providedAccountId ? derivedAccountId : null;

--- a/lib/commonOpts.ts
+++ b/lib/commonOpts.ts
@@ -85,7 +85,6 @@ export function addUseEnvironmentOptions(yargs: Argv): Argv {
     .option('use-env', {
       describe: i18n(`${i18nKey}.options.useEnv.describe`),
       type: 'boolean',
-      default: false,
     })
     .conflicts('use-env', 'account');
 }

--- a/lib/localDev.ts
+++ b/lib/localDev.ts
@@ -124,7 +124,7 @@ const checkIfParentAccountIsAuthed = accountConfig => {
 // Confirm the default account is a developer account if developing public apps
 const checkIfAccountFlagIsSupported = (accountConfig, hasPublicApps) => {
   if (hasPublicApps) {
-    if (!isDeveloperTestAccount) {
+    if (!isDeveloperTestAccount(accountConfig)) {
       logger.error(
         i18n(`${i18nKey}.validateAccountOption.invalidPublicAppAccount`, {
           useCommand: uiCommandReference('hs accounts use'),
@@ -248,8 +248,9 @@ const createDeveloperTestAccountForLocalDev = async (
   let currentPortalCount = 0;
   let maxTestPortals = 10;
   try {
-    const validateResult =
-      await validateDevTestAccountUsageLimits(accountConfig);
+    const validateResult = await validateDevTestAccountUsageLimits(
+      accountConfig
+    );
     if (validateResult) {
       currentPortalCount = validateResult.results
         ? validateResult.results.length
@@ -305,8 +306,9 @@ const createDeveloperTestAccountForLocalDev = async (
 
 // Prompt user to confirm usage of an existing developer test account that is not currently in the config
 const useExistingDevTestAccount = async (env, account) => {
-  const useExistingDevTestAcct =
-    await confirmUseExistingDeveloperTestAccountPrompt(account);
+  const useExistingDevTestAcct = await confirmUseExistingDeveloperTestAccountPrompt(
+    account
+  );
   if (!useExistingDevTestAcct) {
     logger.log('');
     logger.log(


### PR DESCRIPTION
## Description and Context
This fixes some bugs I discovered with the new injected account middleware in `hs project dev.` We were not correctly checking and handling account flags and had changed the command's behavior accidentally, so that when a customer runs `hs project dev` with an app developer account set as default, they did not receive the menu to choose a developer test account. @camden11, you're the person who best understands the intricacies here.  

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

- [ ] Address feedback

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@camden11 @brandenrodgers @joe-yeager 
