### PR TITLE
Fix bug in `hs fetch`

### DIFF
--- a/commands/fetch.ts
+++ b/commands/fetch.ts
@@ -42,7 +42,7 @@ exports.handler = async options => {
   const { derivedAccountId } = options;
   const cmsPublishMode = getCmsPublishMode(options);
 
-  trackCommandUsage('fetch', { mode: cmsPublishMode }, accountId);
+  trackCommandUsage('fetch', { mode: cmsPublishMode }, derivedAccountId);
 
   try {
     // Fetch and write file/folder.


### PR DESCRIPTION
## Description and Context
I found a spare `accountId` variable in `hs fetch` which was causing the command to fail. I replaced it with `derivedAccountId`. 

I performed a manual check of every command file where we refer to `accountId` to ensure that there were no more bugs, and I found none. We should be really careful not to introduce bugs before merging `next` into `main` next week. 

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

- [ ] Address feedback 

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@brandenrodgers @camden11 @joe-yeager 
