### PR TITLE
Refactor `loadAndValidateOptions` p.2 (config middleware)

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -9,6 +9,7 @@ const { logger } = require('@hubspot/local-dev-lib/logger');
 const { addUserAgentHeader } = require('@hubspot/local-dev-lib/http');
 const {
   loadConfig,
+  getAndLoadConfigIfNeeded,
   configFileExists,
   getConfigPath,
 } = require('@hubspot/local-dev-lib/config');
@@ -148,6 +149,7 @@ const setRequestHeaders = () => {
 };
 
 const loadConfigMiddleware = async options => {
+  // Load the new config and check for the conflicting config flag
   if (configFileExists(true)) {
     loadConfig('', options);
 
@@ -159,6 +161,7 @@ const loadConfigMiddleware = async options => {
       );
       process.exit(EXIT_CODES.ERROR);
     }
+    return;
   }
 
   // We need to load the config when options.config exists,
@@ -166,7 +169,12 @@ const loadConfigMiddleware = async options => {
   if (options.config && fs.existsSync(options.config)) {
     const { config: configPath } = options;
     await loadConfig(configPath, options);
+    return;
   }
+
+  // Load deprecated config without a config flag and with no warnings
+  getAndLoadConfigIfNeeded(options);
+  return;
 };
 
 const checkAndWarnGitInclusionMiddleware = () => {

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -10,7 +10,6 @@ const {
 } = require('@hubspot/local-dev-lib/constants/auth');
 const { commaSeparatedValues } = require('@hubspot/local-dev-lib/text');
 const {
-  loadConfig,
   getConfigPath,
   validateConfig,
   getAccountConfig,
@@ -30,9 +29,6 @@ const { EXIT_CODES } = require('./enums/exitCodes');
 const { logError } = require('./errorHandlers/index');
 
 async function loadAndValidateOptions(options, shouldValidateAccount = true) {
-  const { config: configPath } = options;
-  loadConfig(configPath, options);
-
   let validAccount = true;
   if (shouldValidateAccount) {
     validAccount = await validateAccount(options);


### PR DESCRIPTION
## Description and Context
This is the second of three PRs to refactor `loadAndValidateOptions` and divide its functionality in middleware functions. You can read full details in this [Canvas](https://hubspot.enterprise.slack.com/docs/T024G0P55/F084D9R14S0) I wrote up. 

Here, I've moved all the functionality to load config (both deprecated and the new centralized config) to middleware. 

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

- [x] Address feedback

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@camden11 @brandenrodgers @joe-yeager 