### PR TITLE
Fix bug in `hs sandbox delete` 

### DIFF
--- a/lib/prompts/sandboxesPrompt.ts
+++ b/lib/prompts/sandboxesPrompt.ts
@@ -26,7 +26,7 @@ function mapSandboxAccountChoices(
 ): PromptChoices {
   return (
     portals
-      ?.filter(p => !isSandbox(p))
+      ?.filter(p => isSandbox(p))
       .map(p => ({
         name: uiAccountDescription(getAccountIdentifier(p), false),
         value: p.name || getAccountIdentifier(p),


### PR DESCRIPTION
## Description and Context
I noticed that we were not filtering accounts correctly in the `hs sandbox delete` command while working on another PR.

## Screenshots
<!-- Provide images of the before and after functionality -->

Before (Showing standard accounts to select for sandbox deletion):

<img width="945" alt="Screenshot 2024-12-20 at 2 25 54 PM" src="https://github.com/user-attachments/assets/4cc59f28-c8fe-4df4-b698-a03bc03fb751" />

After (Correctly showing sandbox accounts to select for deletion):

<img width="906" alt="Screenshot 2024-12-20 at 2 27 39 PM" src="https://github.com/user-attachments/assets/1385068c-6f7b-45db-ad3f-ee56575edf9b" />

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

- [ ] Address feedback

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@brandenrodgers @camden11 @joe-yeager 
