### PR TITLE
Chore: Fix the no config error for hs --version

### DIFF
--- a/acceptance-tests/tests/commands/hs.spec.ts
+++ b/acceptance-tests/tests/commands/hs.spec.ts
@@ -1,0 +1,36 @@
+import { describe, beforeAll, it, expect, afterAll } from 'vitest';
+import { TestState } from '../../lib/TestState';
+
+describe('hs', () => {
+  let testState: TestState;
+
+  beforeAll(async () => {
+    testState = new TestState();
+  });
+
+  afterAll(() => {
+    testState.cleanup();
+  });
+
+  describe('hs', () => {
+    it('should log out the help message', async () => {
+      const output = await testState.cli.executeWithTestConfig([]);
+
+      expect(output).toContain(
+        'The command line interface to interact with HubSpot'
+      );
+    });
+
+    it('should log out the help message when --help is passed', async () => {
+      const output = await testState.cli.executeWithTestConfig(['--help']);
+
+      expect(output).toContain(
+        'The command line interface to interact with HubSpot'
+      );
+    });
+
+    it('should not throw when --version is passed', async () => {
+      await testState.cli.executeWithTestConfig(['--version']);
+    });
+  });
+});

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -108,7 +108,7 @@ const handleFailure = (msg, err, yargs) => {
   }
 
   if (msg === null) {
-    yargs.showHelp();
+    yargs.showHelp('log');
     process.exit(EXIT_CODES.SUCCESS);
   } else {
     process.exit(EXIT_CODES.ERROR);
@@ -177,6 +177,11 @@ const SKIP_CONFIG_VALIDATION = {
 };
 
 const loadConfigMiddleware = async options => {
+  // Skip this when no command is provided
+  if (!options._.length) {
+    return;
+  }
+
   const maybeValidateConfig = () => {
     if (
       !isTargetedCommand(options, SKIP_CONFIG_VALIDATION) &&
@@ -201,7 +206,11 @@ const loadConfigMiddleware = async options => {
   maybeValidateConfig();
 };
 
-const checkAndWarnGitInclusionMiddleware = () => {
+const checkAndWarnGitInclusionMiddleware = options => {
+  // Skip this when no command is provided
+  if (!options._.length) {
+    return;
+  }
   checkAndWarnGitInclusion(getConfigPath());
 };
 
@@ -231,6 +240,11 @@ const SKIP_ACCOUNT_VALIDATION = {
 };
 
 const validateAccountOptions = async options => {
+  // Skip this when no command is provided
+  if (!options._.length) {
+    return;
+  }
+
   let validAccount = true;
   if (!isTargetedCommand(options, SKIP_ACCOUNT_VALIDATION)) {
     validAccount = await validateAccount(options);


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
We were attempting to load a config when the user runs `hs --version`, but a user shouldn't need to have a CLI config to check the version of the CLI.

I also added some tests to make sure we automatically catch this next time.

## Screenshots
<!-- Provide images of the before and after functionality -->

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
