### PR TITLE
chore: Better error for secret deletes

### DIFF
--- a/commands/secret/deleteSecret.ts
+++ b/commands/secret/deleteSecret.ts
@@ -68,11 +68,13 @@ exports.handler = async options => {
       })
     );
   } catch (err) {
-    logger.error(
-      i18n(`${i18nKey}.errors.delete`, {
-        secretName,
-      })
-    );
+    if (secretName) {
+      logger.error(
+        i18n(`${i18nKey}.errors.delete`, {
+          secretName,
+        })
+      );
+    }
     logError(
       err,
       new ApiErrorContext({


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
Running `hs secrets delete` with no secret specified should show the user a list of secrets to choose from. If your access key doesn't have permission to fetch the list of secrets, we show an error saying that you need to update your auth.

We also show something like `[ERROR] The secret "test" was not deleted`. This error shows "undefined" for the secret name when no secret is initially entered as a positional arg. This is a pretty big edge case so I think just omitting the error in that case is fine.

## Screenshots
<!-- Provide images of the before and after functionality -->

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
