### PR TITLE
Fix bug in `hubdb create`

### DIFF
--- a/commands/hubdb/create.ts
+++ b/commands/hubdb/create.ts
@@ -54,7 +54,7 @@ exports.handler = async options => {
     const filePath =
       'path' in options
         ? path.resolve(getCwd(), options.path)
-        : await selectPathPrompt(options);
+        : path.resolve(getCwd(), (await selectPathPrompt(options)).path);
     if (!checkAndConvertToJson(filePath)) {
       process.exit(EXIT_CODES.ERROR);
     }

--- a/commands/hubdb/create.ts
+++ b/commands/hubdb/create.ts
@@ -51,7 +51,7 @@ exports.handler = async options => {
 
   let filePath;
   try {
-    const { path: filePath } =
+    const filePath =
       'path' in options
         ? path.resolve(getCwd(), options.path)
         : await selectPathPrompt(options);


### PR DESCRIPTION
## Description and Context
We're incorrectly setting the `filePath` variable in the `hubdb create` command, and it's causing a fatal error. This PR fixes that. 

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

- [ ] Address any feedback 

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@brandenrodgers @joe-yeager @camden11 