### PR TITLE
fix: Fix build id prompt in hs project deploy

### DIFF
--- a/commands/project/deploy.ts
+++ b/commands/project/deploy.ts
@@ -114,7 +114,7 @@ exports.handler = async options => {
           latestBuild.buildId === deployedBuildId
             ? undefined
             : latestBuild.buildId,
-        validate: () =>
+        validate: buildId =>
           validateBuildId(
             buildId,
             deployedBuildId,


### PR DESCRIPTION
## Description and Context
`hs project deploy` now prompts users for a `buildId` when one isn't provided, but the prompt wasn't working due to an invalid validation function

## Who to Notify
@brandenrodgers @kemmerle @joe-yeager 
