### PR TITLE
test: Increase the polling timeout

### DIFF
--- a/acceptance-tests/tests/workflows/secretsFlow.spec.ts
+++ b/acceptance-tests/tests/workflows/secretsFlow.spec.ts
@@ -12,8 +12,8 @@ const SECRET = {
 };
 
 const secretPollingOptions = {
-  interval: 2000,
-  timeout: 20000,
+  interval: 5000,
+  timeout: 60000,
 };
 
 async function waitForSecretsListToContainSecret(testState: TestState) {


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->

Increase the polling timeout to 60 seconds to increase the test stability.  @brandenrodgers and I both observed that sometimes the secrets take up to 30 seconds to exist in the portal, so hopefully this will solve for the majority of the situations where latency is the cause of failure.