### PR TITLE
Improve prompting behavior for `hs custom-object create`

### DIFF
--- a/commands/customObject/create.ts
+++ b/commands/customObject/create.ts
@@ -20,8 +20,13 @@ exports.describe = i18n(`${i18nKey}.describe`);
 exports.handler = async options => {
   const { path, name: providedName, derivedAccountId } = options;
   let definitionPath = path;
+  let name = providedName;
 
   trackCommandUsage('custom-object-batch-create', null, derivedAccountId);
+
+  if (!name) {
+    name = await inputPrompt(i18n(`${i18nKey}.inputName`));
+  }
 
   if (!definitionPath) {
     definitionPath = await inputPrompt(i18n(`${i18nKey}.inputPath`));
@@ -33,9 +38,6 @@ exports.handler = async options => {
   if (!objectJson) {
     process.exit(EXIT_CODES.ERROR);
   }
-
-  const name =
-    providedName || (await inputPrompt(i18n(`${i18nKey}.inputSchema`)));
 
   try {
     await batchCreateObjects(derivedAccountId, name, objectJson);

--- a/lang/en.lyaml
+++ b/lang/en.lyaml
@@ -214,8 +214,8 @@ en:
               describe: "Schema name to add the object instance to"
           success:
             objectsCreated: "Objects created"
-          inputSchema: "What would you like to name the schema?"
-          inputPath: "[--path] Where is the JSON file containing the object definitions?"
+          inputName: "Enter the name of the schema for the custom object(s) you'd like to create:"
+          inputPath: "[--path] Enter the path to the JSON file containing the object definitions:"
         schema:
           describe: "Commands for managing custom object schemas."
           subcommands:

--- a/lang/en.lyaml
+++ b/lang/en.lyaml
@@ -214,7 +214,7 @@ en:
               describe: "Schema name to add the object instance to"
           success:
             objectsCreated: "Objects created"
-          inputName: "Enter the name of the schema for the custom object(s) you'd like to create:"
+          inputName: "[--name] Enter the name of the schema for the custom object(s) you'd like to create:"
           inputPath: "[--path] Enter the path to the JSON file containing the object definitions:"
         schema:
           describe: "Commands for managing custom object schemas."


### PR DESCRIPTION
## Description and Context
We recently updated `hs custom-object create` to prompt users for a custom object's name and JSON definition path when not provided. When testing, I found the way we're currently prompting to be a bit confusing. The command currently asks for the path of the JSON definitions before asking what kind of object you want to create, which seems non intuitive. The prompt for the name of the custom object type is also misleading, asking what you'd like to name your schema when you're not actually creating a schema. I've fixed both of these things.

## Screenshots
Before:
<img width="567" alt="Screenshot 2025-01-07 at 5 05 03 PM" src="https://github.com/user-attachments/assets/f208dc94-5509-4328-b66e-cab09f9419b5" />

After:
<img width="568" alt="Screenshot 2025-01-07 at 5 03 57 PM" src="https://github.com/user-attachments/assets/92211924-de73-44f1-b517-96e8b9f65716" />

## Who to Notify
@brandenrodgers @kemmerle @joe-yeager 
