### PR TITLE
Fix npm release badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # @hubspot/cli
 
-[![Official Release](https://img.shields.io/npm/v/@hubspot/cli/latest?label=Official%20Release)](https://www.npmjs.com/package/@hubspot/cli) [![Latest Version](https://img.shields.io/github/v/tag/hubspot/hubspot-cli?label=Latest%20Version)](https://www.npmjs.com/package/@hubspot/cli?activeTab=versions)
+[![Official Release](https://img.shields.io/npm/v/@hubspot/cli/latest?label=Official%20Release)](https://www.npmjs.com/package/@hubspot/cli) [![Latest Beta Version](https://img.shields.io/npm/v/@hubspot/cli/next?label=Latest%20Version)](https://www.npmjs.com/package/@hubspot/cli?activeTab=versions)
 
 A CLI for HubSpot developers to enable local development and automation. [Learn more about building on HubSpot](https://developers.hubspot.com).
 
@@ -58,13 +58,14 @@ There are two ways that the tools can authenticate with HubSpot.
 3. Select `OAuth2` and follow the steps
 
 _**Note:** The Account ID used should be the Test Account ID (not the developer app ID). Client ID and Client Secret are from the developer app._
+
 ### Exit Codes
 
 The CLI will exit with one of the following exit codes:
+
 - `0`: A successful run
 - `1`: There was a config problem or an internal error
 - `2`: There are warnings or validation issues
-
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # @hubspot/cli
 
-[![Official Release](https://img.shields.io/npm/v/@hubspot/cli/latest?label=Official%20Release)](https://www.npmjs.com/package/@hubspot/cli) [![Latest Beta Version](https://img.shields.io/npm/v/@hubspot/cli/next?label=Latest%20Version)](https://www.npmjs.com/package/@hubspot/cli?activeTab=versions)
+[![Official Release](https://img.shields.io/npm/v/@hubspot/cli/latest?label=Official%20Release)](https://www.npmjs.com/package/@hubspot/cli) [![Latest Beta Version](https://img.shields.io/npm/v/@hubspot/cli/next?label=Latest%20Beta%20Version)](https://www.npmjs.com/package/@hubspot/cli?activeTab=versions)
 
 A CLI for HubSpot developers to enable local development and automation. [Learn more about building on HubSpot](https://developers.hubspot.com).
 


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
Our badge was showing the experimental release as the latest one, but those releases aren't intended to be safe to use for external users. I switched it to show the latest beta release instead.

## Screenshots
<!-- Provide images of the before and after functionality -->
### Before
<img width="923" alt="image" src="https://github.com/user-attachments/assets/ac6d3140-e05b-4b25-b21e-279e8293ca83" />

### After
<img width="523" alt="image" src="https://github.com/user-attachments/assets/64f4f2de-be32-4458-b5a1-2736b03f7d30" />

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
