### PR TITLE
Remove support for portal env variable

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -182,7 +182,7 @@ const handleDeprecatedEnvVariables = options => {
     !process.env.HUBSPOT_ACCOUNT_ID
   ) {
     uiDeprecatedTag(
-      i18n(`${i18nKey}.injectAccountIdMiddleware.portalEnvVarDeprecated`, {
+      i18n(`${i18nKey}.handleDeprecatedEnvVariables.portalEnvVarDeprecated`, {
         configPath: getConfigPath(),
       })
     );

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -8,6 +8,7 @@ const { logger } = require('@hubspot/local-dev-lib/logger');
 const { addUserAgentHeader } = require('@hubspot/local-dev-lib/http');
 const {
   loadConfig,
+  getAccountId,
   configFileExists,
   getConfigPath,
   validateConfig,
@@ -194,7 +195,7 @@ const injectAccountIdMiddleware = async options => {
     process.env.HUBSPOT_ACCOUNT_ID = process.env.HUBSPOT_PORTAL_ID;
     options.derivedAccountId = parseInt(process.env.HUBSPOT_ACCOUNT_ID, 10);
   } else {
-    options.derivedAccountId = getAccountIdFromConfig(account);
+    options.derivedAccountId = getAccountId(account);
   }
 };
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -284,8 +284,8 @@ const argv = yargs
   .middleware([
     setLogLevel,
     setRequestHeaders,
-    injectAccountIdMiddleware,
     loadConfigMiddleware,
+    injectAccountIdMiddleware,
     checkAndWarnGitInclusionMiddleware,
     validateAccountOptions,
   ])

--- a/lang/en.lyaml
+++ b/lang/en.lyaml
@@ -7,7 +7,7 @@ en:
         cliUpdateNotification: "HubSpot CLI version {{#cyan}}{{#bold}}{currentVersion}{{/bold}}{{/cyan}} is outdated.\nRun {{ updateCommand }} to upgrade to version {{#cyan}}{{#bold}}{latestVersion}{{/bold}}{{/cyan}}"
       srcIsProject: "\"{{ src }}\" is in a project folder. Did you mean \"hs project {{command}}\"?"
       setDefaultAccountMoved: "This command has moved. Try `hs accounts use` instead"
-      injectAccountIdMiddleware:
+      handleDeprecatedEnvVariables:
         portalEnvVarDeprecated: "The HUBSPOT_PORTAL_ID environment variable is deprecated. Please use HUBSPOT_ACCOUNT_ID instead."
       loadConfigMiddleware:
         configFileExists: "A configuration file already exists at {{ configPath }}. To specify a new configuration file, delete the existing one and try again."

--- a/lang/en.lyaml
+++ b/lang/en.lyaml
@@ -8,7 +8,7 @@ en:
       srcIsProject: "\"{{ src }}\" is in a project folder. Did you mean \"hs project {{command}}\"?"
       setDefaultAccountMoved: "This command has moved. Try `hs accounts use` instead"
       injectAccountIdMiddleware:
-        portalEnvVarDeprecated: "The HUBSPOT_PORTAL_ID environment variable is deprecatted. Please use HUBSPOT_ACCOUNT_ID instead."
+        portalEnvVarDeprecated: "The HUBSPOT_PORTAL_ID environment variable is deprecated. Please use HUBSPOT_ACCOUNT_ID instead."
       loadConfigMiddleware:
         configFileExists: "A configuration file already exists at {{ configPath }}. To specify a new configuration file, delete the existing one and try again."
     completion:

--- a/lang/en.lyaml
+++ b/lang/en.lyaml
@@ -7,6 +7,8 @@ en:
         cliUpdateNotification: "HubSpot CLI version {{#cyan}}{{#bold}}{currentVersion}{{/bold}}{{/cyan}} is outdated.\nRun {{ updateCommand }} to upgrade to version {{#cyan}}{{#bold}}{latestVersion}{{/bold}}{{/cyan}}"
       srcIsProject: "\"{{ src }}\" is in a project folder. Did you mean \"hs project {{command}}\"?"
       setDefaultAccountMoved: "This command has moved. Try `hs accounts use` instead"
+      injectAccountIdMiddleware:
+        portalEnvVarDeprecated: "The HUBSPOT_PORTAL_ID environment variable is deprecatted. Please use HUBSPOT_ACCOUNT_ID instead."
       loadConfigMiddleware:
         configFileExists: "A configuration file already exists at {{ configPath }}. To specify a new configuration file, delete the existing one and try again."
     completion:

--- a/lib/commonOpts.ts
+++ b/lib/commonOpts.ts
@@ -117,28 +117,6 @@ export function getAccountId(
   return getAccountIdFromConfig(account);
 }
 
-/**
- * Auto-injects the derivedAccountId flag into all commands
- */
-export async function injectAccountIdMiddleware(
-  options: Arguments<{
-    derivedAccountId?: number | null;
-    account?: number | string;
-  }>
-): Promise<void> {
-  const { account } = options;
-
-  // Preserves the original --account flag for certain commands.
-  options.providedAccountId = account;
-
-  if (options.useEnv && process.env.HUBSPOT_ACCOUNT_ID) {
-    options.derivedAccountId = parseInt(process.env.HUBSPOT_ACCOUNT_ID, 10);
-    return;
-  }
-
-  options.derivedAccountId = getAccountIdFromConfig(account);
-}
-
 export function getCmsPublishMode(
   options: Arguments<{ cmsPublishMode?: CmsPublishMode }>
 ): CmsPublishMode {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": "https://github.com/HubSpot/hubspot-cli",
   "dependencies": {
-    "@hubspot/local-dev-lib": "3.1.1-beta.0",
+    "@hubspot/local-dev-lib": "3.1.1",
     "@hubspot/serverless-dev-runtime": "7.0.1",
     "@hubspot/theme-preview-dev-server": "0.0.10",
     "@hubspot/ui-extensions-dev-server": "0.8.40",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": "https://github.com/HubSpot/hubspot-cli",
   "dependencies": {
-    "@hubspot/local-dev-lib": "3.1.0",
+    "@hubspot/local-dev-lib": "3.1.1-beta.0",
     "@hubspot/serverless-dev-runtime": "7.0.1",
     "@hubspot/theme-preview-dev-server": "0.0.10",
     "@hubspot/ui-extensions-dev-server": "0.8.40",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10709,7 +10709,16 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -10791,7 +10800,7 @@ stringify-object@^3.2.1, stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -10804,6 +10813,13 @@ strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.1.0"
@@ -11829,8 +11845,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
-  name wrap-ansi-cjs
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -11843,6 +11858,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1446,10 +1446,10 @@
     semver "^6.3.0"
     unixify "^1.0.0"
 
-"@hubspot/local-dev-lib@3.1.1-beta.0":
-  version "3.1.1-beta.0"
-  resolved "https://registry.yarnpkg.com/@hubspot/local-dev-lib/-/local-dev-lib-3.1.1-beta.0.tgz#2b827476deb4feec4b369743a5d7d056a56fc3f5"
-  integrity sha512-QoQZ17nc8rXOAK346KjQvMzL1O/+itoJaiE0raVhIXy7xkujrpV6kG+l6gCmnh5KKtzSrHH+uG6vj08robWC0A==
+"@hubspot/local-dev-lib@3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@hubspot/local-dev-lib/-/local-dev-lib-3.1.1.tgz#b67646d7a7b399cebc5d74f62c389c13554e950c"
+  integrity sha512-/SIKBuC3ORkKMXityS6tCz2sNU7OY96slJtLM0CxRlKDCiwEGb08Lf0Ruf1PMBJnAu8iHbw/6SprefFEHEQOpw==
   dependencies:
     address "^2.0.1"
     axios "^1.3.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1446,10 +1446,10 @@
     semver "^6.3.0"
     unixify "^1.0.0"
 
-"@hubspot/local-dev-lib@3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@hubspot/local-dev-lib/-/local-dev-lib-3.1.0.tgz#76b5d524aa694aad2bfc6e199ee1dac314f15774"
-  integrity sha512-iop3PgZ0ZWejCH6PmSeYnnGwV8vGIuA4F+w7SxukdX3QfhivlczClATWPaZanv1CYJHdflqoItq1kdF8ASJJmA==
+"@hubspot/local-dev-lib@3.1.1-beta.0":
+  version "3.1.1-beta.0"
+  resolved "https://registry.yarnpkg.com/@hubspot/local-dev-lib/-/local-dev-lib-3.1.1-beta.0.tgz#2b827476deb4feec4b369743a5d7d056a56fc3f5"
+  integrity sha512-QoQZ17nc8rXOAK346KjQvMzL1O/+itoJaiE0raVhIXy7xkujrpV6kG+l6gCmnh5KKtzSrHH+uG6vj08robWC0A==
   dependencies:
     address "^2.0.1"
     axios "^1.3.5"


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
Issue: https://github.com/HubSpot/hubspot-cli/issues/1327

In CLI release 7.0.0 we've moved away from referring to hubspot accounts as "portals" in favor of "account". This is a move that we've been slowly moving towards for a while now.

There was an issue with `HUBSPOT_ACCOUNT_ID` not working correctly that's fixed by https://github.com/HubSpot/hubspot-local-dev-lib/pull/225

This also adds a message for folks who are still using `HUBSPOT_PORTAL_ID`

## Screenshots
<!-- Provide images of the before and after functionality -->

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
