### PR TITLE
chore: Add a debugging command

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "circular-deps": "yarn madge --circular .",
     "release": "yarn ts-node ./scripts/release.ts release",
     "hs": "yarn build && node ./dist/bin/hs",
+    "hs-debug": "yarn build && NODE_DEBUG=http* node --inspect-brk ./dist/bin/hs",
     "update-ldl": "yarn add --exact @hubspot/local-dev-lib@latest"
   },
   "lint-staged": {


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
Adds a debugging command to be used for local development of the CLI.  The command sets the http* libraries to debugging mode and starts the CLI in debugging mode.

