### PR TITLE
Update hs upload --clean flag description

### DIFF
--- a/lang/en.lyaml
+++ b/lang/en.lyaml
@@ -972,7 +972,7 @@ en:
         convertFields:
           describe: "If true, converts any javascript fields files contained in module folder or project root."
         clean:
-          describe: "Will cause upload to delete files in your HubSpot account that are not found locally."
+          describe: "Will delete the destination directory and its contents before uploading. This will also clear the global content associated with any global partial templates and modules."
         force:
           describe: "Skips confirmation prompts when doing a clean upload."
       previewUrl: "To preview this theme, visit: {{ previewUrl }}"


### PR DESCRIPTION
## Description and Context
This description doesn't exactly accurately reflect what happens, where all assets are deleted before re-uploading. This updates the description to be more clear and hopefully prevent any mishaps with deleting global content


https://github.com/HubSpot/hubspot-cli/issues/930

## Screenshots
N/A

## TODO
N/A

## Who to Notify
N/A
