### PR TITLE
feat: Update generic error message when repo doe not contain config.json file

### DIFF
--- a/lang/en.lyaml
+++ b/lang/en.lyaml
@@ -1311,6 +1311,7 @@ en:
           invalidCharacters: "The selected destination contains invalid characters. Please provide a new path and try again."
           invalidTemplate: "[--template] Could not find template {{ template }}. Please choose an available template."
           noProjectsInConfig: "Please ensure that there is a config.json file that contains a \"projects\" field."
+          missingConfigFileTemplateSource: "Please ensure that there is a config.json file in the repository used as the --template-source"
           missingPropertiesInConfig: "Please ensure that each of the projects in your config.json file contain the following properties: [\"name\", \"label\", \"path\", \"insertPath\"]."
       selectPublicAppPrompt:
         selectAppIdMigrate: "[--appId] Choose an app under {{ accountName }} to migrate:"

--- a/lib/prompts/createProjectPrompt.ts
+++ b/lib/prompts/createProjectPrompt.ts
@@ -50,11 +50,17 @@ async function createTemplateOptions(
     ? DEFAULT_PROJECT_TEMPLATE_BRANCH
     : githubRef;
 
-  const config = await fetchFileFromRepository<ProjectTemplateRepoConfig>(
-    templateSource || HUBSPOT_PROJECT_COMPONENTS_GITHUB_PATH,
-    'config.json',
-    branch
-  );
+  let config: ProjectTemplateRepoConfig;
+  try {
+    config = await fetchFileFromRepository<ProjectTemplateRepoConfig>(
+      templateSource || HUBSPOT_PROJECT_COMPONENTS_GITHUB_PATH,
+      'config.json',
+      branch
+    );
+  } catch (e) {
+    logger.error(i18n(`${i18nKey}.errors.missingConfigFileTemplateSource`));
+    process.exit(EXIT_CODES.ERROR);
+  }
 
   if (!config || !config[PROJECT_COMPONENT_TYPES.PROJECTS]) {
     logger.error(i18n(`${i18nKey}.errors.noProjectsInConfig`));


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
I noticed there was a generic error message that was being logged when the `--template-source` does not have ` config.json` file in the project root. Updating that message to give a more actionable error message instead of `[ERROR] An error occurred fetching JSON file.`

## Screenshots
### Before
<!-- Provide images of the before and after functionality -->
![Screenshot 2025-01-21 at 1 43 49 PM](https://github.com/user-attachments/assets/ee192f7c-395a-47a7-865f-b2c81cfda06a)

### After
![Screenshot 2025-01-21 at 1 43 30 PM](https://github.com/user-attachments/assets/75e56a6e-3e22-4ccb-b4ce-bc8c4c7b6640)
