### PR TITLE
POC: Remove i18n files

### DIFF
--- a/commands/doctor.ts
+++ b/commands/doctor.ts
@@ -10,16 +10,15 @@ import path from 'path';
 import { ArgumentsCamelCase, BuilderCallback, Options } from 'yargs';
 import { getCwd } from '@hubspot/local-dev-lib/path';
 import { addGlobalOptions } from '../lib/commonOpts';
-const { i18n } = require('../lib/lang');
+
+import { doctor as doctorLang } from '../lang/constants';
 
 export interface DoctorOptions {
   'output-dir'?: string;
 }
 
-const i18nKey = 'commands.doctor';
-
 export const command = 'doctor';
-export const describe = i18n(`${i18nKey}.describe`);
+export const describe = doctorLang.command.describe;
 
 export const handler = async ({
   outputDir,
@@ -43,7 +42,7 @@ export const handler = async ({
     if (output?.diagnosis) {
       logger.log(output.diagnosis);
     } else {
-      logger.error(i18n(`${i18nKey}.errors.generatingDiagnosis`));
+      logger.error(doctorLang.command.errors);
       return process.exit(EXIT_CODES.ERROR);
     }
     return process.exit(EXIT_CODES.SUCCESS);
@@ -60,13 +59,13 @@ export const handler = async ({
 
   try {
     fs.writeFileSync(outputFile, JSON.stringify(output, null, 4));
-    logger.success(i18n(`${i18nKey}.outputWritten`, { filename: outputFile }));
+    logger.success(doctorLang.command.outputWritten(outputFile));
   } catch (e) {
     logger.error(
-      i18n(`${i18nKey}.errors.unableToWriteOutputFile`, {
-        file: outputFile,
-        errorMessage: e instanceof Error ? e.message : e,
-      })
+      doctorLang.command.errors.unableToWriteOutputFile(
+        outputFile,
+        e instanceof Error ? e.message : e
+      )
     );
     return process.exit(EXIT_CODES.ERROR);
   }
@@ -76,7 +75,7 @@ export const handler = async ({
 
 export const builder: BuilderCallback<DoctorOptions, DoctorOptions> = yargs => {
   yargs.option<keyof DoctorOptions, Options>('output-dir', {
-    describe: i18n(`${i18nKey}.options.outputDir`),
+    describe: doctorLang.command.options.outputDir,
     type: 'string',
   });
   addGlobalOptions(yargs);

--- a/commands/doctor.ts
+++ b/commands/doctor.ts
@@ -42,7 +42,7 @@ export const handler = async ({
     if (output?.diagnosis) {
       logger.log(output.diagnosis);
     } else {
-      logger.error(doctorLang.command.errors);
+      logger.error(doctorLang.command.errors.generatingDiagnosis);
       return process.exit(EXIT_CODES.ERROR);
     }
     return process.exit(EXIT_CODES.SUCCESS);

--- a/lang/constants.ts
+++ b/lang/constants.ts
@@ -17,7 +17,7 @@ export const doctor = {
   diagnosticsComplete: `Diagnostics complete`,
   accountChecks: {
     active: `Default account active`,
-    inactive: 'Default account isn`t active',
+    inactive: `Default account isn't active`,
     inactiveSecondary: (command: string) =>
       `Run ${command} to remove inactive accounts from your CLI config`,
     unableToDetermine: `Unable to determine if the portal is active`,

--- a/lang/constants.ts
+++ b/lang/constants.ts
@@ -1,0 +1,104 @@
+import { bold } from 'chalk';
+export const doctor = {
+  command: {
+    describe:
+      'Retrieve diagnostic information about your local HubSpot configurations.',
+    options: {
+      outputDir: 'Directory to save a detailed diagnosis JSON file in',
+    },
+    errors: {
+      generatingDiagnosis: 'Error generating diagnosis',
+      unableToWriteOutputFile: (file: string, errorMessage: unknown) =>
+        `Unable to write output to ${bold(file)}, ${errorMessage}`,
+    },
+    outputWritten: (file: string) => `Output written to ${bold(file)}`,
+  },
+  runningDiagnostics: `Running diagnostics...`,
+  diagnosticsComplete: `Diagnostics complete`,
+  accountChecks: {
+    active: `Default account active`,
+    inactive: 'Default account isn`t active',
+    inactiveSecondary: (command: string) =>
+      `Run ${command} to remove inactive accounts from your CLI config`,
+    unableToDetermine: `Unable to determine if the portal is active`,
+  },
+  pak: {
+    invalid: `Personal access key is invalid`,
+    invalidSecondary: (command: string) =>
+      `To get a new key, run ${command}, deactivate your access key, and generate a new one. Then use that new key to authenticate your account.`,
+    valid: (link: string) => `Personal Access Key is valid. ${link}`,
+    viewScopes: `View selected scopes`,
+  },
+  nodeChecks: {
+    unableToDetermine: `Unable to determine what version of node is installed`,
+    minimumNotMet: (nodeVersion: string) =>
+      `Minimum Node version is not met. Upgrade to ${nodeVersion} or higher`,
+    success: (nodeVersion: string) => `node v${nodeVersion} is installed`,
+  },
+  npmChecks: {
+    notInstalled: `npm is not installed`,
+    installed: (npmVersion: string) => `npm v${npmVersion} is installed`,
+    unableToDetermine: `Unable to determine if npm is installed`,
+  },
+  hsChecks: {
+    notLatest: (hsVersion: string) => `Version ${hsVersion} outdated`,
+    notLatestSecondary: (command: string, hsVersion: string) =>
+      `Run ${command} to upgrade to the latest version ${hsVersion}`,
+    latest: (hsVersion: string) => `HubSpot CLI v${hsVersion} up to date`,
+    unableToDetermine: `Unable to determine if HubSpot CLI is up to date.`,
+    unableToDetermineSecondary: (command: string, link: string) =>
+      `Run ${command} to check your installed version, then visit the ${link} to validate whether you have the latest version`,
+    unableToDetermineSecondaryLink: `npm HubSpot CLI version history`,
+  },
+  projectDependencyChecks: {
+    missingDependencies: (dir: string) =>
+      `missing dependencies in ${bold(dir)}`,
+    missingDependenciesSecondary: (command: string) =>
+      `Run ${command} to install all project dependencies locally`,
+
+    unableToDetermine: (dir: string) =>
+      `Unable to determine if dependencies are installed ${dir}`,
+
+    success: `App dependencies are installed and up to date`,
+  },
+  files: {
+    validJson: `JSON files valid`,
+    invalidJson: (filename: string) => `invalid JSON in ${bold(filename)}`,
+  },
+  port: {
+    inUse: (port: string | number) => `Port ${port} is in use`,
+    inUseSecondary: (command: string) =>
+      `Make sure it is available if before running ${command}`,
+    available: (port: string | number) =>
+      `Port ${port} available for local development`,
+  },
+  diagnosis: {
+    cli: {
+      header: `HubSpot CLI install`,
+    },
+    cliConfig: {
+      header: `CLI configuration`,
+      configFileSubHeader: (filename: string) =>
+        `Config File: ${bold(filename)}`,
+      defaultAccountSubHeader: (accountDetails: string) =>
+        `Default Account: ${accountDetails}`,
+      noConfigFile: `CLI configuration not found`,
+      noConfigFileSecondary: (command: string) =>
+        `Run ${command} and follow the prompts to create your CLI configuration file and connect it to your HubSpot account`,
+    },
+    projectConfig: {
+      header: `Project configuration`,
+      projectDirSubHeader: (projectDir: unknown) =>
+        `Project dir: ${bold(projectDir)}`,
+      projectNameSubHeader: (projectName: unknown) =>
+        `Project name: ${projectName}`,
+    },
+    counts: {
+      errors: (count: number) => `${bold('Errors:')} ${count}`,
+      warnings: (count: number) => `${bold('Warnings:')} ${count}`,
+    },
+    oauth: {
+      missingClientId: `Error building oauth URL: missing client ID.`,
+    },
+  },
+};

--- a/lang/en.lyaml
+++ b/lang/en.lyaml
@@ -296,14 +296,6 @@ en:
                 update: "Your schema has been updated in account \"{{ accountId }}\""
                 viewAtUrl: "Schema can be viewed at {{ url }}"
               selectSchema: "Which schema would you like to update?"
-    doctor:
-      describe: "Retrieve diagnostic information about your local HubSpot configurations."
-      options:
-        outputDir: "Directory to save a detailed diagnosis JSON file in"
-      errors:
-        generatingDiagnosis: "Error generating diagnosis"
-        unableToWriteOutputFile: "Unable to write output to {{#bold}}{{ file }}{{/bold}}, {{ errorMessage }}"
-      outputWritten: "Output written to {{#bold}}{{ filename }}{{/bold}}"
     fetch:
       describe: "Fetch a file, directory or module from HubSpot and write to a path on your computer."
       errors:
@@ -1508,62 +1500,6 @@ en:
         portalMissingScope: "Your account does not have access to this action. Talk to an account admin to request it."
         userMissingScope: "You don't have access to this action. Ask an account admin to change your permissions in Users & Teams settings."
         genericMissingScope: "Your access key does not allow this action. Please generate a new access key by running `hs auth personalaccesskey`."
-    doctor:
-      runningDiagnostics: "Running diagnostics..."
-      diagnosticsComplete: "Diagnostics complete"
-      accountChecks:
-        active: "Default account active"
-        inactive: "Default account isn't active"
-        inactiveSecondary: "Run {{ command }} to remove inactive accounts from your CLI config"
-        unableToDetermine: "Unable to determine if the portal is active"
-        pak:
-          invalid: "Personal access key is invalid"
-          invalidSecondary: "To get a new key, run {{ command }}, deactivate your access key, and generate a new one. Then use that new key to authenticate your account."
-          valid: "Personal Access Key is valid. {{ link }}"
-          viewScopes: "View selected scopes"
-      nodeChecks:
-        unableToDetermine: "Unable to determine what version of node is installed"
-        minimumNotMet: "Minimum Node version is not met. Upgrade to {{ nodeVersion }} or higher"
-        success: "node v{{ nodeVersion }} is installed"
-      npmChecks:
-        notInstalled: "npm is not installed"
-        installed: "npm v{{ npmVersion }} is installed"
-        unableToDetermine: "Unable to determine if npm is installed"
-      hsChecks:
-        notLatest: "Version {{ hsVersion }} outdated"
-        notLatestSecondary: "Run {{ command }} to upgrade to the latest version {{ hsVersion }}"
-        latest: "HubSpot CLI v{{ hsVersion }} up to date"
-        unableToDetermine: "Unable to determine if HubSpot CLI is up to date."
-        unableToDetermineSecondary: "Run {{ command }} to check your installed version; then visit the {{ link }} to validate whether you have the latest version"
-        unableToDetermineSecondaryLink: "npm HubSpot CLI version history"
-      projectDependenciesChecks:
-        missingDependencies: "missing dependencies in {{#bold}}{{ dir }}{{/bold}}"
-        missingDependenciesSecondary: "Run {{ command }} to install all project dependencies locally"
-        unableToDetermine: "Unable to determine if dependencies are installed {{ dir }}"
-        success: "App dependencies are installed and up to date"
-      files:
-        invalidJson: "invalid JSON in {{#bold}}{{ filename }}{{/bold}}"
-        validJson: "JSON files valid"
-      port:
-        inUse: "Port {{ port }} is in use"
-        inUseSecondary: "Make sure it is available if before running {{ command }}"
-        available: "Port {{ port }} available for local development"
-      diagnosis:
-        cli:
-          header: "HubSpot CLI install"
-        cliConfig:
-          header: "CLI configuration"
-          configFileSubHeader: "Config File: {{#bold}}{{ filename }}{{/bold}}"
-          defaultAccountSubHeader: "Default Account: {{accountDetails}}"
-          noConfigFile: "CLI configuration not found"
-          noConfigFileSecondary: "Run {{command}} and follow the prompts to create your CLI configuration file and connect it to your HubSpot account"
-        projectConfig:
-          header: "Project configuration"
-          projectDirSubHeader: "Project dir: {{#bold}}{{ projectDir }}{{/bold}}"
-          projectNameSubHeader: "Project name: {{#bold}}{{ projectName }}{{/bold}}"
-        counts:
-          errors: '{{#bold}}Errors:{{/bold}} {{ count }}'
-          warnings: "{{#bold}}Warning:{{/bold}} {{ count }}"
     oauth:
       missingClientId: "Error building oauth URL: missing client ID."
 

--- a/lib/doctor/Diagnosis.ts
+++ b/lib/doctor/Diagnosis.ts
@@ -3,7 +3,7 @@ import { bold, green, red } from 'chalk';
 import { helpers } from '../interpolation';
 import { DiagnosticInfo } from './DiagnosticInfoBuilder';
 import { uiAccountDescription } from '../ui';
-const { i18n } = require('../lang');
+import { doctor } from '../../lang/constants';
 
 interface DiagnosisOptions {
   diagnosticInfo: DiagnosticInfo;
@@ -32,8 +32,6 @@ interface DiagnosisCategories {
   cliConfig: DiagnosisCategory;
 }
 
-const i18nKey = `lib.doctor.diagnosis`;
-
 export class Diagnosis {
   private readonly prefixes: prefixes;
   private readonly diagnosis: DiagnosisCategories;
@@ -52,22 +50,22 @@ export class Diagnosis {
 
     this.diagnosis = {
       cli: {
-        header: i18n(`${i18nKey}.cli.header`),
+        header: doctor.diagnosis.cli.header,
         sections: [],
       },
       cliConfig: {
-        header: i18n(`${i18nKey}.cliConfig.header`),
+        header: doctor.diagnosis.cliConfig.header,
         sections: [],
       },
       project: {
-        header: i18n(`${i18nKey}.projectConfig.header`),
+        header: doctor.diagnosis.projectConfig.header,
         subheaders: [
-          i18n(`${i18nKey}.projectConfig.projectDirSubHeader`, {
-            projectDir: diagnosticInfo.project?.config?.projectDir,
-          }),
-          i18n(`${i18nKey}.projectConfig.projectNameSubHeader`, {
-            projectName: diagnosticInfo.project?.config?.projectConfig?.name,
-          }),
+          doctor.diagnosis.projectConfig.projectDirSubHeader(
+            diagnosticInfo.project?.config?.projectDir
+          ),
+          doctor.diagnosis.projectConfig.projectNameSubHeader(
+            diagnosticInfo.project?.config?.projectConfig?.name
+          ),
         ],
         sections: [],
       },
@@ -75,12 +73,10 @@ export class Diagnosis {
 
     if (diagnosticInfo.config) {
       this.diagnosis.cliConfig.subheaders = [
-        i18n(`${i18nKey}.cliConfig.configFileSubHeader`, {
-          filename: diagnosticInfo.config,
-        }),
-        i18n(`${i18nKey}.cliConfig.defaultAccountSubHeader`, {
-          accountDetails: uiAccountDescription(accountId!),
-        }),
+        doctor.diagnosis.cliConfig.configFileSubHeader(diagnosticInfo.config),
+        doctor.diagnosis.cliConfig.defaultAccountSubHeader(
+          uiAccountDescription(accountId!)
+        ),
       ];
     }
   }
@@ -123,16 +119,8 @@ export class Diagnosis {
     }
 
     output.push('');
-    output.push(
-      i18n(`${i18nKey}.counts.errors`, {
-        count: this.errorCount,
-      })
-    );
-    output.push(
-      i18n(`${i18nKey}.counts.warnings`, {
-        count: this.warningCount,
-      })
-    );
+    output.push(doctor.diagnosis.counts.errors(this.errorCount));
+    output.push(doctor.diagnosis.counts.warnings(this.warningCount));
     output.push('');
 
     return output.join('\n');

--- a/lib/doctor/Doctor.ts
+++ b/lib/doctor/Doctor.ts
@@ -22,12 +22,10 @@ import { isSpecifiedError } from '@hubspot/local-dev-lib/errors/index';
 import { getHubSpotWebsiteOrigin } from '@hubspot/local-dev-lib/urls';
 import { uiCommandReference } from '../ui';
 import pkg from '../../package.json';
+import { doctor } from '../../lang/constants';
 
-const { i18n } = require('../lang');
 const { uiLink } = require('../ui');
 const minMajorNodeVersion = 18;
-
-const i18nKey = `lib.doctor`;
 
 export class Doctor {
   accountId: number | null;
@@ -48,7 +46,7 @@ export class Doctor {
 
   async diagnose(): Promise<DiagnosticInfo> {
     SpinniesManager.add('runningDiagnostics', {
-      text: i18n(`${i18nKey}.runningDiagnostics`),
+      text: doctor.runningDiagnostics,
     });
 
     this.diagnosticInfo =
@@ -68,7 +66,7 @@ export class Doctor {
     ]);
 
     SpinniesManager.succeed('runningDiagnostics', {
-      text: i18n(`${i18nKey}.diagnosticsComplete`),
+      text: doctor.diagnosticsComplete,
       succeedColor: 'white',
     });
 
@@ -99,12 +97,9 @@ export class Doctor {
     if (!this.diagnosticInfo?.config) {
       this.diagnosis?.addCLIConfigSection({
         type: 'error',
-        message: i18n(`${i18nKey}.diagnosis.cliConfig.noConfigFile`),
-        secondaryMessaging: i18n(
-          `${i18nKey}.diagnosis.cliConfig.noConfigFileSecondary`,
-          {
-            command: uiCommandReference('hs init'),
-          }
+        message: doctor.diagnosis.cliConfig.noConfigFile,
+        secondaryMessaging: doctor.diagnosis.cliConfig.noConfigFileSecondary(
+          uiCommandReference('hs init')
         ),
       });
       return [];
@@ -113,23 +108,22 @@ export class Doctor {
   }
 
   private async checkIfAccessTokenValid(): Promise<void> {
-    const localI18nKey = `${i18nKey}.accountChecks`;
     try {
       await accessTokenForPersonalAccessKey(this.accountId!, true);
       this.diagnosis?.addCLIConfigSection({
         type: 'success',
-        message: i18n(`${localI18nKey}.active`),
+        message: doctor.accountChecks.active,
       });
       this.diagnosis?.addCLIConfigSection({
         type: 'success',
-        message: i18n(`${localI18nKey}.pak.valid`, {
-          link: uiLink(
-            i18n(`${localI18nKey}.pak.viewScopes`),
+        message: doctor.pak.valid(
+          uiLink(
+            doctor.pak.viewScopes,
             `${getHubSpotWebsiteOrigin(
               this.diagnosticInfoBuilder?.env || 'PROD'
             )}/personal-access-key/${this.diagnosticInfo?.account.accountId}`
-          ),
-        }),
+          )
+        ),
       });
     } catch (error) {
       const portalNotActive =
@@ -146,10 +140,10 @@ export class Doctor {
       if (portalNotActive) {
         this.diagnosis?.addCLIConfigSection({
           type: 'error',
-          message: i18n(`${localI18nKey}.inactive`),
-          secondaryMessaging: i18n(`${localI18nKey}.inactiveSecondary`, {
-            command: uiCommandReference(`hs accounts clean`),
-          }),
+          message: doctor.accountChecks.inactive,
+          secondaryMessaging: doctor.accountChecks.inactiveSecondary(
+            uiCommandReference(`hs accounts clean`)
+          ),
         });
       } else if (
         isSpecifiedError(error, {
@@ -161,30 +155,29 @@ export class Doctor {
       ) {
         this.diagnosis?.addCLIConfigSection({
           type: 'success',
-          message: i18n(`${localI18nKey}.active`),
+          message: doctor.accountChecks.active,
         });
         this.diagnosis?.addCLIConfigSection({
           type: 'error',
-          message: i18n(`${localI18nKey}.pak.invalid`),
-          secondaryMessaging: i18n(`${localI18nKey}.pak.invalidSecondary`, {
-            command: uiCommandReference(`hs auth`),
-          }),
+          message: doctor.pak.invalid,
+          secondaryMessaging: doctor.pak.invalidSecondary(
+            uiCommandReference(`hs auth`)
+          ),
         });
       } else {
         this.diagnosis?.addCLIConfigSection({
           type: 'error',
-          message: i18n(`${localI18nKey}.unableToDetermine`),
+          message: doctor.accountChecks.unableToDetermine,
         });
       }
     }
   }
 
   private async checkIfNodeIsInstalled(): Promise<void> {
-    const localI18nKey = `${i18nKey}.nodeChecks`;
     if (!this.diagnosticInfo?.versions.node) {
       return this.diagnosis?.addCliSection({
         type: 'error',
-        message: i18n(`${localI18nKey}.unableToDetermine`),
+        message: doctor.nodeChecks.unableToDetermine,
       });
     }
 
@@ -194,34 +187,29 @@ export class Doctor {
     if (!currentNodeMajor || parseInt(currentNodeMajor) < minMajorNodeVersion) {
       return this.diagnosis?.addCliSection({
         type: 'warning',
-        message: i18n(`${localI18nKey}.minimumNotMet`, {
-          nodeVersion: this.diagnosticInfo?.versions.node,
-        }),
+        message: doctor.nodeChecks.minimumNotMet(
+          this.diagnosticInfo?.versions.node
+        ),
       });
     }
     this.diagnosis?.addCliSection({
       type: 'success',
-      message: i18n(`${localI18nKey}.success`, {
-        nodeVersion: this.diagnosticInfo?.versions.node,
-      }),
+      message: doctor.nodeChecks.success(this.diagnosticInfo?.versions.node),
     });
   }
 
   private async checkIfNpmIsInstalled(): Promise<void> {
-    const localI18nKey = `${i18nKey}.npmChecks`;
     const npmVersion = this.diagnosticInfo?.versions?.npm;
     if (!npmVersion) {
       return this.diagnosis?.addCliSection({
         type: 'error',
-        message: i18n(`${localI18nKey}.notInstalled`),
+        message: doctor.npmChecks.notInstalled,
       });
     }
 
     this.diagnosis?.addCliSection({
       type: 'success',
-      message: i18n(`${localI18nKey}.installed`, {
-        npmVersion,
-      }),
+      message: doctor.npmChecks.installed(npmVersion),
     });
   }
 
@@ -236,16 +224,13 @@ export class Doctor {
     } catch (e) {
       return this.diagnosis?.addCliSection({
         type: 'error',
-        message: i18n(`${i18nKey}.hsChecks.unableToDetermine`),
-        secondaryMessaging: i18n(
-          `${i18nKey}.hsChecks.unableToDetermineSecondary`,
-          {
-            command: uiCommandReference(`hs --version`),
-            link: uiLink(
-              i18n(`${i18nKey}.hsChecks.unableToDetermineSecondaryLink`),
-              `https://www.npmjs.com/package/${pkg.name}?activeTab=versions`
-            ),
-          }
+        message: doctor.hsChecks.unableToDetermine,
+        secondaryMessaging: doctor.hsChecks.unableToDetermineSecondary(
+          uiCommandReference(`hs --version`),
+          uiLink(
+            doctor.hsChecks.unableToDetermineSecondaryLink,
+            `https://www.npmjs.com/package/${pkg.name}?activeTab=versions`
+          )
         ),
       });
     }
@@ -254,27 +239,22 @@ export class Doctor {
       const onNextTag = pkg.version.includes('beta');
       this.diagnosis?.addCliSection({
         type: 'warning',
-        message: i18n(`${i18nKey}.hsChecks.notLatest`, {
-          hsVersion: pkg.version,
-        }),
-        secondaryMessaging: i18n(`${i18nKey}.hsChecks.notLatestSecondary`, {
-          hsVersion: onNextTag ? nextCliVersion : latestCLIVersion,
-          command: uiCommandReference(`npm install -g ${pkg.name}`),
-        }),
+        message: doctor.hsChecks.notLatest(latestCLIVersion),
+        secondaryMessaging: doctor.hsChecks.notLatestSecondary(
+          uiCommandReference(`npm install -g ${pkg.name}`),
+          onNextTag ? nextCliVersion : latestCLIVersion
+        ),
       });
     } else {
       this.diagnosis?.addCliSection({
         type: 'success',
-        message: i18n(`${i18nKey}.hsChecks.latest`, {
-          hsVersion: latestCLIVersion,
-        }),
+        message: doctor.hsChecks.latest(latestCLIVersion),
       });
     }
   }
 
   private async checkIfNpmInstallRequired(): Promise<void> {
     let foundError = false;
-    const localI18nKey = `${i18nKey}.projectDependenciesChecks`;
 
     for (const packageFile of this.diagnosticInfo?.packageFiles || []) {
       const packageDirName = path.dirname(packageFile);
@@ -288,15 +268,14 @@ export class Doctor {
 
           this.diagnosis?.addProjectSection({
             type: 'warning',
-            message: i18n(`${localI18nKey}.missingDependencies`, {
-              dir: packageDirName,
-            }),
-            secondaryMessaging: i18n(
-              `${localI18nKey}.missingDependenciesSecondary`,
-              {
-                command: uiCommandReference('hs project install-deps'),
-              }
-            ),
+            message:
+              doctor.projectDependencyChecks.missingDependencies(
+                packageDirName
+              ),
+            secondaryMessaging:
+              doctor.projectDependencyChecks.missingDependenciesSecondary(
+                uiCommandReference('hs project install-deps')
+              ),
           });
         }
       } catch (e) {
@@ -305,16 +284,13 @@ export class Doctor {
         if (!(await this.isValidJsonFile(packageFile))) {
           this.diagnosis?.addProjectSection({
             type: 'error',
-            message: i18n(`${i18nKey}.files.invalidJson`, {
-              filename: packageFile,
-            }),
+            message: doctor.files.invalidJson(packageFile),
           });
         } else {
           this.diagnosis?.addProjectSection({
             type: 'error',
-            message: i18n(`${localI18nKey}.unableToDetermine`, {
-              dir: packageDirName,
-            }),
+            message:
+              doctor.projectDependencyChecks.unableToDetermine(packageDirName),
           });
         }
 
@@ -325,7 +301,7 @@ export class Doctor {
     if (!foundError) {
       this.diagnosis?.addProjectSection({
         type: 'success',
-        message: i18n(`${localI18nKey}.success`),
+        message: doctor.projectDependencyChecks.success,
       });
     }
   }
@@ -352,9 +328,7 @@ export class Doctor {
         foundError = true;
         this.diagnosis?.addProjectSection({
           type: 'error',
-          message: i18n(`${i18nKey}.files.invalidJson`, {
-            filename: jsonFile,
-          }),
+          message: doctor.files.invalidJson(fileToCheck),
         });
       }
     }
@@ -362,32 +336,26 @@ export class Doctor {
     if (!foundError) {
       this.diagnosis?.addProjectSection({
         type: 'success',
-        message: i18n(`${i18nKey}.files.validJson`),
+        message: doctor.files.validJson,
       });
     }
   }
 
   private async checkIfPortsAreAvailable(): Promise<void> {
-    const localI18nKey = `${i18nKey}.port`;
-
     if (await isPortManagerPortAvailable()) {
       this.diagnosis?.addProjectSection({
         type: 'success',
-        message: i18n(`${localI18nKey}.available`, {
-          port: PORT_MANAGER_SERVER_PORT,
-        }),
+        message: doctor.port.available(PORT_MANAGER_SERVER_PORT),
       });
       return;
     }
 
     this.diagnosis?.addProjectSection({
       type: 'warning',
-      message: i18n(`${localI18nKey}.inUse`, {
-        port: PORT_MANAGER_SERVER_PORT,
-      }),
-      secondaryMessaging: i18n(`${localI18nKey}.inUseSecondary`, {
-        command: uiCommandReference('hs project dev'),
-      }),
+      message: doctor.port.inUse(PORT_MANAGER_SERVER_PORT),
+      secondaryMessaging: doctor.port.inUseSecondary(
+        uiCommandReference('hs project dev')
+      ),
     });
   }
 }

--- a/lib/doctor/__tests__/__snapshots__/Diagnosis.test.ts.snap
+++ b/lib/doctor/__tests__/__snapshots__/Diagnosis.test.ts.snap
@@ -7,7 +7,7 @@ HubSpot CLI install
     - The CLI Section is Showing
 
 Errors: 0
-Warning: 0
+Warnings: 0
 "
 `;
 
@@ -30,6 +30,6 @@ Project name: Super cool project
     - The Project Section is Showing
 
 Errors: 1
-Warning: 1
+Warnings: 1
 "
 `;

--- a/scripts/get-all-commands.ts
+++ b/scripts/get-all-commands.ts
@@ -43,7 +43,7 @@ async function extractCommands(
   return commands;
 }
 
-(async function() {
+(async function () {
   SpinniesManager.init();
   SpinniesManager.add('extractingCommands', { text: 'Extracting commands' });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,6 @@
     "outDir": "dist",
     "noErrorTruncation": true
   },
-  "include": ["bin", "commands", "lib"],
+  "include": ["bin", "commands", "lib", "lang"],
   "exclude": ["**/__tests__/*"]
 }


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
Pros:
- Removes the friction from having to edit large JSON/YAML files
- Code completion
- Type checking for interpolated strings
- Unit testable since the lookup no longer requires 
- Remove custom interpolation language, uses direct JavaScript
- Easy to tell if a key is not used
- Easy to tell exactly where a key is used
- The Co-Pilot suggestions were actually really useful when using the consts 

Cons:
- If we do eventually leverage i18n, we will have to walk back the pattern. 
- Porting to the new format will take time