### PR TITLE
feat: add scope authorization check to hs doctor

### DIFF
--- a/lang/en.lyaml
+++ b/lang/en.lyaml
@@ -1520,7 +1520,7 @@ en:
           incomplete:
             one: "Personal access key is valid. {{ count }} scope available, but not included in your key."
             other: "Personal access key is valid. {{ count }} scopes available, but not included in your key."
-          incompleteSecondary: "To add the available scopes, run `hs auth` and re-authenticate your account with a new key that has those scopes. {{ link }}"
+          incompleteSecondary: "To add the available scopes, run {{ command}} and re-authenticate your account with a new key that has those scopes. {{ link }}"
           invalid: "Personal access key is invalid"
           invalidSecondary: "To get a new key, run {{ command }}, deactivate your access key, and generate a new one. Then use that new key to authenticate your account."
           valid: "Personal Access Key is valid. {{ link }}"

--- a/lang/en.lyaml
+++ b/lang/en.lyaml
@@ -1517,7 +1517,7 @@ en:
         inactiveSecondary: "Run {{ command }} to remove inactive accounts from your CLI config"
         unableToDetermine: "Unable to determine if the portal is active"
         pak:
-          incomplete: "Personal access key is valid. There are more scopes available to your user, but not included in your key."
+          incomplete: "Personal access key is valid, but there are more scopes available to your user that are not included in your key."
           incompleteSecondary: "To add the available scopes, run {{ command }} and re-authenticate your account with a new key that has those scopes. Visit hubspot.com to view selected and available scopes for your personal access key. {{ link }}"
           invalid: "Personal access key is invalid"
           invalidSecondary: "To get a new key, run {{ command }}, deactivate your access key, and generate a new one. Then use that new key to authenticate your account."

--- a/lang/en.lyaml
+++ b/lang/en.lyaml
@@ -1517,6 +1517,10 @@ en:
         inactiveSecondary: "Run {{ command }} to remove inactive accounts from your CLI config"
         unableToDetermine: "Unable to determine if the portal is active"
         pak:
+          incomplete:
+            one: "Personal access key is valid. {{ count }} scope available, but not included in your key."
+            other: "Personal access key is valid. {{ count }} scopes available, but not included in your key."
+          incompleteSecondary: "To add the available scopes, run `hs auth` and re-authenticate your account with a new key that has those scopes. {{ link }}"
           invalid: "Personal access key is invalid"
           invalidSecondary: "To get a new key, run {{ command }}, deactivate your access key, and generate a new one. Then use that new key to authenticate your account."
           valid: "Personal Access Key is valid. {{ link }}"

--- a/lang/en.lyaml
+++ b/lang/en.lyaml
@@ -1517,10 +1517,8 @@ en:
         inactiveSecondary: "Run {{ command }} to remove inactive accounts from your CLI config"
         unableToDetermine: "Unable to determine if the portal is active"
         pak:
-          incomplete:
-            one: "Personal access key is valid. {{ count }} scope available, but not included in your key."
-            other: "Personal access key is valid. {{ count }} scopes available, but not included in your key."
-          incompleteSecondary: "To add the available scopes, run {{ command}} and re-authenticate your account with a new key that has those scopes. Visit hubspot.com to view selected and available scopes for your personal access key. {{ link }}"
+          incomplete: "Personal access key is valid. There are more scopes available to your user, but not included in your key."
+          incompleteSecondary: "To add the available scopes, run {{ command }} and re-authenticate your account with a new key that has those scopes. Visit hubspot.com to view selected and available scopes for your personal access key. {{ link }}"
           invalid: "Personal access key is invalid"
           invalidSecondary: "To get a new key, run {{ command }}, deactivate your access key, and generate a new one. Then use that new key to authenticate your account."
           valid: "Personal Access Key is valid. {{ link }}"

--- a/lang/en.lyaml
+++ b/lang/en.lyaml
@@ -1262,7 +1262,7 @@ en:
         selectScopes: "Select access scopes (see https://developers.hubspot.com/docs/methods/oauth2/initiate-oauth-integration#scopes)"
         personalAccessKeySetupTitle: "HubSpot Personal Access Key Setup"
         personalAccessKeyBrowserOpenPrep: "A personal access key is required to authenticate the CLI to interact with your HubSpot account. We'll open a secure page in your default browser where you can view and copy your personal access key."
-        personalAccessKeyBrowserOpenPrompt: "Open hubspot.com to copy your personal access key?"
+        personalAccessKeyBrowserOpenPrompt: "Open HubSpot to copy your personal access key?"
         logs:
           openingWebBrowser: "Opening {{ url }} in your web browser"
         errors:
@@ -1372,8 +1372,8 @@ en:
       installPublicAppPrompt:
         explanation: "Local development requires this app to be installed in the target test account"
         reinstallExplanation: "This app's required scopes have been updated since it was last installed on the target test account. To avoid issues with local development, we recommend reinstalling the app with the updated scopes."
-        prompt: "Open hubspot.com to install this app?"
-        reinstallPrompt: "Open hubspot.com to reinstall this app?"
+        prompt: "Open HubSpot to install this app?"
+        reinstallPrompt: "Open HubSpot to reinstall this app?"
         decline: "To continue local development of this app, install it in your target test account and re-run {{#bold}}`hs project dev`{{/bold}}"
       selectHubDBTablePrompt:
         selectTable: "Select a HubDB table:"
@@ -1518,7 +1518,7 @@ en:
         unableToDetermine: "Unable to determine if the portal is active"
         pak:
           incomplete: "Personal access key is valid, but there are more scopes available to your user that are not included in your key."
-          incompleteSecondary: "To add the available scopes, run {{ command }} and re-authenticate your account with a new key that has those scopes. Visit hubspot.com to view selected and available scopes for your personal access key. {{ link }}"
+          incompleteSecondary: "To add the available scopes, run {{ command }} and re-authenticate your account with a new key that has those scopes. Visit HubSpot to view selected and available scopes for your personal access key. {{ link }}"
           invalid: "Personal access key is invalid"
           invalidSecondary: "To get a new key, run {{ command }}, deactivate your access key, and generate a new one. Then use that new key to authenticate your account."
           valid: "Personal Access Key is valid. {{ link }}"

--- a/lang/en.lyaml
+++ b/lang/en.lyaml
@@ -1520,7 +1520,7 @@ en:
           incomplete:
             one: "Personal access key is valid. {{ count }} scope available, but not included in your key."
             other: "Personal access key is valid. {{ count }} scopes available, but not included in your key."
-          incompleteSecondary: "To add the available scopes, run {{ command}} and re-authenticate your account with a new key that has those scopes. {{ link }}"
+          incompleteSecondary: "To add the available scopes, run {{ command}} and re-authenticate your account with a new key that has those scopes. Visit hubspot.com to view selected and available scopes for your personal access key. {{ link }}"
           invalid: "Personal access key is invalid"
           invalidSecondary: "To get a new key, run {{ command }}, deactivate your access key, and generate a new one. Then use that new key to authenticate your account."
           valid: "Personal Access Key is valid. {{ link }}"

--- a/lib/doctor/Doctor.ts
+++ b/lib/doctor/Doctor.ts
@@ -149,6 +149,7 @@ export class Doctor {
             }
           ),
           secondaryMessaging: i18n(`${localI18nKey}.pak.incompleteSecondary`, {
+            command: uiCommandReference(`hs auth`),
             link: linkToPakUI,
           }),
         });

--- a/lib/doctor/Doctor.ts
+++ b/lib/doctor/Doctor.ts
@@ -132,6 +132,13 @@ export class Doctor {
         message: i18n(`${localI18nKey}.active`),
       });
 
+      const linkToPakUI = uiLink(
+        i18n(`${localI18nKey}.pak.viewScopes`),
+        `${getHubSpotWebsiteOrigin(
+          this.diagnosticInfoBuilder?.env || 'PROD'
+        )}/personal-access-key/${this.diagnosticInfo?.account.accountId}`
+      );
+
       if (missingScopes.length > 0) {
         this.diagnosis?.addCLIConfigSection({
           type: 'warning',
@@ -142,25 +149,13 @@ export class Doctor {
             }
           ),
           secondaryMessaging: i18n(`${localI18nKey}.pak.incompleteSecondary`, {
-            link: uiLink(
-              i18n(`${localI18nKey}.pak.viewScopes`),
-              `${getHubSpotWebsiteOrigin(
-                this.diagnosticInfoBuilder?.env || 'PROD'
-              )}/personal-access-key/${this.diagnosticInfo?.account.accountId}`
-            ),
+            link: linkToPakUI,
           }),
         });
       } else {
         this.diagnosis?.addCLIConfigSection({
           type: 'success',
-          message: i18n(`${localI18nKey}.pak.valid`, {
-            link: uiLink(
-              i18n(`${localI18nKey}.pak.viewScopes`),
-              `${getHubSpotWebsiteOrigin(
-                this.diagnosticInfoBuilder?.env || 'PROD'
-              )}/personal-access-key/${this.diagnosticInfo?.account.accountId}`
-            ),
-          }),
+          message: i18n(`${localI18nKey}.pak.valid`, { link: linkToPakUI }),
         });
       }
     } catch (error) {

--- a/lib/doctor/Doctor.ts
+++ b/lib/doctor/Doctor.ts
@@ -123,11 +123,9 @@ export class Doctor {
       const pakScopes = new Set(await scopesOnAccessToken(this.accountId!));
       const missingScopes = (
         await authorizedScopesForPortalAndUser(this.accountId!)
-      )
-        .filter(
-          data => data.userAuthorized && !pakScopes.has(data.scopeGroup.name)
-        )
-        .map(data => data.scopeGroup.name);
+      ).filter(
+        data => data.userAuthorized && !pakScopes.has(data.scopeGroup.name)
+      );
 
       this.diagnosis?.addCLIConfigSection({
         type: 'success',

--- a/lib/doctor/Doctor.ts
+++ b/lib/doctor/Doctor.ts
@@ -22,6 +22,7 @@ import {
   authorizedScopesForPortalAndUser,
   scopesOnAccessToken,
 } from '@hubspot/local-dev-lib/personalAccessKey';
+import { ScopeGroupAuthorization } from '@hubspot/local-dev-lib/types/Accounts';
 import { isSpecifiedError } from '@hubspot/local-dev-lib/errors/index';
 import { getHubSpotWebsiteOrigin } from '@hubspot/local-dev-lib/urls';
 import { uiCommandReference } from '../ui';
@@ -120,11 +121,13 @@ export class Doctor {
     const localI18nKey = `${i18nKey}.accountChecks`;
     try {
       await accessTokenForPersonalAccessKey(this.accountId!, true);
+
       const pakScopes = new Set(await scopesOnAccessToken(this.accountId!));
       const missingScopes = (
         await authorizedScopesForPortalAndUser(this.accountId!)
       ).filter(
-        data => data.userAuthorized && !pakScopes.has(data.scopeGroup.name)
+        (data: ScopeGroupAuthorization) =>
+          data.userAuthorized && !pakScopes.has(data.scopeGroup.name)
       );
 
       this.diagnosis?.addCLIConfigSection({

--- a/lib/doctor/Doctor.ts
+++ b/lib/doctor/Doctor.ts
@@ -145,12 +145,7 @@ export class Doctor {
       if (missingScopes.length > 0) {
         this.diagnosis?.addCLIConfigSection({
           type: 'warning',
-          message: i18n(
-            `${localI18nKey}.pak.incomplete${missingScopes.length == 1 ? '.one' : '.other'}`,
-            {
-              count: missingScopes.length,
-            }
-          ),
+          message: i18n(`${localI18nKey}.pak.incomplete`),
           secondaryMessaging: i18n(`${localI18nKey}.pak.incompleteSecondary`, {
             command: uiCommandReference(`hs auth`),
             link: linkToPakUI,

--- a/lib/doctor/__tests__/Doctor.test.ts
+++ b/lib/doctor/__tests__/Doctor.test.ts
@@ -355,57 +355,7 @@ describe('lib/doctor/Doctor', () => {
         expect(doctor['diagnosis']?.addCLIConfigSection).toHaveBeenCalledWith({
           type: 'warning',
           message:
-            'Personal access key is valid. 1 scope available, but not included in your key.',
-          secondaryMessaging: expect.any(String),
-        });
-      });
-
-      it('should warn when there are multiple missing authorized scopes', async () => {
-        scopesOnAccessToken.mockResolvedValueOnce(['scope1', 'scope2']);
-        authorizedScopesForPortalAndUser.mockResolvedValueOnce([
-          {
-            scopeGroup: {
-              name: 'scope1',
-              shortDescription: 'scope1',
-              longDescription: 'scope1',
-            },
-            portalAuthorized: true,
-            userAuthorized: true,
-          },
-          {
-            scopeGroup: {
-              name: 'scope2',
-              shortDescription: 'scope2',
-              longDescription: 'scope2',
-            },
-            portalAuthorized: true,
-            userAuthorized: true,
-          },
-          {
-            scopeGroup: {
-              name: 'scope3',
-              shortDescription: 'scope3',
-              longDescription: 'scope3',
-            },
-            portalAuthorized: true,
-            userAuthorized: true,
-          },
-          {
-            scopeGroup: {
-              name: 'scope4',
-              shortDescription: 'scope4',
-              longDescription: 'scope4',
-            },
-            portalAuthorized: true,
-            userAuthorized: true,
-          },
-        ]);
-
-        await doctor.diagnose();
-        expect(doctor['diagnosis']?.addCLIConfigSection).toHaveBeenCalledWith({
-          type: 'warning',
-          message:
-            'Personal access key is valid. 2 scopes available, but not included in your key.',
+            'Personal access key is valid, but there are more scopes available to your user that are not included in your key.',
           secondaryMessaging: expect.any(String),
         });
       });

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": "https://github.com/HubSpot/hubspot-cli",
   "dependencies": {
-    "@hubspot/local-dev-lib": "3.2.0",
+    "@hubspot/local-dev-lib": "3.3.0",
     "@hubspot/project-parsing-lib": "0.0.4",
     "@hubspot/serverless-dev-runtime": "7.0.2",
     "@hubspot/theme-preview-dev-server": "0.0.10",


### PR DESCRIPTION
## Description and Context

Adds scope authorization checking to `hs doctor`. The goal is to alert the user if there are potential issues we detect with their local configuration. In this situation, we're highlighting when the personal access key being used for auth has fewer scopes than the current user has access to. If so, we'll detail that in the doctor response.

I'll add some tests before merging but wanted to get some eyes on the shape of things ahead of that.

Depends on https://github.com/HubSpot/hubspot-local-dev-lib/pull/232
