### PR TITLE
Remove unsupported types from sandbox sync

### DIFF
--- a/lib/sandboxes.ts
+++ b/lib/sandboxes.ts
@@ -35,6 +35,13 @@ export const SANDBOX_API_TYPE_MAP = {
   [HUBSPOT_ACCOUNT_TYPES.DEVELOPMENT_SANDBOX]: 2,
 } as const;
 
+export const UNSUPPORTED_V1_SYNC_TYPES = [
+  'hub-trials',
+  'gates',
+  'lead-settings',
+  'object-schemas-full', // TODO: Remove object-schemas-full once we've migrated sandboxes to v2
+];
+
 export function getSandboxTypeAsString(accountType?: AccountType): string {
   if (accountType === HUBSPOT_ACCOUNT_TYPES.DEVELOPMENT_SANDBOX) {
     return 'development'; // Only place we're using this specific name
@@ -84,7 +91,9 @@ export async function getAvailableSyncTypes(
   if (!syncTypes) {
     throw new Error(i18n(`${i18nKey}.sync.failure.syncTypeFetch`));
   }
-  return syncTypes.map(t => ({ type: t.name }));
+  return syncTypes
+    .filter(t => !UNSUPPORTED_V1_SYNC_TYPES.includes(t.name))
+    .map(t => ({ type: t.name }));
 }
 
 export async function validateSandboxUsageLimits(


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
Supporting PR: https://github.com/HubSpot/hubspot-local-dev-lib/pull/233

Did some testing and realized the new endpoint (in LDL) is returning a few unsupported types for our v1 sandbox sync. Since we don't support v2 sandboxes in the CLI yet, we have to filter these options out so the sandbox sync succeeds. Without the filter, the sandbox sync hangs indefinitely due to unsupported sync type. 

I ran this locally with `yarn hs sandbox create` and with LDL running locally at the same time (hoping that is still the way to test!)

## Screenshots
<!-- Provide images of the before and after functionality -->
n/a

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
