### PR TITLE
Fix: minor bug with project create

### DIFF
--- a/lib/projects/index.ts
+++ b/lib/projects/index.ts
@@ -145,13 +145,15 @@ export async function createProjectConfig(
     }
   );
 
-  const _config: ProjectConfig = JSON.parse(
-    fs.readFileSync(projectConfigPath).toString()
-  );
-  writeProjectConfig(projectConfigPath, {
-    ..._config,
-    name: projectName,
-  });
+  if (fs.existsSync(projectConfigPath)) {
+    const _config: ProjectConfig = JSON.parse(
+      fs.readFileSync(projectConfigPath).toString()
+    );
+    writeProjectConfig(projectConfigPath, {
+      ..._config,
+      name: projectName,
+    });
+  }
 
   if (template.name === 'no-template') {
     fs.ensureDirSync(path.join(projectPath, 'src'));


### PR DESCRIPTION
## Description and Context
Background: The UIE squad is currently making changes to the project examples in `HubSpot/ui-extensions-examples`. Now each example folder will contain two project templates, one with a public and the other with a private app. That means there will be no `hsproject.json` in the root directory. 

In our `createProjectConfig` function, we were assuming that there would always be an `hsproject.json` file at the root of the directory, and so when attempting to write a folder containing two projects we were receiving the following error:

<img width="926" alt="Screenshot 2025-02-05 at 11 54 03 AM" src="https://github.com/user-attachments/assets/9df0cbba-1a0e-492f-b864-fcf3556417c8" />

To avoid this error, I've added a check for whether the `hsproject.json` file exists in the project template. 

QUESTION: Will this have unintended consequences? I tested out creating a project with one of our standard templates with an `hsproject.json`, and everything was WAD.

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

- [ ] Address feedback 

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@brandenrodgers @camden11 @joe-yeager 
