### PR TITLE
feat: Remove option, upload to v3 based on platform version

### DIFF
--- a/commands/__tests__/project.test.ts
+++ b/commands/__tests__/project.test.ts
@@ -83,6 +83,7 @@ describe('commands/project', () => {
 
     it.each(subcommands)('should attach the %s subcommand', (name, module) => {
       projectCommand.builder(yargs);
+      expect(module).toBeDefined();
       expect(yargs.command).toHaveBeenCalledWith(module);
     });
   });

--- a/commands/project/__tests__/deploy.test.ts
+++ b/commands/project/__tests__/deploy.test.ts
@@ -49,7 +49,6 @@ describe('commands/project/deploy', () => {
   const projectFlag = 'project';
   const buildFlag = 'build';
   const buildAliases = ['build-id'];
-  const useV3Flag = 'use-v3';
 
   describe('command', () => {
     it('should have the correct command structure', () => {
@@ -77,11 +76,6 @@ describe('commands/project/deploy', () => {
         [buildFlag]: expect.objectContaining({
           alias: buildAliases,
           type: 'number',
-        }),
-        [useV3Flag]: expect.objectContaining({
-          type: 'boolean',
-          hidden: true,
-          default: false,
         }),
       });
 

--- a/commands/project/deploy.ts
+++ b/commands/project/deploy.ts
@@ -1,4 +1,6 @@
 // @ts-nocheck
+import { useV3Api } from '../../lib/projects/buildAndDeploy';
+
 const chalk = require('chalk');
 const {
   addAccountOptions,
@@ -135,7 +137,7 @@ exports.handler = async options => {
       derivedAccountId,
       projectName,
       buildIdToDeploy,
-      options.useV3
+      useV3Api(projectConfig?.platformVersion)
     );
 
     if (!deployResp || deployResp.error) {
@@ -187,11 +189,6 @@ exports.builder = yargs => {
       alias: ['build-id'],
       describe: i18n(`${i18nKey}.options.build.describe`),
       type: 'number',
-    },
-    'use-v3': {
-      hidden: true,
-      type: 'boolean',
-      default: false,
     },
   });
 

--- a/commands/project/deploy.ts
+++ b/commands/project/deploy.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { useV3Api } from '../../lib/projects/buildAndDeploy';
+const { useV3Api } = require('../../lib/projects/buildAndDeploy');
 
 const chalk = require('chalk');
 const {

--- a/commands/project/upload.ts
+++ b/commands/project/upload.ts
@@ -1,4 +1,6 @@
 // @ts-nocheck
+import { useV3Api } from '../../lib/projects/buildAndDeploy';
+
 const {
   addAccountOptions,
   addConfigOptions,
@@ -32,7 +34,7 @@ exports.command = 'upload';
 exports.describe = uiBetaTag(i18n(`${i18nKey}.describe`), false);
 
 exports.handler = async options => {
-  const { forceCreate, message, derivedAccountId, useV3 } = options;
+  const { forceCreate, message, derivedAccountId } = options;
   const accountConfig = getAccountConfig(derivedAccountId);
   const accountType = accountConfig && accountConfig.accountType;
 
@@ -54,7 +56,7 @@ exports.handler = async options => {
       projectDir,
       pollProjectBuildAndDeploy,
       message,
-      useV3
+      useV3Api(projectConfig?.platformVersion)
     );
 
     if (uploadError) {
@@ -125,11 +127,6 @@ exports.builder = yargs => {
       describe: i18n(`${i18nKey}.options.message.describe`),
       type: 'string',
       default: '',
-    },
-    'use-v3': {
-      hidden: true,
-      type: 'boolean',
-      default: false,
     },
   });
 

--- a/commands/project/upload.ts
+++ b/commands/project/upload.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { useV3Api } from '../../lib/projects/buildAndDeploy';
+const { useV3Api } = require('../../lib/projects/buildAndDeploy');
 
 const {
   addAccountOptions,

--- a/lib/projects/__tests__/buildAndDeploy.test.ts
+++ b/lib/projects/__tests__/buildAndDeploy.test.ts
@@ -1,0 +1,25 @@
+import { useV3Api } from '../buildAndDeploy';
+
+describe('buildAndDeploy', () => {
+  describe('useV3Api', () => {
+    it('returns true if platform version is equal to the minimum', () => {
+      expect(useV3Api('2025.1')).toBe(true);
+    });
+
+    it('returns true if platform version is greater than the minimum', () => {
+      expect(useV3Api('2026.2')).toBe(true);
+    });
+
+    it('returns false if platform version is less than the minimum', () => {
+      expect(useV3Api('2025.0')).toBe(false);
+    });
+
+    it('returns false if platform version is invalid', () => {
+      expect(useV3Api(null)).toBe(false);
+    });
+
+    it('returns false for an invalid platform version', () => {
+      expect(useV3Api('notplaformversion')).toBe(false);
+    });
+  });
+});

--- a/lib/projects/buildAndDeploy.ts
+++ b/lib/projects/buildAndDeploy.ts
@@ -46,7 +46,11 @@ const SPINNER_STATUS = {
 };
 
 export function useV3Api(platformVersion?: string | null) {
-  return platformVersion === '2025.1';
+  if (!platformVersion || typeof platformVersion !== 'string') {
+    return false;
+  }
+  const [year, minor] = platformVersion.split('.');
+  return Number(year) >= 2025 && Number(minor) >= 1;
 }
 
 function getSubtasks(task: ProjectTask): ProjectSubtask[] {

--- a/lib/projects/buildAndDeploy.ts
+++ b/lib/projects/buildAndDeploy.ts
@@ -45,6 +45,10 @@ const SPINNER_STATUS = {
   SPINNING: 'spinning',
 };
 
+export function useV3Api(platformVersion?: string | null) {
+  return platformVersion === '2025.1';
+}
+
 function getSubtasks(task: ProjectTask): ProjectSubtask[] {
   if ('subbuildStatuses' in task) {
     return task.subbuildStatuses;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hubspot/cli",
-  "version": "7.0.2",
+  "version": "7.0.12-experimental.0",
   "description": "The official CLI for developing on HubSpot",
   "license": "Apache-2.0",
   "repository": "https://github.com/HubSpot/hubspot-cli",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hubspot/cli",
-  "version": "7.0.12-experimental.0",
+  "version": "7.0.2",
   "description": "The official CLI for developing on HubSpot",
   "license": "Apache-2.0",
   "repository": "https://github.com/HubSpot/hubspot-cli",


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
Remove the `--useV3` flag and route to v3 of the projects APIs based on platform version instead
