### PR TITLE
Fix error case in account rename

### DIFF
--- a/commands/account/__tests__/rename.test.ts
+++ b/commands/account/__tests__/rename.test.ts
@@ -13,7 +13,7 @@ describe('commands/account/rename', () => {
   describe('command', () => {
     it('should have the correct command structure', () => {
       expect(accountRenameCommand.command).toEqual(
-        'rename <accountName> <newName>'
+        'rename <account-name> <new-name>'
       );
     });
   });
@@ -30,11 +30,11 @@ describe('commands/account/rename', () => {
 
       expect(yargsMock.example).toHaveBeenCalledTimes(1);
       expect(yargsMock.positional).toHaveBeenCalledTimes(2);
-      expect(yargsMock.positional).toHaveBeenCalledWith('accountName', {
+      expect(yargsMock.positional).toHaveBeenCalledWith('account-name', {
         describe: expect.any(String),
         type: 'string',
       });
-      expect(yargsMock.positional).toHaveBeenCalledWith('newName', {
+      expect(yargsMock.positional).toHaveBeenCalledWith('new-name', {
         describe: expect.any(String),
         type: 'string',
       });

--- a/commands/account/rename.ts
+++ b/commands/account/rename.ts
@@ -5,10 +5,12 @@ import { addConfigOptions, addAccountOptions } from '../../lib/commonOpts';
 import { trackCommandUsage } from '../../lib/usageTracking';
 import { i18n } from '../../lib/lang';
 import { CommonArgs, ConfigArgs } from '../../types/Yargs';
+import { logError } from '../../lib/errorHandlers';
+import { EXIT_CODES } from '../../lib/enums/exitCodes';
 
 const i18nKey = 'commands.account.subcommands.rename';
 
-export const command = 'rename <accountName> <newName>';
+export const command = 'rename <account-name> <new-name>';
 export const describe = i18n(`${i18nKey}.describe`);
 
 type AccountRenameArgs = CommonArgs &
@@ -24,30 +26,38 @@ export async function handler(
 
   trackCommandUsage('accounts-rename', undefined, derivedAccountId);
 
-  await renameAccount(accountName, newName);
+  try {
+    await renameAccount(accountName, newName);
+  } catch (error) {
+    logError(error);
+    process.exit(EXIT_CODES.ERROR);
+  }
 
-  return logger.log(
+  logger.log(
     i18n(`${i18nKey}.success.renamed`, {
       name: accountName,
       newName,
     })
   );
+  process.exit(EXIT_CODES.SUCCESS);
 }
 
 export function builder(yargs: Argv): Argv<AccountRenameArgs> {
   addConfigOptions(yargs);
   addAccountOptions(yargs);
 
-  yargs.positional('accountName', {
+  yargs.positional('account-name', {
     describe: i18n(`${i18nKey}.positionals.accountName.describe`),
     type: 'string',
   });
-  yargs.positional('newName', {
+  yargs.positional('new-name', {
     describe: i18n(`${i18nKey}.positionals.newName.describe`),
     type: 'string',
   });
 
-  yargs.example([['$0 accounts rename myExistingPortalName myNewPortalName']]);
+  yargs.example([
+    ['$0 accounts rename myExistingAccountName myNewAccountName'],
+  ]);
 
   return yargs as Argv<AccountRenameArgs>;
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": "https://github.com/HubSpot/hubspot-cli",
   "dependencies": {
-    "@hubspot/local-dev-lib": "3.3.0",
+    "@hubspot/local-dev-lib": "3.3.1",
     "@hubspot/project-parsing-lib": "0.0.4",
     "@hubspot/serverless-dev-runtime": "7.0.2",
     "@hubspot/theme-preview-dev-server": "0.0.10",


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
Depends on: https://github.com/HubSpot/hubspot-local-dev-lib/pull/238

The LDL util wasn't returning a promise, so the error thrown by `renameAccount` was never getting caught. I also think we may have missed this command when updating the other commands. This fixes it so it follows the new arg casing conventions.

## Screenshots
<!-- Provide images of the before and after functionality -->
### Before
<img width="832" alt="image" src="https://github.com/user-attachments/assets/bf734aff-3ac0-4643-a0e1-940ac77a8774" />

### After
<img width="664" alt="image" src="https://github.com/user-attachments/assets/3a4fb6c6-35d0-45ca-a30c-8780911a0459" />

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
