### PR TITLE
Chore: Change the min platform version for the API revamp

### DIFF
--- a/lib/projects/__tests__/buildAndDeploy.test.ts
+++ b/lib/projects/__tests__/buildAndDeploy.test.ts
@@ -2,8 +2,12 @@ import { useV3Api } from '../buildAndDeploy';
 
 describe('buildAndDeploy', () => {
   describe('useV3Api', () => {
+    it('returns true if platform version is UNSTABLE', () => {
+      expect(useV3Api('UNSTABLE')).toBe(true);
+    });
+
     it('returns true if platform version is equal to the minimum', () => {
-      expect(useV3Api('2025.1')).toBe(true);
+      expect(useV3Api('2025.2')).toBe(true);
     });
 
     it('returns true if platform version is greater than the minimum', () => {

--- a/lib/projects/buildAndDeploy.ts
+++ b/lib/projects/buildAndDeploy.ts
@@ -49,7 +49,7 @@ export function useV3Api(platformVersion?: string | null) {
   if (!platformVersion || typeof platformVersion !== 'string') {
     return false;
   }
-  if (platformVersion === 'UNSTABLE') {
+  if (platformVersion.toLowerCase() === 'unstable') {
     return true;
   }
   const [year, minor] = platformVersion.split('.');

--- a/lib/projects/buildAndDeploy.ts
+++ b/lib/projects/buildAndDeploy.ts
@@ -49,8 +49,11 @@ export function useV3Api(platformVersion?: string | null) {
   if (!platformVersion || typeof platformVersion !== 'string') {
     return false;
   }
+  if (platformVersion === 'UNSTABLE') {
+    return true;
+  }
   const [year, minor] = platformVersion.split('.');
-  return Number(year) >= 2025 && Number(minor) >= 1;
+  return Number(year) >= 2025 && Number(minor) >= 2;
 }
 
 function getSubtasks(task: ProjectTask): ProjectSubtask[] {


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
Change the minimum required version from `2025.1` to either `2025.2` or `UNSTABLE`