### PR TITLE
chore: Convert `sandbox` commands to TypeScript

### DIFF
--- a/commands/__tests__/hubdb.test.ts
+++ b/commands/__tests__/hubdb.test.ts
@@ -3,6 +3,7 @@ import * as clear from '../hubdb/clear';
 import * as create from '../hubdb/create';
 import * as deleteCommand from '../hubdb/delete';
 import * as fetch from '../hubdb/fetch';
+import * as hubdbCommands from '../hubdb';
 
 jest.mock('yargs');
 jest.mock('../hubdb/clear');
@@ -17,9 +18,6 @@ const commandSpy = jest
 const demandCommandSpy = jest
   .spyOn(yargs as Argv, 'demandCommand')
   .mockReturnValue(yargs as Argv);
-
-// Import this last so mocks apply
-import * as hubdbCommands from '../hubdb';
 
 describe('commands/hubdb', () => {
   describe('command', () => {

--- a/commands/__tests__/sandbox.test.ts
+++ b/commands/__tests__/sandbox.test.ts
@@ -1,6 +1,7 @@
 import yargs, { Argv } from 'yargs';
 import * as create from '../sandbox/create';
 import * as del from '../sandbox/delete';
+import * as sandboxCommands from '../sandbox';
 
 jest.mock('yargs');
 jest.mock('../sandbox/create');
@@ -12,9 +13,6 @@ const commandSpy = jest
 const demandCommandSpy = jest
   .spyOn(yargs as Argv, 'demandCommand')
   .mockReturnValue(yargs as Argv);
-
-// Import this last so mocks apply
-import * as sandboxCommands from '../sandbox';
 
 describe('commands/sandbox', () => {
   describe('command', () => {

--- a/commands/__tests__/sandbox.test.ts
+++ b/commands/__tests__/sandbox.test.ts
@@ -16,7 +16,7 @@ const demandCommandSpy = jest
 // Import this last so mocks apply
 import * as sandboxCommands from '../sandbox';
 
-describe('commands/account', () => {
+describe('commands/sandbox', () => {
   describe('command', () => {
     it('should have the correct command structure', () => {
       expect(sandboxCommands.command).toEqual(['sandbox', 'sandboxes']);

--- a/commands/__tests__/sandbox.test.ts
+++ b/commands/__tests__/sandbox.test.ts
@@ -1,0 +1,57 @@
+import yargs, { Argv } from 'yargs';
+import * as create from '../sandbox/create';
+import * as del from '../sandbox/delete';
+
+jest.mock('yargs');
+jest.mock('../sandbox/create');
+jest.mock('../sandbox/delete');
+
+const commandSpy = jest
+  .spyOn(yargs as Argv, 'command')
+  .mockReturnValue(yargs as Argv);
+const demandCommandSpy = jest
+  .spyOn(yargs as Argv, 'demandCommand')
+  .mockReturnValue(yargs as Argv);
+
+// Import this last so mocks apply
+import * as sandboxCommands from '../sandbox';
+
+describe('commands/account', () => {
+  describe('command', () => {
+    it('should have the correct command structure', () => {
+      expect(sandboxCommands.command).toEqual(['sandbox', 'sandboxes']);
+    });
+  });
+
+  describe('describe', () => {
+    it('should provide a description', () => {
+      expect(sandboxCommands.describe).toBeDefined();
+    });
+  });
+
+  describe('builder', () => {
+    beforeEach(() => {
+      commandSpy.mockClear();
+      demandCommandSpy.mockClear();
+    });
+
+    const subcommands = [create, del];
+
+    it('should demand the command takes one positional argument', () => {
+      sandboxCommands.builder(yargs as Argv);
+
+      expect(demandCommandSpy).toHaveBeenCalledTimes(1);
+      expect(demandCommandSpy).toHaveBeenCalledWith(1, '');
+    });
+
+    it('should add the correct number of sub commands', () => {
+      sandboxCommands.builder(yargs as Argv);
+      expect(commandSpy).toHaveBeenCalledTimes(subcommands.length);
+    });
+
+    it.each(subcommands)('should attach the %s subcommand', module => {
+      sandboxCommands.builder(yargs as Argv);
+      expect(commandSpy).toHaveBeenCalledWith(module);
+    });
+  });
+});

--- a/commands/__tests__/secret.test.ts
+++ b/commands/__tests__/secret.test.ts
@@ -3,6 +3,7 @@ import * as addSecret from '../secret/addSecret';
 import * as deleteSecret from '../secret/deleteSecret';
 import * as listSecret from '../secret/listSecret';
 import * as updateSecret from '../secret/updateSecret';
+import * as secretCommands from '../secret';
 
 jest.mock('yargs');
 jest.mock('../secret/addSecret');
@@ -17,9 +18,6 @@ const commandSpy = jest
 const demandCommandSpy = jest
   .spyOn(yargs as Argv, 'demandCommand')
   .mockReturnValue(yargs as Argv);
-
-// Import this last so mocks apply
-import * as secretCommands from '../secret';
 
 describe('commands/account', () => {
   describe('command', () => {

--- a/commands/hubdb/__tests__/clear.test.ts
+++ b/commands/hubdb/__tests__/clear.test.ts
@@ -11,7 +11,7 @@ jest.mock('../../../lib/commonOpts');
 // Import this last so mocks apply
 import * as hubdbClearCommand from '../clear';
 
-describe('commands/account/clean', () => {
+describe('commands/hubdb/clear', () => {
   const yargsMock = yargs as Argv;
 
   describe('command', () => {

--- a/commands/hubdb/__tests__/clear.test.ts
+++ b/commands/hubdb/__tests__/clear.test.ts
@@ -4,12 +4,10 @@ import {
   addConfigOptions,
   addUseEnvironmentOptions,
 } from '../../../lib/commonOpts';
+import * as hubdbClearCommand from '../clear';
 
 jest.mock('yargs');
 jest.mock('../../../lib/commonOpts');
-
-// Import this last so mocks apply
-import * as hubdbClearCommand from '../clear';
 
 describe('commands/hubdb/clear', () => {
   const yargsMock = yargs as Argv;

--- a/commands/hubdb/__tests__/create.test.ts
+++ b/commands/hubdb/__tests__/create.test.ts
@@ -4,12 +4,10 @@ import {
   addConfigOptions,
   addUseEnvironmentOptions,
 } from '../../../lib/commonOpts';
+import * as hubdbCreateCommand from '../create';
 
 jest.mock('yargs');
 jest.mock('../../../lib/commonOpts');
-
-// Import this last so mocks apply
-import * as hubdbCreateCommand from '../create';
 
 describe('commands/hubdb/create', () => {
   const yargsMock = yargs as Argv;

--- a/commands/hubdb/__tests__/create.test.ts
+++ b/commands/hubdb/__tests__/create.test.ts
@@ -11,7 +11,7 @@ jest.mock('../../../lib/commonOpts');
 // Import this last so mocks apply
 import * as hubdbCreateCommand from '../create';
 
-describe('commands/account/clean', () => {
+describe('commands/hubdb/create', () => {
   const yargsMock = yargs as Argv;
 
   describe('command', () => {

--- a/commands/hubdb/__tests__/delete.test.ts
+++ b/commands/hubdb/__tests__/delete.test.ts
@@ -11,7 +11,7 @@ jest.mock('../../../lib/commonOpts');
 // Import this last so mocks apply
 import * as hubdbDeleteCommand from '../delete';
 
-describe('commands/account/clean', () => {
+describe('commands/hubdb/delete', () => {
   const yargsMock = yargs as Argv;
 
   describe('command', () => {

--- a/commands/hubdb/__tests__/delete.test.ts
+++ b/commands/hubdb/__tests__/delete.test.ts
@@ -4,12 +4,10 @@ import {
   addConfigOptions,
   addUseEnvironmentOptions,
 } from '../../../lib/commonOpts';
+import * as hubdbDeleteCommand from '../delete';
 
 jest.mock('yargs');
 jest.mock('../../../lib/commonOpts');
-
-// Import this last so mocks apply
-import * as hubdbDeleteCommand from '../delete';
 
 describe('commands/hubdb/delete', () => {
   const yargsMock = yargs as Argv;

--- a/commands/hubdb/__tests__/fetch.test.ts
+++ b/commands/hubdb/__tests__/fetch.test.ts
@@ -11,7 +11,7 @@ jest.mock('../../../lib/commonOpts');
 // Import this last so mocks apply
 import * as hubdbFetchCommand from '../fetch';
 
-describe('commands/account/clean', () => {
+describe('commands/hubdb/fetch', () => {
   const yargsMock = yargs as Argv;
 
   describe('command', () => {

--- a/commands/hubdb/__tests__/fetch.test.ts
+++ b/commands/hubdb/__tests__/fetch.test.ts
@@ -4,12 +4,10 @@ import {
   addConfigOptions,
   addUseEnvironmentOptions,
 } from '../../../lib/commonOpts';
+import * as hubdbFetchCommand from '../fetch';
 
 jest.mock('yargs');
 jest.mock('../../../lib/commonOpts');
-
-// Import this last so mocks apply
-import * as hubdbFetchCommand from '../fetch';
 
 describe('commands/hubdb/fetch', () => {
   const yargsMock = yargs as Argv;

--- a/commands/sandbox.ts
+++ b/commands/sandbox.ts
@@ -13,7 +13,6 @@ export const describe = uiBetaTag(i18n(`${i18nKey}.describe`), false);
 export function builder(yargs: Argv): Argv {
   addGlobalOptions(yargs);
 
-  // @ts-ignore TODO
   yargs.command(create).command(del).demandCommand(1, '');
 
   return yargs;

--- a/commands/sandbox.ts
+++ b/commands/sandbox.ts
@@ -1,19 +1,20 @@
-// @ts-nocheck
-const { addGlobalOptions } = require('../lib/commonOpts');
-const { i18n } = require('../lib/lang');
-const { uiBetaTag } = require('../lib/ui');
-const create = require('./sandbox/create');
-const del = require('./sandbox/delete');
+import { Argv } from 'yargs';
+import { addGlobalOptions } from '../lib/commonOpts';
+import { i18n } from '../lib/lang';
+import { uiBetaTag } from '../lib/ui';
+import * as create from './sandbox/create';
+import * as del from './sandbox/delete';
 
 const i18nKey = 'commands.sandbox';
 
-exports.command = ['sandbox', 'sandboxes'];
-exports.describe = uiBetaTag(i18n(`${i18nKey}.describe`), false);
+export const command = ['sandbox', 'sandboxes'];
+export const describe = uiBetaTag(i18n(`${i18nKey}.describe`), false);
 
-exports.builder = yargs => {
+export function builder(yargs: Argv): Argv {
   addGlobalOptions(yargs);
 
+  // @ts-ignore TODO
   yargs.command(create).command(del).demandCommand(1, '');
 
   return yargs;
-};
+}

--- a/commands/sandbox/__tests__/create.test.ts
+++ b/commands/sandbox/__tests__/create.test.ts
@@ -9,7 +9,6 @@ import {
 jest.mock('yargs');
 jest.mock('../../../lib/commonOpts');
 
-// Import this last so mocks apply
 import * as sandboxCreateCommand from '../create';
 
 describe('commands/sandbox/create', () => {

--- a/commands/sandbox/__tests__/create.test.ts
+++ b/commands/sandbox/__tests__/create.test.ts
@@ -5,11 +5,10 @@ import {
   addUseEnvironmentOptions,
   addTestingOptions,
 } from '../../../lib/commonOpts';
+import * as sandboxCreateCommand from '../create';
 
 jest.mock('yargs');
 jest.mock('../../../lib/commonOpts');
-
-import * as sandboxCreateCommand from '../create';
 
 describe('commands/sandbox/create', () => {
   const yargsMock = yargs as Argv;

--- a/commands/sandbox/__tests__/create.test.ts
+++ b/commands/sandbox/__tests__/create.test.ts
@@ -1,0 +1,49 @@
+import yargs, { Argv } from 'yargs';
+import {
+  addAccountOptions,
+  addConfigOptions,
+  addUseEnvironmentOptions,
+  addTestingOptions,
+} from '../../../lib/commonOpts';
+
+jest.mock('yargs');
+jest.mock('../../../lib/commonOpts');
+
+// Import this last so mocks apply
+import * as sandboxCreateCommand from '../create';
+
+describe('commands/sandbox/create', () => {
+  const yargsMock = yargs as Argv;
+
+  describe('command', () => {
+    it('should have the correct command structure', () => {
+      expect(sandboxCreateCommand.command).toEqual('create');
+    });
+  });
+
+  describe('describe', () => {
+    it('should provide a description', () => {
+      expect(sandboxCreateCommand.describe).toBeDefined();
+    });
+  });
+
+  describe('builder', () => {
+    it('should support the correct options', () => {
+      sandboxCreateCommand.builder(yargsMock);
+
+      expect(yargsMock.example).toHaveBeenCalledTimes(1);
+
+      expect(addTestingOptions).toHaveBeenCalledTimes(1);
+      expect(addTestingOptions).toHaveBeenCalledWith(yargsMock);
+
+      expect(addAccountOptions).toHaveBeenCalledTimes(1);
+      expect(addAccountOptions).toHaveBeenCalledWith(yargsMock);
+
+      expect(addConfigOptions).toHaveBeenCalledTimes(1);
+      expect(addConfigOptions).toHaveBeenCalledWith(yargsMock);
+
+      expect(addUseEnvironmentOptions).toHaveBeenCalledTimes(1);
+      expect(addUseEnvironmentOptions).toHaveBeenCalledWith(yargsMock);
+    });
+  });
+});

--- a/commands/sandbox/__tests__/delete.test.ts
+++ b/commands/sandbox/__tests__/delete.test.ts
@@ -9,7 +9,6 @@ import {
 jest.mock('yargs');
 jest.mock('../../../lib/commonOpts');
 
-// Import this last so mocks apply
 import * as sandboxDeleteCommand from '../delete';
 
 describe('commands/sandbox/delete', () => {

--- a/commands/sandbox/__tests__/delete.test.ts
+++ b/commands/sandbox/__tests__/delete.test.ts
@@ -1,0 +1,49 @@
+import yargs, { Argv } from 'yargs';
+import {
+  addAccountOptions,
+  addConfigOptions,
+  addUseEnvironmentOptions,
+  addTestingOptions,
+} from '../../../lib/commonOpts';
+
+jest.mock('yargs');
+jest.mock('../../../lib/commonOpts');
+
+// Import this last so mocks apply
+import * as sandboxDeleteCommand from '../delete';
+
+describe('commands/sandbox/delete', () => {
+  const yargsMock = yargs as Argv;
+
+  describe('command', () => {
+    it('should have the correct command structure', () => {
+      expect(sandboxDeleteCommand.command).toEqual('delete');
+    });
+  });
+
+  describe('describe', () => {
+    it('should provide a description', () => {
+      expect(sandboxDeleteCommand.describe).toBeDefined();
+    });
+  });
+
+  describe('builder', () => {
+    it('should support the correct options', () => {
+      sandboxDeleteCommand.builder(yargsMock);
+
+      expect(yargsMock.example).toHaveBeenCalledTimes(1);
+
+      expect(addTestingOptions).toHaveBeenCalledTimes(1);
+      expect(addTestingOptions).toHaveBeenCalledWith(yargsMock);
+
+      expect(addAccountOptions).toHaveBeenCalledTimes(1);
+      expect(addAccountOptions).toHaveBeenCalledWith(yargsMock);
+
+      expect(addConfigOptions).toHaveBeenCalledTimes(1);
+      expect(addConfigOptions).toHaveBeenCalledWith(yargsMock);
+
+      expect(addUseEnvironmentOptions).toHaveBeenCalledTimes(1);
+      expect(addUseEnvironmentOptions).toHaveBeenCalledWith(yargsMock);
+    });
+  });
+});

--- a/commands/sandbox/__tests__/delete.test.ts
+++ b/commands/sandbox/__tests__/delete.test.ts
@@ -5,11 +5,10 @@ import {
   addUseEnvironmentOptions,
   addTestingOptions,
 } from '../../../lib/commonOpts';
+import * as sandboxDeleteCommand from '../delete';
 
 jest.mock('yargs');
 jest.mock('../../../lib/commonOpts');
-
-import * as sandboxDeleteCommand from '../delete';
 
 describe('commands/sandbox/delete', () => {
   const yargsMock = yargs as Argv;

--- a/commands/sandbox/create.ts
+++ b/commands/sandbox/create.ts
@@ -177,7 +177,7 @@ export async function handler(
     );
 
     const sandboxAccountConfig = getAccountConfig(result.sandbox.sandboxHubId);
-    // Check if account config exists
+    // Check if sandbox account config exists
     if (!sandboxAccountConfig) {
       logger.error(
         i18n(`${i18nKey}.failure.noSandboxAccountConfig`, {

--- a/commands/sandbox/create.ts
+++ b/commands/sandbox/create.ts
@@ -45,12 +45,6 @@ import {
 import { getAccountIdentifier } from '@hubspot/local-dev-lib/config/getAccountIdentifier';
 import { SandboxSyncTask } from '../../types/Sandboxes';
 
-function isValidSandboxType(
-  type: string
-): type is keyof typeof SANDBOX_TYPE_MAP {
-  return type in SANDBOX_TYPE_MAP;
-}
-
 const i18nKey = 'commands.sandbox.subcommands.create';
 
 export const command = 'create';
@@ -58,7 +52,11 @@ export const describe = uiBetaTag(i18n(`${i18nKey}.describe`), false);
 
 type CombinedArgs = ConfigArgs & AccountArgs & EnvironmentArgs & TestingArgs;
 type SandboxCreateArgs = CommonArgs &
-  CombinedArgs & { name?: string; force?: boolean; type?: string };
+  CombinedArgs & {
+    name?: string;
+    force?: boolean;
+    type?: string;
+  };
 
 export async function handler(
   args: ArgumentsCamelCase<SandboxCreateArgs>
@@ -109,11 +107,7 @@ export async function handler(
     }
   }
 
-  const sandboxType =
-    type && isValidSandboxType(type.toLowerCase())
-      ? // @ts-ignore TODO Continues to be a problem even after adding a type guard
-        SANDBOX_TYPE_MAP[type]
-      : typePrompt!.type;
+  const sandboxType = type ? SANDBOX_TYPE_MAP[type] : typePrompt!.type;
 
   // Check usage limits and exit if parent portal has no available sandboxes for the selected type
   try {
@@ -238,7 +232,7 @@ export function builder(yargs: Argv): Argv<SandboxCreateArgs> {
   });
   yargs.option('type', {
     describe: i18n(`${i18nKey}.options.type.describe`),
-    type: 'string',
+    choices: Object.keys(SANDBOX_TYPE_MAP),
   });
 
   yargs.example([

--- a/commands/sandbox/create.ts
+++ b/commands/sandbox/create.ts
@@ -42,7 +42,6 @@ import {
   EnvironmentArgs,
   TestingArgs,
 } from '../../types/Yargs';
-import { getAccountIdentifier } from '@hubspot/local-dev-lib/config/getAccountIdentifier';
 import { SandboxSyncTask } from '../../types/Sandboxes';
 
 const i18nKey = 'commands.sandbox.subcommands.create';
@@ -89,7 +88,7 @@ export async function handler(
           HUBSPOT_ACCOUNT_TYPE_STRINGS[
             HUBSPOT_ACCOUNT_TYPES[accountConfig.accountType]
           ],
-        accountName: getAccountIdentifier(accountConfig) || '',
+        accountName: accountConfig.name || '',
       })
     );
     process.exit(EXIT_CODES.ERROR);
@@ -107,7 +106,9 @@ export async function handler(
     }
   }
 
-  const sandboxType = type ? SANDBOX_TYPE_MAP[type] : typePrompt!.type;
+  const sandboxType = type
+    ? SANDBOX_TYPE_MAP[type.toLowerCase()]
+    : typePrompt!.type;
 
   // Check usage limits and exit if parent portal has no available sandboxes for the selected type
   try {

--- a/commands/sandbox/delete.ts
+++ b/commands/sandbox/delete.ts
@@ -101,12 +101,20 @@ export async function handler(
       } else if (!force) {
         const parentAccountPrompt = await deleteSandboxPrompt(true);
         if (!parentAccountPrompt) {
-          logger.error(i18n(`${i18nKey}.failure.noParentAccount`));
+          logger.error(
+            i18n(`${i18nKey}.failure.noParentAccount`, {
+              authCommand: uiCommandReference('hs auth'),
+            })
+          );
           process.exit(EXIT_CODES.ERROR);
         }
         parentAccountId = getAccountId(parentAccountPrompt.account);
       } else {
-        logger.error(i18n(`${i18nKey}.failure.noParentAccount`));
+        logger.error(
+          i18n(`${i18nKey}.failure.noParentAccount`, {
+            authCommand: uiCommandReference('hs auth'),
+          })
+        );
         process.exit(EXIT_CODES.ERROR);
       }
     }
@@ -195,6 +203,7 @@ export async function handler(
       logger.error(
         i18n(`${i18nKey}.failure.invalidKey`, {
           account: uiAccountDescription(parentAccountId),
+          authCommand: uiCommandReference('hs auth personalaccesskey'),
         })
       );
     } else if (

--- a/commands/sandbox/delete.ts
+++ b/commands/sandbox/delete.ts
@@ -68,7 +68,7 @@ export async function handler(
     if (!accountPrompt) {
       logger.log('');
       logger.error(
-        i18n(`${i18nKey}.failure.noAccounts`, {
+        i18n(`${i18nKey}.failure.noSandboxAccounts`, {
           authCommand: uiCommandReference('hs auth'),
         })
       );

--- a/commands/sandbox/delete.ts
+++ b/commands/sandbox/delete.ts
@@ -26,7 +26,11 @@ import { deleteSandboxPrompt } from '../../lib/prompts/sandboxesPrompt';
 import { selectAccountFromConfig } from '../../lib/prompts/accountsPrompt';
 import { EXIT_CODES } from '../../lib/enums/exitCodes';
 import { promptUser } from '../../lib/prompts/promptUtils';
-import { uiAccountDescription, uiBetaTag } from '../../lib/ui';
+import {
+  uiAccountDescription,
+  uiBetaTag,
+  uiCommandReference,
+} from '../../lib/ui';
 import {
   CommonArgs,
   ConfigArgs,
@@ -59,6 +63,15 @@ export async function handler(
       // Account is required, throw error if force flag is present and no account is specified
       logger.log('');
       logger.error(i18n(`${i18nKey}.failure.noAccount`));
+      process.exit(EXIT_CODES.ERROR);
+    }
+    if (!accountPrompt) {
+      logger.log('');
+      logger.error(
+        i18n(`${i18nKey}.failure.noAccounts`, {
+          authCommand: uiCommandReference('hs auth'),
+        })
+      );
       process.exit(EXIT_CODES.ERROR);
     }
   }

--- a/commands/sandbox/delete.ts
+++ b/commands/sandbox/delete.ts
@@ -203,7 +203,7 @@ export async function handler(
       logger.error(
         i18n(`${i18nKey}.failure.invalidKey`, {
           account: uiAccountDescription(parentAccountId),
-          authCommand: uiCommandReference('hs auth personalaccesskey'),
+          authCommand: uiCommandReference('hs auth'),
         })
       );
     } else if (

--- a/commands/secret/__tests__/addSecret.test.ts
+++ b/commands/secret/__tests__/addSecret.test.ts
@@ -11,7 +11,7 @@ jest.mock('../../../lib/commonOpts');
 // Import this last so mocks apply
 import * as addSecretCommand from '../addSecret';
 
-describe('commands/account/clean', () => {
+describe('commands/secret/addSecret', () => {
   const yargsMock = yargs as Argv;
 
   describe('command', () => {

--- a/commands/secret/__tests__/addSecret.test.ts
+++ b/commands/secret/__tests__/addSecret.test.ts
@@ -4,12 +4,10 @@ import {
   addAccountOptions,
   addUseEnvironmentOptions,
 } from '../../../lib/commonOpts';
+import * as addSecretCommand from '../addSecret';
 
 jest.mock('yargs');
 jest.mock('../../../lib/commonOpts');
-
-// Import this last so mocks apply
-import * as addSecretCommand from '../addSecret';
 
 describe('commands/secret/addSecret', () => {
   const yargsMock = yargs as Argv;

--- a/commands/secret/__tests__/deleteSecret.test.ts
+++ b/commands/secret/__tests__/deleteSecret.test.ts
@@ -11,7 +11,7 @@ jest.mock('../../../lib/commonOpts');
 // Import this last so mocks apply
 import * as deleteSecretCommand from '../deleteSecret';
 
-describe('commands/account/clean', () => {
+describe('commands/secret/deleteSecret', () => {
   let yargsMock = yargs as Argv;
 
   beforeEach(() => {

--- a/commands/secret/__tests__/deleteSecret.test.ts
+++ b/commands/secret/__tests__/deleteSecret.test.ts
@@ -4,12 +4,10 @@ import {
   addAccountOptions,
   addUseEnvironmentOptions,
 } from '../../../lib/commonOpts';
+import * as deleteSecretCommand from '../deleteSecret';
 
 jest.mock('yargs');
 jest.mock('../../../lib/commonOpts');
-
-// Import this last so mocks apply
-import * as deleteSecretCommand from '../deleteSecret';
 
 describe('commands/secret/deleteSecret', () => {
   let yargsMock = yargs as Argv;

--- a/commands/secret/__tests__/listSecret.test.ts
+++ b/commands/secret/__tests__/listSecret.test.ts
@@ -4,12 +4,10 @@ import {
   addAccountOptions,
   addUseEnvironmentOptions,
 } from '../../../lib/commonOpts';
+import * as listSecretCommand from '../listSecret';
 
 jest.mock('yargs');
 jest.mock('../../../lib/commonOpts');
-
-// Import this last so mocks apply
-import * as listSecretCommand from '../listSecret';
 
 describe('commands/secret/listSecret', () => {
   const yargsMock = yargs as Argv;

--- a/commands/secret/__tests__/listSecret.test.ts
+++ b/commands/secret/__tests__/listSecret.test.ts
@@ -11,7 +11,7 @@ jest.mock('../../../lib/commonOpts');
 // Import this last so mocks apply
 import * as listSecretCommand from '../listSecret';
 
-describe('commands/account/clean', () => {
+describe('commands/secret/listSecret', () => {
   const yargsMock = yargs as Argv;
 
   describe('command', () => {

--- a/commands/secret/__tests__/updateSecret.test.ts
+++ b/commands/secret/__tests__/updateSecret.test.ts
@@ -4,12 +4,10 @@ import {
   addAccountOptions,
   addUseEnvironmentOptions,
 } from '../../../lib/commonOpts';
+import * as updateSecretCommand from '../updateSecret';
 
 jest.mock('yargs');
 jest.mock('../../../lib/commonOpts');
-
-// Import this last so mocks apply
-import * as updateSecretCommand from '../updateSecret';
 
 describe('commands/secret/updateSecret', () => {
   const yargsMock = yargs as Argv;

--- a/commands/secret/__tests__/updateSecret.test.ts
+++ b/commands/secret/__tests__/updateSecret.test.ts
@@ -11,7 +11,7 @@ jest.mock('../../../lib/commonOpts');
 // Import this last so mocks apply
 import * as updateSecretCommand from '../updateSecret';
 
-describe('commands/account/clean', () => {
+describe('commands/secret/updateSecret', () => {
   const yargsMock = yargs as Argv;
 
   describe('command', () => {

--- a/lang/en.lyaml
+++ b/lang/en.lyaml
@@ -833,10 +833,10 @@ en:
             noAccount: "No account specified. Specify an account by using the --account flag."
             noSandboxAccounts: "There are no sandboxes connected to the CLI. To add a sandbox, run {{ authCommand }}."
             noSandboxAccountId: "This sandbox can't be deleted from the CLI because we could not find the associated sandbox account."
-            noParentAccount: "This sandbox can't be deleted from the CLI because you haven't given the CLI access to its parent account. To do this, run {{#bold}}hs auth{{/bold}} and add the parent account."
+            noParentAccount: "This sandbox can't be deleted from the CLI because you haven't given the CLI access to its parent account. To do this, run {{ authCommand }} and add the parent account."
             objectNotFound: "Sandbox {{#bold}}{{ account }}{{/bold}} may have been deleted through the UI. The account has been removed from the config."
-            noParentPortalAvailable: "This sandbox can't be deleted from the CLI because you haven't given the CLI access to its parent account. To do this, run {{#bold}}{{ command }}{{/bold}}. You can also delete the sandbox from the HubSpot management tool: {{#bold}}{{ url }}{{/bold}}."
-            invalidKey: "Your personal access key for account {{#bold}}{{ account }}{{/bold}} is inactive. To re-authenticate, please run {{#bold}}hs auth personalaccesskey{{/bold}}."
+            noParentPortalAvailable: "This sandbox can't be deleted from the CLI because you haven't given the CLI access to its parent account. To do this, run {{ command }}. You can also delete the sandbox from the HubSpot management tool: {{#bold}}{{ url }}{{/bold}}."
+            invalidKey: "Your personal access key for account {{#bold}}{{ account }}{{/bold}} is inactive. To re-authenticate, please run {{ authCommand }}."
           options:
             force:
               describe: "Skips all confirmation prompts when deleting a sandbox account."

--- a/lang/en.lyaml
+++ b/lang/en.lyaml
@@ -831,6 +831,7 @@ en:
           failure:
             invalidUser: "Couldn't delete {{ accountName }} because your account has been removed from {{ parentAccountName }} or your permission set doesn't allow you to delete the sandbox. To update your permissions, contact a super admin in {{ parentAccountName }}."
             noAccount: "No account specified. Specify an account by using the --account flag."
+            cannotFindParentAccountId: "Cannot fetch your accounts to find the parent account associated with your sandbox account. Please try again..."
             noSandboxAccounts: "There are no sandboxes connected to the CLI. To add a sandbox, run {{#bold}}hs auth{{/bold}}."
             noParentAccount: "This sandbox can't be deleted from the CLI because you haven't given the CLI access to its parent account. To do this, run {{#bold}}hs auth{{/bold}} and add the parent account."
             objectNotFound: "Sandbox {{#bold}}{{ account }}{{/bold}} may have been deleted through the UI. The account has been removed from the config."

--- a/lang/en.lyaml
+++ b/lang/en.lyaml
@@ -833,8 +833,10 @@ en:
             noAccount: "No account specified. Specify an account by using the --account flag."
             cannotFindParentAccountId: "Cannot fetch your accounts to find the parent account associated with your sandbox account. Please try again..."
             noSandboxAccounts: "There are no sandboxes connected to the CLI. To add a sandbox, run {{#bold}}hs auth{{/bold}}."
+            noSandboxAccountId: "This sandbox can't be deleted from the CLI because we could not find the associated sandbox account."
             noParentAccount: "This sandbox can't be deleted from the CLI because you haven't given the CLI access to its parent account. To do this, run {{#bold}}hs auth{{/bold}} and add the parent account."
             objectNotFound: "Sandbox {{#bold}}{{ account }}{{/bold}} may have been deleted through the UI. The account has been removed from the config."
+            noParentAccountId: "This sandbox can't be deleted from the CLI because we could not find the associated parent account."
             noParentPortalAvailable: "This sandbox can't be deleted from the CLI because you haven't given the CLI access to its parent account. To do this, run {{#bold}}{{ command }}{{/bold}}. You can also delete the sandbox from the HubSpot management tool: {{#bold}}{{ url }}{{/bold}}."
             invalidKey: "Your personal access key for account {{#bold}}{{ account }}{{/bold}} is inactive. To re-authenticate, please run {{#bold}}hs auth personalaccesskey{{/bold}}."
           options:
@@ -1353,6 +1355,8 @@ en:
           message: "Choose the type of sandbox you want to create"
           developer: "Development sandbox (Includes production's object definitions)"
           standard: "Standard sandbox (Includes partial copy of production's assets)"
+        failure:
+          noSandboxAccounts:  "There are no sandboxes connected to the CLI. To add a sandbox, run {{ authCommand }}."
       uploadPrompt:
         enterDest: "Enter the destination path: "
         enterSrc: "Enter the source path: "

--- a/lang/en.lyaml
+++ b/lang/en.lyaml
@@ -831,7 +831,7 @@ en:
           failure:
             invalidUser: "Couldn't delete {{ accountName }} because your account has been removed from {{ parentAccountName }} or your permission set doesn't allow you to delete the sandbox. To update your permissions, contact a super admin in {{ parentAccountName }}."
             noAccount: "No account specified. Specify an account by using the --account flag."
-            noAccounts: "There are no sandbox accounts authorized for this CLI. To add a sandbox account, run {{ authCommand }}."
+            noSandboxAccounts: "There are no sandboxes connected to the CLI. To add a sandbox, run {{ authCommand }}."
             noSandboxAccountId: "This sandbox can't be deleted from the CLI because we could not find the associated sandbox account."
             noParentAccount: "This sandbox can't be deleted from the CLI because you haven't given the CLI access to its parent account. To do this, run {{#bold}}hs auth{{/bold}} and add the parent account."
             objectNotFound: "Sandbox {{#bold}}{{ account }}{{/bold}} may have been deleted through the UI. The account has been removed from the config."

--- a/lang/en.lyaml
+++ b/lang/en.lyaml
@@ -813,6 +813,8 @@ en:
             invalidAccountType: "Sandboxes must be created from a production account. Your current default account {{#bold}}{{ accountName }}{{/bold}} is a {{ accountType }}.
               \n- Run {{#bold}}hs accounts use{{/bold}} to switch to your default account to your production account.
               \n- Run {{#bold}}hs auth{{/bold}} to connect a production account to the HubSpot CLI.\n"
+            noAccountConfig: "There is no account associated with {{ accountId }} in the config file. Please choose another account and try again, or authenticate {{ accountId }} using {{ authCommand }}."
+            noSandboxAccountConfig: "There is no sandbox account associated with {{ accountId }} in the config file. Please try to re-authenticate your sandbox account using {{ authCommand}}."
         delete:
           describe: "Delete a sandbox account."
           debug:

--- a/lang/en.lyaml
+++ b/lang/en.lyaml
@@ -831,7 +831,6 @@ en:
           failure:
             invalidUser: "Couldn't delete {{ accountName }} because your account has been removed from {{ parentAccountName }} or your permission set doesn't allow you to delete the sandbox. To update your permissions, contact a super admin in {{ parentAccountName }}."
             noAccount: "No account specified. Specify an account by using the --account flag."
-            noSandboxAccounts: "There are no sandboxes connected to the CLI. To add a sandbox, run {{#bold}}hs auth{{/bold}}."
             noSandboxAccountId: "This sandbox can't be deleted from the CLI because we could not find the associated sandbox account."
             noParentAccount: "This sandbox can't be deleted from the CLI because you haven't given the CLI access to its parent account. To do this, run {{#bold}}hs auth{{/bold}} and add the parent account."
             objectNotFound: "Sandbox {{#bold}}{{ account }}{{/bold}} may have been deleted through the UI. The account has been removed from the config."
@@ -1353,8 +1352,6 @@ en:
           message: "Choose the type of sandbox you want to create"
           developer: "Development sandbox (Includes production's object definitions)"
           standard: "Standard sandbox (Includes partial copy of production's assets)"
-        failure:
-          noSandboxAccounts:  "There are no sandboxes connected to the CLI. To add a sandbox, run {{ authCommand }}."
       uploadPrompt:
         enterDest: "Enter the destination path: "
         enterSrc: "Enter the source path: "

--- a/lang/en.lyaml
+++ b/lang/en.lyaml
@@ -831,6 +831,7 @@ en:
           failure:
             invalidUser: "Couldn't delete {{ accountName }} because your account has been removed from {{ parentAccountName }} or your permission set doesn't allow you to delete the sandbox. To update your permissions, contact a super admin in {{ parentAccountName }}."
             noAccount: "No account specified. Specify an account by using the --account flag."
+            noAccounts: "There are no sandbox accounts authorized for this CLI. To add a sandbox account, run {{ authCommand }}."
             noSandboxAccountId: "This sandbox can't be deleted from the CLI because we could not find the associated sandbox account."
             noParentAccount: "This sandbox can't be deleted from the CLI because you haven't given the CLI access to its parent account. To do this, run {{#bold}}hs auth{{/bold}} and add the parent account."
             objectNotFound: "Sandbox {{#bold}}{{ account }}{{/bold}} may have been deleted through the UI. The account has been removed from the config."

--- a/lang/en.lyaml
+++ b/lang/en.lyaml
@@ -831,12 +831,10 @@ en:
           failure:
             invalidUser: "Couldn't delete {{ accountName }} because your account has been removed from {{ parentAccountName }} or your permission set doesn't allow you to delete the sandbox. To update your permissions, contact a super admin in {{ parentAccountName }}."
             noAccount: "No account specified. Specify an account by using the --account flag."
-            cannotFindParentAccountId: "Cannot fetch your accounts to find the parent account associated with your sandbox account. Please try again..."
             noSandboxAccounts: "There are no sandboxes connected to the CLI. To add a sandbox, run {{#bold}}hs auth{{/bold}}."
             noSandboxAccountId: "This sandbox can't be deleted from the CLI because we could not find the associated sandbox account."
             noParentAccount: "This sandbox can't be deleted from the CLI because you haven't given the CLI access to its parent account. To do this, run {{#bold}}hs auth{{/bold}} and add the parent account."
             objectNotFound: "Sandbox {{#bold}}{{ account }}{{/bold}} may have been deleted through the UI. The account has been removed from the config."
-            noParentAccountId: "This sandbox can't be deleted from the CLI because we could not find the associated parent account."
             noParentPortalAvailable: "This sandbox can't be deleted from the CLI because you haven't given the CLI access to its parent account. To do this, run {{#bold}}{{ command }}{{/bold}}. You can also delete the sandbox from the HubSpot management tool: {{#bold}}{{ url }}{{/bold}}."
             invalidKey: "Your personal access key for account {{#bold}}{{ account }}{{/bold}} is inactive. To re-authenticate, please run {{#bold}}hs auth personalaccesskey{{/bold}}."
           options:

--- a/lib/buildAccount.ts
+++ b/lib/buildAccount.ts
@@ -26,6 +26,7 @@ import { handleDeveloperTestAccountCreateError } from './developerTestAccounts';
 import { CLIAccount } from '@hubspot/local-dev-lib/types/Accounts';
 import { DeveloperTestAccount } from '@hubspot/local-dev-lib/types/developerTestAccounts';
 import { SandboxResponse } from '@hubspot/local-dev-lib/types/Sandbox';
+import { SandboxAccountType } from '../types/Sandboxes';
 
 export async function saveAccountToConfig(
   accountId: number | undefined,
@@ -149,10 +150,6 @@ export async function buildDeveloperTestAccount(
   return developerTestAccount;
 }
 
-type SandboxType =
-  | typeof HUBSPOT_ACCOUNT_TYPES.STANDARD_SANDBOX
-  | typeof HUBSPOT_ACCOUNT_TYPES.DEVELOPMENT_SANDBOX;
-
 type SandboxAccount = SandboxResponse & {
   name: string;
 };
@@ -160,7 +157,7 @@ type SandboxAccount = SandboxResponse & {
 export async function buildSandbox(
   sandboxName: string,
   parentAccountConfig: CLIAccount,
-  sandboxType: SandboxType,
+  sandboxType: SandboxAccountType,
   env: Environment,
   force = false
 ): Promise<SandboxAccount> {

--- a/lib/prompts/sandboxesPrompt.ts
+++ b/lib/prompts/sandboxesPrompt.ts
@@ -1,6 +1,6 @@
 import { promptUser } from './promptUtils';
 import { i18n } from '../lang';
-import { uiAccountDescription, uiCommandReference } from '../ui';
+import { uiAccountDescription } from '../ui';
 import { HUBSPOT_ACCOUNT_TYPES } from '@hubspot/local-dev-lib/constants/config';
 import { getAccountIdentifier } from '@hubspot/local-dev-lib/config/getAccountIdentifier';
 import { isSandbox } from '../accountTypes';
@@ -71,19 +71,13 @@ export async function sandboxTypePrompt(): Promise<SandboxTypePromptResponse> {
 
 export function deleteSandboxPrompt(
   promptParentAccount = false
-): Promise<DeleteSandboxPromptResponse> {
+): Promise<DeleteSandboxPromptResponse | undefined> {
   const accountsList = getConfigAccounts();
   const choices = promptParentAccount
     ? mapNonSandboxAccountChoices(accountsList)
     : mapSandboxAccountChoices(accountsList);
   if (!choices.length) {
-    return Promise.reject(
-      new Error(
-        i18n(`${i18nKey}.failure.noSandboxAccounts`, {
-          authCommand: uiCommandReference('hs auth'),
-        })
-      )
-    );
+    return Promise.resolve(undefined);
   }
   return promptUser<DeleteSandboxPromptResponse>([
     {

--- a/lib/prompts/sandboxesPrompt.ts
+++ b/lib/prompts/sandboxesPrompt.ts
@@ -10,11 +10,12 @@ import {
 } from '@hubspot/local-dev-lib/config';
 import { CLIAccount } from '@hubspot/local-dev-lib/types/Accounts';
 import { PromptChoices } from '../../types/Prompts';
+import { SandboxAccountType } from '../../types/Sandboxes';
 
 const i18nKey = 'lib.prompts.sandboxesPrompt';
 
 type SandboxTypePromptResponse = {
-  type: string;
+  type: SandboxAccountType;
 };
 
 type DeleteSandboxPromptResponse = {

--- a/lib/prompts/sandboxesPrompt.ts
+++ b/lib/prompts/sandboxesPrompt.ts
@@ -1,6 +1,6 @@
 import { promptUser } from './promptUtils';
 import { i18n } from '../lang';
-import { uiAccountDescription } from '../ui';
+import { uiAccountDescription, uiCommandReference } from '../ui';
 import { HUBSPOT_ACCOUNT_TYPES } from '@hubspot/local-dev-lib/constants/config';
 import { getAccountIdentifier } from '@hubspot/local-dev-lib/config/getAccountIdentifier';
 import { isSandbox } from '../accountTypes';
@@ -71,13 +71,19 @@ export async function sandboxTypePrompt(): Promise<SandboxTypePromptResponse> {
 
 export function deleteSandboxPrompt(
   promptParentAccount = false
-): Promise<DeleteSandboxPromptResponse> | void {
+): Promise<DeleteSandboxPromptResponse> {
   const accountsList = getConfigAccounts();
   const choices = promptParentAccount
     ? mapNonSandboxAccountChoices(accountsList)
     : mapSandboxAccountChoices(accountsList);
   if (!choices.length) {
-    return;
+    return Promise.reject(
+      new Error(
+        i18n(`${i18nKey}.failure.noSandboxAccounts`, {
+          authCommand: uiCommandReference('hs auth'),
+        })
+      )
+    );
   }
   return promptUser<DeleteSandboxPromptResponse>([
     {

--- a/lib/sandboxes.ts
+++ b/lib/sandboxes.ts
@@ -15,7 +15,7 @@ import { Environment } from '@hubspot/local-dev-lib/types/Config';
 import { i18n } from './lang';
 import { uiAccountDescription } from './ui';
 import { logError } from './errorHandlers/index';
-import { SandboxSyncTask } from '../types/Sandboxes';
+import { SandboxSyncTask, SandboxAccountType } from '../types/Sandboxes';
 
 const i18nKey = 'lib.sandbox';
 
@@ -23,12 +23,12 @@ export const SYNC_TYPES = {
   OBJECT_RECORDS: 'object-records',
 } as const;
 
-export const SANDBOX_TYPE_MAP = {
+export const SANDBOX_TYPE_MAP: { [key: string]: SandboxAccountType } = {
   dev: HUBSPOT_ACCOUNT_TYPES.DEVELOPMENT_SANDBOX,
   developer: HUBSPOT_ACCOUNT_TYPES.DEVELOPMENT_SANDBOX,
   development: HUBSPOT_ACCOUNT_TYPES.DEVELOPMENT_SANDBOX,
   standard: HUBSPOT_ACCOUNT_TYPES.STANDARD_SANDBOX,
-} as const;
+};
 
 export const SANDBOX_API_TYPE_MAP = {
   [HUBSPOT_ACCOUNT_TYPES.STANDARD_SANDBOX]: 1,

--- a/lib/ui/index.ts
+++ b/lib/ui/index.ts
@@ -89,7 +89,7 @@ export function uiCommandReference(command: string): string {
   );
 }
 
-export function uiFeatureHighlight(commands: string[], title: string): void {
+export function uiFeatureHighlight(commands: string[], title?: string): void {
   const i18nKey = 'lib.ui.featureHighlight';
 
   uiInfoSection(title ? title : i18n(`${i18nKey}.defaultTitle`), () => {

--- a/lib/ui/index.ts
+++ b/lib/ui/index.ts
@@ -119,7 +119,7 @@ export function uiBetaTag(message: string, log = true): string | undefined {
 
   if (log) {
     logger.log(result);
-    return undefined;
+    return;
   } else {
     return result;
   }

--- a/lib/ui/index.ts
+++ b/lib/ui/index.ts
@@ -107,7 +107,7 @@ export function uiFeatureHighlight(commands: string[], title?: string): void {
   });
 }
 
-export function uiBetaTag(message: string, log = true): void | string {
+export function uiBetaTag(message: string, log = true): string | undefined {
   const i18nKey = 'lib.ui';
 
   const terminalUISupport = getTerminalUISupport();
@@ -119,6 +119,7 @@ export function uiBetaTag(message: string, log = true): void | string {
 
   if (log) {
     logger.log(result);
+    return undefined;
   } else {
     return result;
   }

--- a/types/Sandboxes.ts
+++ b/types/Sandboxes.ts
@@ -1,3 +1,9 @@
+import { HUBSPOT_ACCOUNT_TYPES } from '@hubspot/local-dev-lib/constants/config';
+
 export type SandboxSyncTask = {
   type: string;
 };
+
+export type SandboxAccountType =
+  | typeof HUBSPOT_ACCOUNT_TYPES.STANDARD_SANDBOX
+  | typeof HUBSPOT_ACCOUNT_TYPES.DEVELOPMENT_SANDBOX;

--- a/types/Yargs.ts
+++ b/types/Yargs.ts
@@ -24,3 +24,7 @@ export type EnvironmentArgs = {
 export type StringArgType = Options & {
   type: 'string';
 };
+
+export type TestingArgs = {
+  qa?: boolean;
+};


### PR DESCRIPTION
## Description and Context
In this PR, I've converted the `sandbox` commands to TypeScript and added basic tests. I also corrected the names on the `hubdb` and `secret` tests which I wrote in previous PRs. 

#### Commands
- [x] `sandbox/create.ts`
- [x] `sandbox/delete.ts`

#### Bucket
- [x] `sandbox.ts`

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

- [x] Address feedback

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@brandenrodgers @camden11 @joe-yeager 
