### PR TITLE
chore: Convert `filemanager` commands to TypeScript

### DIFF
--- a/commands/__tests__/filemanager.test.ts
+++ b/commands/__tests__/filemanager.test.ts
@@ -1,6 +1,7 @@
 import yargs, { Argv } from 'yargs';
 import * as fetch from '../filemanager/fetch';
 import * as upload from '../filemanager/upload';
+import * as fileManagerCommands from '../filemanager';
 
 jest.mock('yargs');
 jest.mock('../filemanager/fetch');
@@ -13,9 +14,6 @@ const commandSpy = jest
 const demandCommandSpy = jest
   .spyOn(yargs as Argv, 'demandCommand')
   .mockReturnValue(yargs as Argv);
-
-// Import this last so mocks apply
-import * as fileManagerCommands from '../filemanager';
 
 describe('commands/filemanager', () => {
   describe('command', () => {

--- a/commands/__tests__/filemanager.test.ts
+++ b/commands/__tests__/filemanager.test.ts
@@ -1,52 +1,58 @@
-// @ts-nocheck
-import yargs from 'yargs';
-import upload from '../filemanager/upload';
-import fetch from '../filemanager/fetch';
+import yargs, { Argv } from 'yargs';
+import * as fetch from '../filemanager/fetch';
+import * as upload from '../filemanager/upload';
 
 jest.mock('yargs');
-jest.mock('../filemanager/upload');
 jest.mock('../filemanager/fetch');
+jest.mock('../filemanager/upload');
 jest.mock('../../lib/commonOpts');
-yargs.command.mockReturnValue(yargs);
-yargs.demandCommand.mockReturnValue(yargs);
+
+const commandSpy = jest
+  .spyOn(yargs as Argv, 'command')
+  .mockReturnValue(yargs as Argv);
+const demandCommandSpy = jest
+  .spyOn(yargs as Argv, 'demandCommand')
+  .mockReturnValue(yargs as Argv);
 
 // Import this last so mocks apply
-import filemanagerCommand from '../filemanager';
+import * as fileManagerCommands from '../filemanager';
 
 describe('commands/filemanager', () => {
   describe('command', () => {
     it('should have the correct command structure', () => {
-      expect(filemanagerCommand.command).toEqual('filemanager');
+      expect(fileManagerCommands.command).toEqual('filemanager');
     });
   });
 
   describe('describe', () => {
     it('should provide a description', () => {
-      expect(filemanagerCommand.describe).toBeDefined();
+      expect(fileManagerCommands.describe).toBeDefined();
     });
   });
 
   describe('builder', () => {
-    const subcommands = [
-      ['upload', upload],
-      ['fetch', fetch],
-    ];
+    beforeEach(() => {
+      commandSpy.mockClear();
+      demandCommandSpy.mockClear();
+    });
+
+    const subcommands = [fetch, upload];
 
     it('should demand the command takes one positional argument', () => {
-      filemanagerCommand.builder(yargs);
+      fileManagerCommands.builder(yargs as Argv);
 
-      expect(yargs.demandCommand).toHaveBeenCalledTimes(1);
-      expect(yargs.demandCommand).toHaveBeenCalledWith(1, '');
+      expect(demandCommandSpy).toHaveBeenCalledTimes(1);
+      expect(demandCommandSpy).toHaveBeenCalledWith(1, '');
     });
 
     it('should add the correct number of sub commands', () => {
-      filemanagerCommand.builder(yargs);
-      expect(yargs.command).toHaveBeenCalledTimes(subcommands.length);
+      fileManagerCommands.builder(yargs as Argv);
+      expect(commandSpy).toHaveBeenCalledTimes(subcommands.length);
     });
 
-    it.each(subcommands)('should attach the %s subcommand', (name, module) => {
-      filemanagerCommand.builder(yargs);
-      expect(yargs.command).toHaveBeenCalledWith(module);
+    it.each(subcommands)('should attach the %s subcommand', module => {
+      fileManagerCommands.builder(yargs as Argv);
+      expect(commandSpy).toHaveBeenCalledWith(module);
     });
   });
 });

--- a/commands/filemanager.ts
+++ b/commands/filemanager.ts
@@ -1,15 +1,16 @@
-// @ts-nocheck
-const upload = require('./filemanager/upload');
-const fetch = require('./filemanager/fetch');
-const { i18n } = require('../lib/lang');
+import { Argv } from 'yargs';
+
+import * as upload from './filemanager/upload';
+import * as fetch from './filemanager/fetch';
+import { i18n } from '../lib/lang';
 
 const i18nKey = 'commands.filemanager';
 
-exports.command = 'filemanager';
-exports.describe = i18n(`${i18nKey}.describe`);
+export const command = 'filemanager';
+export const describe = i18n(`${i18nKey}.describe`);
 
-exports.builder = yargs => {
+export function builder(yargs: Argv): Argv {
   yargs.command(upload).command(fetch).demandCommand(1, '');
 
   return yargs;
-};
+}

--- a/commands/filemanager/__tests__/fetch.test.ts
+++ b/commands/filemanager/__tests__/fetch.test.ts
@@ -1,0 +1,51 @@
+import yargs, { Argv } from 'yargs';
+import {
+  addGlobalOptions,
+  addConfigOptions,
+  addAccountOptions,
+  addOverwriteOptions,
+  addUseEnvironmentOptions,
+} from '../../../lib/commonOpts';
+
+jest.mock('yargs');
+jest.mock('../../../lib/commonOpts');
+
+// Import this last so mocks apply
+import * as fileManagerFetchCommand from '../fetch';
+
+describe('commands/filemanager/fetch', () => {
+  const yargsMock = yargs as Argv;
+
+  describe('command', () => {
+    it('should have the correct command structure', () => {
+      expect(fileManagerFetchCommand.command).toEqual('fetch <src> [dest]');
+    });
+  });
+
+  describe('describe', () => {
+    it('should provide a description', () => {
+      expect(fileManagerFetchCommand.describe).toBeDefined();
+    });
+  });
+
+  describe('builder', () => {
+    it('should support the correct options', () => {
+      fileManagerFetchCommand.builder(yargsMock);
+
+      expect(addGlobalOptions).toHaveBeenCalledTimes(1);
+      expect(addGlobalOptions).toHaveBeenCalledWith(yargsMock);
+
+      expect(addConfigOptions).toHaveBeenCalledTimes(1);
+      expect(addConfigOptions).toHaveBeenCalledWith(yargsMock);
+
+      expect(addAccountOptions).toHaveBeenCalledTimes(1);
+      expect(addAccountOptions).toHaveBeenCalledWith(yargsMock);
+
+      expect(addOverwriteOptions).toHaveBeenCalledTimes(1);
+      expect(addOverwriteOptions).toHaveBeenCalledWith(yargsMock);
+
+      expect(addUseEnvironmentOptions).toHaveBeenCalledTimes(1);
+      expect(addUseEnvironmentOptions).toHaveBeenCalledWith(yargsMock);
+    });
+  });
+});

--- a/commands/filemanager/__tests__/fetch.test.ts
+++ b/commands/filemanager/__tests__/fetch.test.ts
@@ -6,12 +6,10 @@ import {
   addOverwriteOptions,
   addUseEnvironmentOptions,
 } from '../../../lib/commonOpts';
+import * as fileManagerFetchCommand from '../fetch';
 
 jest.mock('yargs');
 jest.mock('../../../lib/commonOpts');
-
-// Import this last so mocks apply
-import * as fileManagerFetchCommand from '../fetch';
 
 describe('commands/filemanager/fetch', () => {
   const yargsMock = yargs as Argv;

--- a/commands/filemanager/__tests__/upload.test.ts
+++ b/commands/filemanager/__tests__/upload.test.ts
@@ -1,0 +1,47 @@
+import yargs, { Argv } from 'yargs';
+import {
+  addGlobalOptions,
+  addConfigOptions,
+  addAccountOptions,
+  addUseEnvironmentOptions,
+} from '../../../lib/commonOpts';
+
+jest.mock('yargs');
+jest.mock('../../../lib/commonOpts');
+
+// Import this last so mocks apply
+import * as fileManagerUploadCommand from '../upload';
+
+describe('commands/filemanager/upload', () => {
+  const yargsMock = yargs as Argv;
+
+  describe('command', () => {
+    it('should have the correct command structure', () => {
+      expect(fileManagerUploadCommand.command).toEqual('upload <src> <dest>');
+    });
+  });
+
+  describe('describe', () => {
+    it('should provide a description', () => {
+      expect(fileManagerUploadCommand.describe).toBeDefined();
+    });
+  });
+
+  describe('builder', () => {
+    it('should support the correct options', () => {
+      fileManagerUploadCommand.builder(yargsMock);
+
+      expect(addGlobalOptions).toHaveBeenCalledTimes(1);
+      expect(addGlobalOptions).toHaveBeenCalledWith(yargsMock);
+
+      expect(addConfigOptions).toHaveBeenCalledTimes(1);
+      expect(addConfigOptions).toHaveBeenCalledWith(yargsMock);
+
+      expect(addAccountOptions).toHaveBeenCalledTimes(1);
+      expect(addAccountOptions).toHaveBeenCalledWith(yargsMock);
+
+      expect(addUseEnvironmentOptions).toHaveBeenCalledTimes(1);
+      expect(addUseEnvironmentOptions).toHaveBeenCalledWith(yargsMock);
+    });
+  });
+});

--- a/commands/filemanager/__tests__/upload.test.ts
+++ b/commands/filemanager/__tests__/upload.test.ts
@@ -5,12 +5,10 @@ import {
   addAccountOptions,
   addUseEnvironmentOptions,
 } from '../../../lib/commonOpts';
+import * as fileManagerUploadCommand from '../upload';
 
 jest.mock('yargs');
 jest.mock('../../../lib/commonOpts');
-
-// Import this last so mocks apply
-import * as fileManagerUploadCommand from '../upload';
 
 describe('commands/filemanager/upload', () => {
   const yargsMock = yargs as Argv;

--- a/commands/filemanager/upload.ts
+++ b/commands/filemanager/upload.ts
@@ -1,34 +1,46 @@
-// @ts-nocheck
-const fs = require('fs');
-const path = require('path');
+import fs from 'fs';
+import path from 'path';
+import { Argv, ArgumentsCamelCase } from 'yargs';
 
-const { uploadFolder } = require('@hubspot/local-dev-lib/fileManager');
-const { uploadFile } = require('@hubspot/local-dev-lib/api/fileManager');
-const { getCwd, convertToUnixPath } = require('@hubspot/local-dev-lib/path');
-const { logger } = require('@hubspot/local-dev-lib/logger');
-const {
-  validateSrcAndDestPaths,
-} = require('@hubspot/local-dev-lib/cms/modules');
-const { shouldIgnoreFile } = require('@hubspot/local-dev-lib/ignoreRules');
+import { uploadFolder } from '@hubspot/local-dev-lib/fileManager';
+import { uploadFile } from '@hubspot/local-dev-lib/api/fileManager';
+import { getCwd, convertToUnixPath } from '@hubspot/local-dev-lib/path';
+import { logger } from '@hubspot/local-dev-lib/logger';
+import { validateSrcAndDestPaths } from '@hubspot/local-dev-lib/cms/modules';
+import { shouldIgnoreFile } from '@hubspot/local-dev-lib/ignoreRules';
 
-const { ApiErrorContext, logError } = require('../../lib/errorHandlers/index');
-const {
+import { ApiErrorContext, logError } from '../../lib/errorHandlers/index';
+import {
   addConfigOptions,
   addGlobalOptions,
   addAccountOptions,
   addUseEnvironmentOptions,
-} = require('../../lib/commonOpts');
-const { trackCommandUsage } = require('../../lib/usageTracking');
-const { i18n } = require('../../lib/lang');
+} from '../../lib/commonOpts';
+import { trackCommandUsage } from '../../lib/usageTracking';
+import { i18n } from '../../lib/lang';
+import { EXIT_CODES } from '../../lib/enums/exitCodes';
+import {
+  AccountArgs,
+  CommonArgs,
+  ConfigArgs,
+  EnvironmentArgs,
+} from '../../types/Yargs';
 
 const i18nKey = 'commands.filemanager.subcommands.upload';
-const { EXIT_CODES } = require('../../lib/enums/exitCodes');
 
-exports.command = 'upload <src> <dest>';
-exports.describe = i18n(`${i18nKey}.describe`);
+export const command = 'upload <src> <dest>';
+export const describe = i18n(`${i18nKey}.describe`);
 
-exports.handler = async options => {
-  const { src, dest, derivedAccountId } = options;
+type CombinedArgs = CommonArgs & ConfigArgs & AccountArgs & EnvironmentArgs;
+type FileManagerUploadArgs = CombinedArgs & {
+  src: string;
+  dest: string;
+};
+
+export async function handler(
+  args: ArgumentsCamelCase<FileManagerUploadArgs>
+): Promise<void> {
+  const { src, dest, derivedAccountId } = args;
 
   const absoluteSrcPath = path.resolve(getCwd(), src);
 
@@ -131,9 +143,9 @@ exports.handler = async options => {
         });
       });
   }
-};
+}
 
-exports.builder = yargs => {
+export function builder(yargs: Argv): Argv<FileManagerUploadArgs> {
   addGlobalOptions(yargs);
   addConfigOptions(yargs);
   addAccountOptions(yargs);
@@ -147,4 +159,6 @@ exports.builder = yargs => {
     describe: i18n(`${i18nKey}.positionals.dest.describe`),
     type: 'string',
   });
-};
+
+  return yargs as Argv<FileManagerUploadArgs>;
+}

--- a/types/Yargs.ts
+++ b/types/Yargs.ts
@@ -21,6 +21,11 @@ export type EnvironmentArgs = {
   'use-env'?: string;
 };
 
+export type OverwriteArgs = Options & {
+  o?: boolean;
+  overwrite?: boolean;
+};
+
 export type StringArgType = Options & {
   type: 'string';
 };


### PR DESCRIPTION
## Description and Context
In this PR, I've converted the `filemanager` commands to TypeScript and added basic tests.

Commands

-  filemanager/fetch.ts
-  filemanager/upload.ts

Bucket

-  filemanager.ts

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

- [ ] Address feedback 

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@brandenrodgers @camden11 @joe-yeager 
