### PR TITLE
Surface httpUseLocalhost in the hs doctor check

### DIFF
--- a/lang/en.lyaml
+++ b/lang/en.lyaml
@@ -1573,7 +1573,7 @@ en:
           noConfigFile: "CLI configuration not found"
           noConfigFileSecondary: "Run {{command}} and follow the prompts to create your CLI configuration file and connect it to your HubSpot account"
           settings:
-            httpUseLocalhost: "The setting {{#bold}}httpUseLocalhost{{/bold}} is set to true"
+            httpUseLocalhost: "The setting {{#bold}}httpUseLocalhost{{/bold}} is enabled"
             httpUseLocalhostSecondary: "This setting causes all CLI requests to route to localhost"
         projectConfig:
           header: "Project configuration"

--- a/lang/en.lyaml
+++ b/lang/en.lyaml
@@ -1572,6 +1572,9 @@ en:
           defaultAccountSubHeader: "Default Account: {{accountDetails}}"
           noConfigFile: "CLI configuration not found"
           noConfigFileSecondary: "Run {{command}} and follow the prompts to create your CLI configuration file and connect it to your HubSpot account"
+          settings:
+            httpUseLocalhost: "The setting {{#bold}}httpUseLocalhost{{/bold}} is set to true"
+            httpUseLocalhostSecondary: "This setting causes all CLI requests to route to localhost"
         projectConfig:
           header: "Project configuration"
           projectDirSubHeader: "Project dir: {{#bold}}{{ projectDir }}{{/bold}}"

--- a/lib/doctor/DiagnosticInfoBuilder.ts
+++ b/lib/doctor/DiagnosticInfoBuilder.ts
@@ -39,7 +39,7 @@ export interface DiagnosticInfo extends FilesInfo {
   path?: string;
   versions: { [hubspotCli]: string; node: string; npm: string | null };
   config: string | null;
-  configSettings: Record<string, unknown>;
+  configSettings: { [key: string]: unknown };
   project: {
     details?: Project;
     config?: ProjectConfig;

--- a/lib/doctor/DiagnosticInfoBuilder.ts
+++ b/lib/doctor/DiagnosticInfoBuilder.ts
@@ -10,7 +10,10 @@ import {
   AuthType,
 } from '@hubspot/local-dev-lib/types/Accounts';
 import { Project } from '@hubspot/local-dev-lib/types/Project';
-import { getAccountId } from '@hubspot/local-dev-lib/config';
+import {
+  getAccountId,
+  isConfigFlagEnabled,
+} from '@hubspot/local-dev-lib/config';
 import { getAccountConfig, getConfigPath } from '@hubspot/local-dev-lib/config';
 import { getAccessToken } from '@hubspot/local-dev-lib/personalAccessKey';
 import { walk } from '@hubspot/local-dev-lib/fs';
@@ -36,6 +39,7 @@ export interface DiagnosticInfo extends FilesInfo {
   path?: string;
   versions: { [hubspotCli]: string; node: string; npm: string | null };
   config: string | null;
+  configSettings: Record<string, unknown>;
   project: {
     details?: Project;
     config?: ProjectConfig;
@@ -66,6 +70,7 @@ const configFiles = [
 
 export class DiagnosticInfoBuilder {
   accountId: number | null;
+  readonly configSettings: { [key: string]: unknown };
   readonly env?: Environment;
   readonly authType?: AuthType;
   readonly accountType?: AccountType;
@@ -79,6 +84,9 @@ export class DiagnosticInfoBuilder {
   constructor(processInfo: NodeJS.Process) {
     this.accountId = getAccountId();
     const accountConfig = getAccountConfig(this.accountId!);
+    this.configSettings = {
+      httpUseLocalhost: isConfigFlagEnabled('httpUseLocalhost'),
+    };
     this.env = accountConfig?.env;
     this.authType = accountConfig?.authType;
     this.accountType = accountConfig?.accountType;
@@ -110,6 +118,7 @@ export class DiagnosticInfoBuilder {
       arch,
       path: mainModule?.path,
       config: getConfigPath(),
+      configSettings: this.configSettings,
       versions: {
         [hubspotCli]: pkg.version,
         node,

--- a/lib/doctor/Doctor.ts
+++ b/lib/doctor/Doctor.ts
@@ -72,6 +72,8 @@ export class Doctor {
       ...(this.projectConfig?.projectConfig ? this.performProjectChecks() : []),
     ]);
 
+    this.performCliConfigSettingsChecks();
+
     SpinniesManager.succeed('runningDiagnostics', {
       text: i18n(`${i18nKey}.diagnosticsComplete`),
       succeedColor: 'white',
@@ -113,7 +115,13 @@ export class Doctor {
         ),
       });
       return [];
-    } else if (this.diagnosticInfo?.configSettings.httpUseLocalhost) {
+    }
+
+    return [this.checkIfAccessTokenValid()];
+  }
+
+  private performCliConfigSettingsChecks(): void {
+    if (this.diagnosticInfo?.configSettings.httpUseLocalhost) {
       this.diagnosis?.addCLIConfigSection({
         type: 'warning',
         message: i18n(
@@ -124,7 +132,6 @@ export class Doctor {
         ),
       });
     }
-    return [this.checkIfAccessTokenValid()];
   }
 
   private async checkIfAccessTokenValid(): Promise<void> {

--- a/lib/doctor/Doctor.ts
+++ b/lib/doctor/Doctor.ts
@@ -113,6 +113,16 @@ export class Doctor {
         ),
       });
       return [];
+    } else if (this.diagnosticInfo?.configSettings.httpUseLocalhost) {
+      this.diagnosis?.addCLIConfigSection({
+        type: 'warning',
+        message: i18n(
+          `${i18nKey}.diagnosis.cliConfig.settings.httpUseLocalhost`
+        ),
+        secondaryMessaging: i18n(
+          `${i18nKey}.diagnosis.cliConfig.settings.httpUseLocalhostSecondary`
+        ),
+      });
     }
     return [this.checkIfAccessTokenValid()];
   }

--- a/lib/doctor/__tests__/Diagnosis.test.ts
+++ b/lib/doctor/__tests__/Diagnosis.test.ts
@@ -16,6 +16,7 @@ describe('lib/doctor/Diagnosis', () => {
     account: {},
     arch: process.arch,
     config: 'path/to/config.json',
+    configSettings: { httpUseLocalhost: false },
     configFiles: [],
     envFiles: [],
     files: [],

--- a/lib/doctor/__tests__/DiagnosticInfoBuilder.test.ts
+++ b/lib/doctor/__tests__/DiagnosticInfoBuilder.test.ts
@@ -19,6 +19,7 @@ import {
   getAccountId as _getAccountId,
   getAccountConfig as _getAccountConfig,
   getConfigPath as _getConfigPath,
+  isConfigFlagEnabled as _isConfigFlagEnabled,
 } from '@hubspot/local-dev-lib/config';
 import { getAccessToken as _getAccessToken } from '@hubspot/local-dev-lib/personalAccessKey';
 import { walk as _walk } from '@hubspot/local-dev-lib/fs';
@@ -42,7 +43,9 @@ const getAccountId = _getAccountId as jest.MockedFunction<typeof _getAccountId>;
 const getProjectConfig = _getProjectConfig as jest.MockedFunction<
   typeof _getProjectConfig
 >;
-
+const isConfigFlagEnabled = _isConfigFlagEnabled as jest.MockedFunction<
+  typeof _isConfigFlagEnabled
+>;
 const fetchProject = _fetchProject as jest.MockedFunction<typeof _fetchProject>;
 
 const utilPromisify = util.promisify as jest.MockedFunction<
@@ -91,6 +94,7 @@ describe('lib/doctor/DiagnosticInfo', () => {
     getAccountId.mockReturnValue(accountId);
     getAccountConfig.mockReturnValue(accountConfig);
     walk.mockResolvedValue(projectFiles);
+    isConfigFlagEnabled.mockReturnValue(false);
   });
 
   it('should initialize the required state on creation', () => {

--- a/lib/doctor/__tests__/Doctor.test.ts
+++ b/lib/doctor/__tests__/Doctor.test.ts
@@ -67,6 +67,7 @@ describe('lib/doctor/Doctor', () => {
     account: {},
     arch: 'x64',
     config: 'path/to/config',
+    configSettings: { httpUseLocalhost: false },
     configFiles: ['src/serverless.json'],
     diagnosis: '',
     envFiles: [],

--- a/lib/doctor/__tests__/__snapshots__/DiagnosticInfoBuilder.test.ts.snap
+++ b/lib/doctor/__tests__/__snapshots__/DiagnosticInfoBuilder.test.ts.snap
@@ -18,6 +18,9 @@ exports[`lib/doctor/DiagnosticInfo generateDiagnosticInfo should gather the requ
     "src/app/public-app.json",
     "src/app/app.functions/serverless.json",
   ],
+  "configSettings": {
+    "httpUseLocalhost": false,
+  },
   "envFiles": [
     "src/app/app.functions/.env",
   ],


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
This sets up the `hs doctor` command to be able to surface warnings when certain CLI settings are enabled. For now it's just surfacing a warning when `httpUseLocalhost` is true.

## Screenshots
<!-- Provide images of the before and after functionality -->
<img width="550" alt="image" src="https://github.com/user-attachments/assets/154ca57e-8e0a-4753-bcae-8133e7dee4ef" />

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
