### PR TITLE
Basic account selection for local dev

### DIFF
--- a/commands/project/dev/unifiedFlow.ts
+++ b/commands/project/dev/unifiedFlow.ts
@@ -64,10 +64,10 @@ export async function unifiedProjectDevFlow(
 
   // TODO Ideally this should require the user to target a Combined account
   // For now, check if the account is either developer or standard
-  const defaultAccountIsRecommendedType =
+  const derivedAccountIsRecommendedType =
     isAppDeveloperAccount(accountConfig) || isStandardAccount(accountConfig);
 
-  if (!defaultAccountIsRecommendedType) {
+  if (!derivedAccountIsRecommendedType) {
     logger.error(
       'You must target a Combined account to use Unified Apps Local Dev'
     );

--- a/commands/project/dev/unifiedFlow.ts
+++ b/commands/project/dev/unifiedFlow.ts
@@ -1,24 +1,31 @@
+import path from 'path';
+import util from 'util';
 import { ArgumentsCamelCase } from 'yargs';
-import { ProjectDevArgs } from '../../../types/Yargs';
-import { CLIAccount } from '@hubspot/local-dev-lib/types/Accounts';
-import { ProjectConfig } from '../../../types/Projects';
 import { logger } from '@hubspot/local-dev-lib/logger';
 import { isTranslationError } from '@hubspot/project-parsing-lib/src/lib/errors';
 import { translateForLocalDev } from '@hubspot/project-parsing-lib';
+import { CLIAccount } from '@hubspot/local-dev-lib/types/Accounts';
+import { getEnv, getConfigAccounts } from '@hubspot/local-dev-lib/config';
+import { getValidEnv } from '@hubspot/local-dev-lib/environment';
+import { ProjectDevArgs } from '../../../types/Yargs';
+import { ProjectConfig } from '../../../types/Projects';
 import { logError } from '../../../lib/errorHandlers';
 import { EXIT_CODES } from '../../../lib/enums/exitCodes';
-import path from 'path';
-import util from 'util';
 import { ensureProjectExists } from '../../../lib/projects';
 import {
   createInitialBuildForNewProject,
   createNewProjectForLocalDev,
+  useExistingDevTestAccount,
+  createDeveloperTestAccountForLocalDev,
 } from '../../../lib/localDev';
+import { selectDeveloperTestTargetAccountPrompt } from '../../../lib/prompts/projectDevTargetAccountPrompt';
 import SpinniesManager from '../../../lib/ui/SpinniesManager';
 import LocalDevManagerV2 from '../../../lib/LocalDevManagerV2';
-import { getEnv } from '@hubspot/local-dev-lib/config';
-import { getValidEnv } from '@hubspot/local-dev-lib/environment';
 import { handleExit } from '../../../lib/process';
+import {
+  isAppDeveloperAccount,
+  isStandardAccount,
+} from '../../../lib/accountTypes';
 
 export async function unifiedProjectDevFlow(
   args: ArgumentsCamelCase<ProjectDevArgs>,
@@ -53,7 +60,47 @@ export async function unifiedProjectDevFlow(
 
   // @TODO: Check if there are runnable components and exit if not
 
-  // @TODO: Add account selection logic
+  const accounts = getConfigAccounts();
+
+  // TODO ideally this should require the user to target a Combined account
+  const defaultAccountIsRecommendedType =
+    isAppDeveloperAccount(accountConfig) || isStandardAccount(accountConfig);
+
+  if (!defaultAccountIsRecommendedType) {
+    logger.error(
+      'You must target a Combined account to use Unified Apps Local Dev'
+    );
+    process.exit(EXIT_CODES.ERROR);
+  }
+
+  let targetTestingAccountId = null;
+  let createNewDeveloperTestAccount = false;
+
+  const devAccountPromptResponse = await selectDeveloperTestTargetAccountPrompt(
+    accounts!,
+    accountConfig
+  );
+
+  targetTestingAccountId = devAccountPromptResponse.targetAccountId;
+  createNewDeveloperTestAccount = devAccountPromptResponse.createNestedAccount;
+
+  // When the developer test account isn't in the CLI config yet
+  if (!!devAccountPromptResponse.notInConfigAccount) {
+    await useExistingDevTestAccount(
+      env,
+      devAccountPromptResponse.notInConfigAccount
+    );
+  }
+
+  if (createNewDeveloperTestAccount) {
+    targetTestingAccountId = await createDeveloperTestAccountForLocalDev(
+      targetAccountId,
+      accountConfig,
+      env
+    );
+  }
+
+  console.log('targetTestingAccountId: ', targetTestingAccountId);
 
   // Check if project exists in HubSpot
   const { projectExists, project: uploadedProject } = await ensureProjectExists(

--- a/commands/project/dev/unifiedFlow.ts
+++ b/commands/project/dev/unifiedFlow.ts
@@ -144,6 +144,7 @@ export async function unifiedProjectDevFlow(
     deployedBuild,
     isGithubLinked,
     targetAccountId,
+    targetTestingAccountId: targetTestingAccountId!,
     projectConfig,
     projectDir,
     projectId: project.id,

--- a/lib/LocalDevManagerV2.ts
+++ b/lib/LocalDevManagerV2.ts
@@ -52,6 +52,7 @@ const i18nKey = 'lib.LocalDevManager';
 
 type LocalDevManagerConstructorOptions = {
   targetAccountId: number;
+  targetTestingAccountId: number;
   projectConfig: ProjectConfig;
   projectDir: string;
   projectId: number;
@@ -64,6 +65,7 @@ type LocalDevManagerConstructorOptions = {
 
 class LocalDevManagerV2 {
   targetAccountId: number;
+  targetTestingAccountId: number;
   projectConfig: ProjectConfig;
   projectDir: string;
   projectId: number;
@@ -82,6 +84,7 @@ class LocalDevManagerV2 {
 
   constructor(options: LocalDevManagerConstructorOptions) {
     this.targetAccountId = options.targetAccountId;
+    this.targetTestingAccountId = options.targetTestingAccountId;
     this.projectConfig = options.projectConfig;
     this.projectDir = options.projectDir;
     this.projectId = options.projectId;
@@ -498,7 +501,7 @@ class LocalDevManagerV2 {
       await DevServerManagerV2.setup({
         components: this.components,
         onUploadRequired: this.logUploadWarning.bind(this),
-        accountId: this.targetAccountId,
+        accountId: this.targetTestingAccountId,
         setActiveApp: this.setActiveApp.bind(this),
       });
       return true;
@@ -519,7 +522,7 @@ class LocalDevManagerV2 {
   async devServerStart(): Promise<void> {
     try {
       await DevServerManagerV2.start({
-        accountId: this.targetAccountId,
+        accountId: this.targetTestingAccountId,
         projectConfig: this.projectConfig,
       });
     } catch (e) {


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
This adds a basic account selection flow to the local dev process. It fetches the list of available developer test accounts, and always assumes that local development should happen on one of them. The flow goes something like this:
- Make sure the target account is either a developer account or a standard account.
- Prompt the user to select or create a developer test account associated with the parent account
- Pass that target test account ID to the local dev manager

## Screenshots
<!-- Provide images of the before and after functionality -->

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
