### PR TITLE
Update middleware for config revamp

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -7,12 +7,12 @@ const chalk = require('chalk');
 const { logger } = require('@hubspot/local-dev-lib/logger');
 const { addUserAgentHeader } = require('@hubspot/local-dev-lib/http');
 const {
-  loadConfig,
-  getAccountId,
-  configFileExists,
-  getConfigPath,
-  validateConfig,
+  globalConfigFileExists,
+  getConfigFilePath,
+  isConfigValid,
+  getConfigAccountIfExists,
 } = require('@hubspot/local-dev-lib/config');
+import { ENVIRONMENT_VARIABLES } from '@hubspot/local-dev-lib/constants/config';
 const { logError } = require('../lib/errorHandlers/index');
 const { setLogLevel, getCommandName } = require('../lib/commonOpts');
 const { validateAccount } = require('../lib/validation');
@@ -183,30 +183,62 @@ const handleDeprecatedEnvVariables = options => {
   ) {
     uiDeprecatedTag(
       i18n(`${i18nKey}.handleDeprecatedEnvVariables.portalEnvVarDeprecated`, {
-        configPath: getConfigPath(),
+        configPath: getConfigFilePath(),
       })
     );
     process.env.HUBSPOT_ACCOUNT_ID = process.env.HUBSPOT_PORTAL_ID;
   }
 };
 
+function addConfigEnvironmentVariablesMiddleware(options) {
+  const { useEnv, config } = options;
+
+  if (useEnv) {
+    process.env[ENVIRONMENT_VARIABLES.USE_ENVIRONMENT_HUBSPOT_CONFIG] = true;
+  }
+
+  if (config) {
+    process.env[ENVIRONMENT_VARIABLES.HUBSPOT_CONFIG_PATH] = config;
+  }
+}
+
 /**
  * Auto-injects the derivedAccountId flag into all commands
  */
 const injectAccountIdMiddleware = async options => {
-  const { account } = options;
+  const { account: accountOption } = options;
 
   // Preserves the original --account flag for certain commands.
-  options.providedAccountId = account;
+  options.providedAccountId = accountOption;
 
-  if (options.useEnv && process.env.HUBSPOT_ACCOUNT_ID) {
-    options.derivedAccountId = parseInt(process.env.HUBSPOT_ACCOUNT_ID, 10);
-  } else {
-    options.derivedAccountId = getAccountId(account);
+  // Check environment variables for accountId
+  if (options.useEnv && process.env[ENVIRONMENT_VARIABLES.HUBSPOT_ACCOUNT_ID]) {
+    options.derivedAccountId = parseInt(
+      process.env[ENVIRONMENT_VARIABLES.HUBSPOT_ACCOUNT_ID],
+      10
+    );
+    return;
   }
+
+  // If not using environment variables, check if provided account exists
+  if (accountOption) {
+    const account = getConfigAccountIfExists(accountOption);
+    if (account) {
+      options.derivedAccountId = account.accountId;
+    } else {
+      logger.error('@TODO Provided account does not exist');
+      process.exit(EXIT_CODES.ERROR);
+    }
+  }
+
+  // If no provided account or environment variable, use the default account
+  try {
+    const defaultAccount = getConfigDefaultAccount();
+    options.derivedAccountId = defaultAccount.accountId;
+  } catch (e) {}
 };
 
-const loadConfigMiddleware = async options => {
+const validateConfigMiddleware = async options => {
   // Skip this when no command is provided
   if (!options._.length) {
     return;
@@ -215,24 +247,21 @@ const loadConfigMiddleware = async options => {
   const maybeValidateConfig = () => {
     if (
       !isTargetedCommand(options, SKIP_CONFIG_VALIDATION) &&
-      !validateConfig()
+      !isConfigValid()
     ) {
       process.exit(EXIT_CODES.ERROR);
     }
   };
 
-  if (configFileExists(true) && options.config) {
+  if (globalConfigFileExists() && options.config) {
     logger.error(
       i18n(`${i18nKey}.loadConfigMiddleware.configFileExists`, {
-        configPath: getConfigPath(),
+        configPath: getConfigFilePath(),
       })
     );
     process.exit(EXIT_CODES.ERROR);
   } else if (!isTargetedCommand(options, { init: { target: true } })) {
-    const { config: configPath } = options;
-    const config = loadConfig(configPath, options);
-
-    // We don't run validateConfig() for auth because users should be able to run it when
+    // We don't run isConfigValid() for auth because users should be able to run it when
     // no accounts are configured, but we still want to exit if the config file is not found
     if (isTargetedCommand(options, { auth: { target: true } }) && !config) {
       process.exit(EXIT_CODES.ERROR);
@@ -294,12 +323,12 @@ const validateAccountOptions = async options => {
 
 const argv = yargs
   .usage('The command line interface to interact with HubSpot.')
-  // loadConfigMiddleware loads the new hidden config for all commands
   .middleware([
     setLogLevel,
     setRequestHeaders,
+    addConfigEnvironmentVariablesMiddleware,
     handleDeprecatedEnvVariables,
-    loadConfigMiddleware,
+    validateConfigMiddleware,
     injectAccountIdMiddleware,
     checkAndWarnGitInclusionMiddleware,
     validateAccountOptions,

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -237,10 +237,12 @@ const injectAccountIdMiddleware = async options => {
   }
 
   // If no provided account or environment variable, use the default account
-  try {
-    const defaultAccount = getConfigDefaultAccount();
-    options.derivedAccountId = defaultAccount.accountId;
-  } catch (e) {}
+  if (!options.derivedAccountId) {
+    try {
+      const defaultAccount = getConfigDefaultAccount();
+      options.derivedAccountId = defaultAccount.accountId;
+    } catch (e) {}
+  }
 };
 
 const validateConfigMiddleware = async options => {

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -226,7 +226,12 @@ const injectAccountIdMiddleware = async options => {
     if (account) {
       options.derivedAccountId = account.accountId;
     } else {
-      logger.error('@TODO Provided account does not exist');
+      logger.error(
+        i18n(`${i18nKey}.injectAccountIdMiddleware.accountNotFound`, {
+          accountIdentifier: accountOption,
+          authCommand: uiCommandReference('{authCommand}'),
+        })
+      );
       process.exit(EXIT_CODES.ERROR);
     }
   }

--- a/lang/en.lyaml
+++ b/lang/en.lyaml
@@ -11,6 +11,8 @@ en:
         portalEnvVarDeprecated: "The HUBSPOT_PORTAL_ID environment variable is deprecated. Please use HUBSPOT_ACCOUNT_ID instead."
       loadConfigMiddleware:
         configFileExists: "A configuration file already exists at {{ configPath }}. To specify a new configuration file, delete the existing one and try again."
+      injectAccountIdMiddleware:
+        accountNotFound: "An account with the provided identifier {{ accountIdentifier }} was not found in your config. Run {{ authCommand }} to add a new account to your config."
     completion:
       describe: "Enable bash completion shortcuts for commands. Concat the generated script to your .bashrc, .bash_profile, or .zshrc file."
       examples:


### PR DESCRIPTION
## Description and Context
This updates `bin/cli.js` with the new config methods from `local-dev-lib`, and makes a few other changes
* Sets environment variables when `use-env` and `config` flags so that LDL is aware of these settings
* Updates the `injectAccountIdMiddleware` to exit with a helpful message if the user provides an account ID that doesn't exist in their config. Right now this still fails, but the missing accountId goes uncaught until the `http` module tries to use it.

## TODO
We'll have to thoroughly test these changes, but won't be able to do that until the rest of the updates are made

## Who to Notify
@brandenrodgers @kemmerle @joe-yeager 
