### PR TITLE
Adding context on how to run project commands

### DIFF
--- a/commands/project/create.ts
+++ b/commands/project/create.ts
@@ -136,6 +136,8 @@ exports.handler = async options => {
   logger.log('');
   logger.log(chalk.bold(i18n(`${i18nKey}.logs.welcomeMessage`)));
   uiFeatureHighlight([
+    'projectCommandTip',
+    'projectUploadCommand',
     'projectDevCommand',
     'projectHelpCommand',
     'feedbackCommand',

--- a/lang/en.lyaml
+++ b/lang/en.lyaml
@@ -540,7 +540,6 @@ en:
           logs:
             success: "Project {{#bold}}{{ projectName }}{{/bold}} was successfully created in {{ projectDest }}"
             welcomeMessage: "Welcome to HubSpot Developer Projects!"
-            navigateToProject: "Navigate into your new project directory to get started"
           examples:
             default: "Create a new project"
             templateSource: "Create a new project from a custom GitHub repository. The repository must contain a valid project template and a config.json file defining the available templates"

--- a/lang/en.lyaml
+++ b/lang/en.lyaml
@@ -540,6 +540,7 @@ en:
           logs:
             success: "Project {{#bold}}{{ projectName }}{{/bold}} was successfully created in {{ projectDest }}"
             welcomeMessage: "Welcome to HubSpot Developer Projects!"
+            navigateToProject: "Navigate into your new project directory to get started"
           examples:
             default: "Create a new project"
             templateSource: "Create a new project from a custom GitHub repository. The repository must contain a valid project template and a config.json file defining the available templates"
@@ -1174,7 +1175,7 @@ en:
       disabledUrlText: "See all HubSpot CLI commands here."
       featureHighlight:
         defaultTitle: "What's next?"
-        commandKeys:
+        featureKeys:
           accountOption:
             command: "--account"
             message: "Use the {{ command }} option with any command to override the default account"
@@ -1204,10 +1205,12 @@ en:
             message: "Run {{ command }} to learn more about available project commands"
           projectUploadCommand:
             command: "hs project upload"
-            message: "Run {{ command }} to upload your project to HubSpot and trigger builds"
+            message: "Run {{ command }} to upload your project to your HubSpot account"
           projectDevCommand:
             command: "hs project dev"
             message: "Run {{ command }} to set up your test environment and start local development"
+          projectCommandTip:
+            message: "Tip: All project commands must be run from within a project directory"
           sampleProjects:
             linkText: "HubSpot's sample projects"
             url: "https://developers.hubspot.com/docs/platform/sample-projects?utm_source=cli&utm_content=project_create_whats_next"

--- a/lib/ui/index.ts
+++ b/lib/ui/index.ts
@@ -89,15 +89,15 @@ export function uiCommandReference(command: string): string {
   );
 }
 
-export function uiFeatureHighlight(commands: string[], title?: string): void {
+export function uiFeatureHighlight(features: string[], title?: string): void {
   const i18nKey = 'lib.ui.featureHighlight';
 
   uiInfoSection(title ? title : i18n(`${i18nKey}.defaultTitle`), () => {
-    commands.forEach((c, i) => {
-      const commandKey = `${i18nKey}.commandKeys.${c}`;
-      const message = i18n(`${commandKey}.message`, {
-        command: uiCommandReference(i18n(`${commandKey}.command`)),
-        link: uiLink(i18n(`${commandKey}.linkText`), i18n(`${commandKey}.url`)),
+    features.forEach((c, i) => {
+      const featureKey = `${i18nKey}.featureKeys.${c}`;
+      const message = i18n(`${featureKey}.message`, {
+        command: uiCommandReference(i18n(`${featureKey}.command`)),
+        link: uiLink(i18n(`${featureKey}.linkText`), i18n(`${featureKey}.url`)),
       });
       if (i !== 0) {
         logger.log('');


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
We've seen a couple cases where users aren't aware that they need to CD into the project directory before running the project commands. This adds a tip to the top of the "what's next" section that tells the users where to run the project commands from.

It also adds a section to explain what `hs project upload` does. IMO we should add that because it's an important command.

## Screenshots
<!-- Provide images of the before and after functionality -->
<img width="612" alt="image" src="https://github.com/user-attachments/assets/54936fb8-a9e9-41e8-b2db-b72703c12945" />

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
