### PR TITLE
Refactor `hs account remove` and `hs account clean` commands for default account override

### DIFF
--- a/commands/account/clean.ts
+++ b/commands/account/clean.ts
@@ -116,21 +116,19 @@ export async function handler(
 
     const accountOverride = getCWDAccountOverride();
     const overrideFilePath = getDefaultAccountOverrideFilePath();
-    if (overrideFilePath && accountOverride) {
-      if (
-        accountsToRemove.some(
-          account =>
-            account.name === accountOverride ||
-            // @ts-ignore: Default account override files can only exist with global config
-            account.accountId === accountOverride
-        )
-      ) {
-        promptMessage =
-          promptMessage +
-          i18n(`${i18nKey}.defaultAccountOverride`, {
-            overrideFilePath,
-          });
-      }
+    const accountOverrideMatches = accountsToRemove.some(
+      account =>
+        account.name === accountOverride ||
+        // @ts-expect-error: Default account override files can only exist with global config
+        account.accountId === accountOverride
+    );
+    if (overrideFilePath && accountOverride && accountOverrideMatches) {
+      promptMessage = `${promptMessage}${i18n(
+        `${i18nKey}.defaultAccountOverride`,
+        {
+          overrideFilePath,
+        }
+      )}`;
     }
 
     const { accountsCleanPrompt } = await promptUser([

--- a/commands/account/clean.ts
+++ b/commands/account/clean.ts
@@ -120,6 +120,7 @@ export async function handler(
       if (
         accountsToRemove.some(
           account =>
+            account.name === accountOverride ||
             // @ts-ignore: Default account override files can only exist with global config
             account.accountId === accountOverride
         )

--- a/commands/account/remove.ts
+++ b/commands/account/remove.ts
@@ -1,3 +1,4 @@
+import fs from 'fs';
 import { Argv, ArgumentsCamelCase } from 'yargs';
 import { logger } from '@hubspot/local-dev-lib/logger';
 import {
@@ -7,9 +8,14 @@ import {
   getConfigDefaultAccount,
   getAccountId,
   updateDefaultAccount,
+  getCWDAccountOverride,
+  getDefaultAccountOverrideFilePath,
 } from '@hubspot/local-dev-lib/config';
+
 import { trackCommandUsage } from '../../lib/usageTracking';
 import { i18n } from '../../lib/lang';
+import { promptUser } from '../../lib/prompts/promptUtils';
+import { logError } from '../../lib/errorHandlers';
 import { selectAccountFromConfig } from '../../lib/prompts/accountsPrompt';
 import { addConfigOptions } from '../../lib/commonOpts';
 import { CommonArgs, ConfigArgs } from '../../types/Yargs';
@@ -52,6 +58,30 @@ export async function handler(
   );
 
   const currentDefaultAccount = getConfigDefaultAccount();
+
+  const accountOverride = getCWDAccountOverride();
+  const overrideFilePath = getDefaultAccountOverrideFilePath();
+  if (
+    overrideFilePath &&
+    accountOverride &&
+    accountOverride === accountToRemove
+  ) {
+    const { deleteOverrideFile } = await promptUser({
+      type: 'confirm',
+      name: 'deleteOverrideFile',
+      message: i18n(`${i18nKey}.prompts.deleteOverrideFile`, {
+        overrideFilePath,
+        accountName: accountToRemove,
+      }),
+    });
+    try {
+      if (deleteOverrideFile) {
+        fs.unlinkSync(overrideFilePath);
+      }
+    } catch (error) {
+      logError(error);
+    }
+  }
 
   await deleteAccount(accountToRemove);
   logger.success(

--- a/lang/en.lyaml
+++ b/lang/en.lyaml
@@ -82,6 +82,7 @@ en:
           logs:
             replaceDefaultAccount: "The removed account was the default account."
           prompts:
+            deleteOverrideFile: "Delete the override file ({{ overrideFilePath }}) associated with {{ accountName }}?"
             selectAccountToRemove: "Select an account to remove from the config"
           errors:
             accountNotFound: "The account \"{{ specifiedAccount }}\" could not be found in {{ configPath }}"
@@ -117,6 +118,7 @@ en:
             one: "Remove 1 inactive account from the CLI config?"
             other: "Remove {{ count }} inactive accounts from the CLI config?"
           defaultAccountOverride: "\n(This will also delete the default account override file at {{ overrideFilePath }})"
+          replaceDefaultAccount: "The default account was removed."
           removeSuccess: "Removed {{ accountName }} from the CLI config."
     auth:
       describe: "Configure authentication for your HubSpot account. This will update the {{ configName }} file that stores your account information."

--- a/lang/en.lyaml
+++ b/lang/en.lyaml
@@ -116,6 +116,7 @@ en:
           confirm:
             one: "Remove 1 inactive account from the CLI config?"
             other: "Remove {{ count }} inactive accounts from the CLI config?"
+          defaultAccountOverride: "\n(This will also delete the default account override file at {{ overrideFilePath }})"
           removeSuccess: "Removed {{ accountName }} from the CLI config."
     auth:
       describe: "Configure authentication for your HubSpot account. This will update the {{ configName }} file that stores your account information."


### PR DESCRIPTION
## Description and Context
In this PR, I've refactored the `hs account remove` and `hs account clean` commands to work with the default account override files we've introduced as part of our config revamp. 

**Note** In `hs account clean`, I've also added a prompt to replace the default account if it's removed. This may be a breaking change, so I wanted to highlight it. 

## Screenshots
<!-- Provide images of the before and after functionality -->

`hs account clean` (with default account override present and with prompt to replace default account):

<img width="1227" alt="Screenshot 2025-03-27 at 10 17 19 AM" src="https://github.com/user-attachments/assets/b4e34ab2-31dd-4119-9f98-31a3c9060394" />

`hs account remove` (with default account override present):

<img width="1403" alt="Screenshot 2025-03-27 at 10 21 46 AM" src="https://github.com/user-attachments/assets/0b9456b2-bd73-4a0a-a1cd-5ebdaad68994" />

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

- [ ] Get OK from the team to add the prompt to update the default account.
- [ ] Get OK from Jono about the copy.

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@brandenrodgers @camden11 @joe-yeager 
