### PR TITLE
Update active install warning copy

### DIFF
--- a/lang/en.lyaml
+++ b/lang/en.lyaml
@@ -1083,10 +1083,10 @@ en:
         restartDev: "  * Re-run {{ command }}"
         pushToGithub: "  * Commit and push your changes to GitHub"
       activeInstallWarning:
-        installCount: "{{#bold}}The app {{ appName }} has {{ installCount }} production {{ installText }}{{/bold}}"
+        installCount: "{{#bold}}The app {{ appName }} is installed in {{ installCount }} {{ accountText }}{{/bold}}"
         explanation: "Some changes made during local development may need to be synced to HubSpot, which will impact those existing installs. We strongly recommend creating a copy of this app to use instead."
         confirmation: "You will always be asked to confirm any permanent changes to your app’s configuration before uploading them."
-        confirmationPrompt: "Proceed with local development of this {{#bold}}production{{/bold}} app?"
+        confirmationPrompt: "Proceed with local development of this app with existing installs?"
       devServer:
         cleanupError: "Failed to cleanup local dev server: {{ message }}"
         setupError: "Failed to setup local dev server: {{ message }}"

--- a/lib/LocalDevManager.ts
+++ b/lib/LocalDevManager.ts
@@ -182,8 +182,8 @@ class LocalDevManager {
       i18n(`${i18nKey}.activeInstallWarning.installCount`, {
         appName: this.activePublicAppData.name,
         installCount: this.publicAppActiveInstalls,
-        installText:
-          this.publicAppActiveInstalls === 1 ? 'install' : 'installs',
+        accountText:
+          this.publicAppActiveInstalls === 1 ? 'account' : 'accounts',
       })
     );
     logger.log(i18n(`${i18nKey}.activeInstallWarning.explanation`));

--- a/lib/LocalDevManagerV2.ts
+++ b/lib/LocalDevManagerV2.ts
@@ -181,8 +181,8 @@ class LocalDevManagerV2 {
       i18n(`${i18nKey}.activeInstallWarning.installCount`, {
         appName: this.activePublicAppData.name,
         installCount: this.publicAppActiveInstalls,
-        installText:
-          this.publicAppActiveInstalls === 1 ? 'install' : 'installs',
+        accountText:
+          this.publicAppActiveInstalls === 1 ? 'account' : 'accounts',
       })
     );
     logger.log(i18n(`${i18nKey}.activeInstallWarning.explanation`));


### PR DESCRIPTION
## Description and Context
The active install warning that shows up during local dev of public/marketplace apps made multiple reference to "production" apps, which is not terminology we use elsewhere. This updates it to hopefully be a bit clearer.

See https://git.hubteam.com/HubSpot/hubspot-cli-issues/issues/805

## Screenshots
Before
<img width="571" alt="Screenshot 2025-03-31 at 1 03 17 PM" src="https://github.com/user-attachments/assets/74bdcf0b-3354-448e-bd6c-2c4766513241" />


After
<img width="567" alt="Screenshot 2025-03-31 at 1 06 45 PM" src="https://github.com/user-attachments/assets/610bdf15-ec6e-43a6-b8b0-aaeeb2c70ff5" />

## Who to Notify
@brandenrodgers @kemmerle @joe-yeager @j0b0sapi3n 
