### PR TITLE
Bug fix: allow creation of projects in CWD + non project folders

### DIFF
--- a/lib/prompts/createProjectPrompt.ts
+++ b/lib/prompts/createProjectPrompt.ts
@@ -69,7 +69,12 @@ export async function createProjectPrompt(
         if (!input) {
           return i18n(`${i18nKey}.errors.destRequired`);
         }
-        if (fs.existsSync(input)) {
+        console.log('INPUT: ', path.resolve(getCwd(), input));
+        console.log('CWD: ', getCwd());
+        if (
+          fs.existsSync(input) &&
+          path.resolve(getCwd(), input) !== getCwd()
+        ) {
           return i18n(`${i18nKey}.errors.invalidDest`);
         }
         if (!isValidPath(input)) {

--- a/lib/prompts/createProjectPrompt.ts
+++ b/lib/prompts/createProjectPrompt.ts
@@ -9,8 +9,23 @@ import {
 import { promptUser } from './promptUtils';
 import { i18n } from '../lang';
 import { ProjectTemplate } from '../../types/Projects';
-
+import { PROJECT_CONFIG_FILE } from '../constants';
 const i18nKey = 'lib.prompts.createProjectPrompt';
+
+function validateProjectDirectory(input?: string): string | boolean {
+  if (!input) {
+    return i18n(`${i18nKey}.errors.destRequired`);
+  }
+  if (
+    fs.existsSync(path.resolve(getCwd(), path.join(input, PROJECT_CONFIG_FILE)))
+  ) {
+    return i18n(`${i18nKey}.errors.invalidDest`);
+  }
+  if (!isValidPath(input)) {
+    return i18n(`${i18nKey}.errors.invalidCharacters`);
+  }
+  return true;
+}
 
 type CreateProjectPromptResponse = {
   name: string;
@@ -65,23 +80,7 @@ export async function createProjectPrompt(
         );
         return path.resolve(getCwd(), projectName);
       },
-      validate: (input?: string) => {
-        if (!input) {
-          return i18n(`${i18nKey}.errors.destRequired`);
-        }
-        console.log('INPUT: ', path.resolve(getCwd(), input));
-        console.log('CWD: ', getCwd());
-        if (
-          fs.existsSync(input) &&
-          path.resolve(getCwd(), input) !== getCwd()
-        ) {
-          return i18n(`${i18nKey}.errors.invalidDest`);
-        }
-        if (!isValidPath(input)) {
-          return i18n(`${i18nKey}.errors.invalidCharacters`);
-        }
-        return true;
-      },
+      validate: validateProjectDirectory,
       filter: input => {
         return untildify(input);
       },


### PR DESCRIPTION
## Description and Context
See https://git.hubteam.com/HubSpot/hubspot-cli-issues/issues/804

Previously, the `hs project create` dest prompt didn't allow you to create a project in any existing folder (including your current working directory) and displayed an error message saying `There is an existing project at this destination. Please provide a new path for this project.` whether a project existed there or now. This updates the prompt to _actually_ check for an `hsproject.json` file rather than just an existing dir. This allows users to create a project in their CWD or another non-project folder via the prompt. Now, entering a dest via the prompt and entering a dest via the `--dest` flag have matching behavior.

## Screenshots
The error that existed previously.
![image](https://github.com/user-attachments/assets/f008dc59-b247-4052-8a71-d1324e144137)


## Who to Notify
@brandenrodgers @kemmerle @joe-yeager @j0b0sapi3n 
