### PR TITLE
chore: Update uie dev server to 0.8.50

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@hubspot/project-parsing-lib": "0.1.1",
     "@hubspot/serverless-dev-runtime": "7.0.2",
     "@hubspot/theme-preview-dev-server": "0.0.10",
-    "@hubspot/ui-extensions-dev-server": "0.8.48",
+    "@hubspot/ui-extensions-dev-server": "0.8.50",
     "archiver": "7.0.1",
     "chalk": "4.1.2",
     "chokidar": "3.6.0",


### PR DESCRIPTION
## Description and Context
This PR is to update the UIE dev server to 0.8.50. This version adds support for platform version 2025.1 in local dev mode.

https://www.npmjs.com/package/@hubspot/ui-extensions-dev-server/v/0.8.50