### PR TITLE
Better task status error message

### DIFF
--- a/lang/en.lyaml
+++ b/lang/en.lyaml
@@ -1145,7 +1145,7 @@ en:
         componentCount: "Found {{ numComponents }} components in this project"
         successStatusText: "DONE"
         failedStatusText: "FAILED"
-        errorFetchingTaskStatus: "Error fetching {{ taskType }} status"
+        errorFetchingTaskStatus: "An error occurred while fetching the status of the current {{ taskType }}. For more information, view this project in HubSpot by running {{ openCommand }}."
       pollBuildAutodeployStatusError: "Error fetching autodeploy status for build #{{ buildId }}"
       pollProjectBuildAndDeploy:
         buildSucceededAutomaticallyDeploying: "Build #{{ buildId }} succeeded. {{#bold}}Automatically deploying{{/bold}} to {{ accountIdentifier }}\n"


### PR DESCRIPTION
## Description and Context
[This issue](https://git.hubteam.com/HubSpot/hubspot-cli-issues/issues/803) (or the bug report that it was based on) was a little bit misleading - the problem was not due to an HTTP timeout, but rather an unhandled error that happened inside `setTimeout` - namely an error fetching build/deploy status while polling. The error that Sejal ran into seems to have been a backend problem that I'm unable to repro, but this should make future errors a bit less confusing.

## Screenshots
Before
<img width="571" alt="Screenshot 2025-03-27 at 3 40 03 PM" src="https://github.com/user-attachments/assets/cc26113a-31a7-4892-87f4-c6d9bfd70e22" />

After (with a fake error)
<img width="570" alt="Screenshot 2025-04-01 at 5 01 47 PM" src="https://github.com/user-attachments/assets/eae883aa-a527-477c-a150-feb61f079186" />

## Who to Notify
@brandenrodgers @kemmerle @joe-yeager 
