### PR TITLE
Log upload warning for all component configs

### DIFF
--- a/lang/en.lyaml
+++ b/lang/en.lyaml
@@ -1077,6 +1077,7 @@ en:
         missingComponents: "Couldn't find the following components in the deployed build for this project: {{#bold}}'{{ missingComponents }}'{{/bold}}. This may cause issues in local development."
         defaultWarning: "{{#bold}}Changing project configuration requires a new project build.{{/bold}}"
         defaultPublicAppWarning: "{{#bold}}Changing project configuration requires a new project build.{{/bold}}\n\nThis will affect your public app's {{#bold}}{{ installCount }} existing {{ installText }}{{/bold}}. If your app has users in production, we strongly recommend creating a copy of this app to test your changes before proceding."
+        defaultMarketplaceAppWarning: "{{#bold}}Changing project configuration requires creating a new project build.{{/bold}}\n\nThis will affect the {{#bold}}{{ installCount }} existing {{ accountText }}{{/bold}} that have installed your marketplace app. We strongly recommend creating a copy of this app to test your changes before proceding."
         header: "{{ warning }} To reflect these changes and continue testing:"
         stopDev: "  * Stop {{ command }}"
         runUpload: "  * Run {{ command }}"

--- a/lang/en.lyaml
+++ b/lang/en.lyaml
@@ -1077,7 +1077,7 @@ en:
         missingComponents: "Couldn't find the following components in the deployed build for this project: {{#bold}}'{{ missingComponents }}'{{/bold}}. This may cause issues in local development."
         defaultWarning: "{{#bold}}Changing project configuration requires a new project build.{{/bold}}"
         defaultPublicAppWarning: "{{#bold}}Changing project configuration requires a new project build.{{/bold}}\n\nThis will affect your public app's {{#bold}}{{ installCount }} existing {{ installText }}{{/bold}}. If your app has users in production, we strongly recommend creating a copy of this app to test your changes before proceding."
-        defaultMarketplaceAppWarning: "{{#bold}}Changing project configuration requires creating a new project build.{{/bold}}\n\nThis will affect the {{#bold}}{{ installCount }} existing {{ accountText }}{{/bold}} that have installed your marketplace app. We strongly recommend creating a copy of this app to test your changes before proceding."
+        defaultMarketplaceAppWarning: "{{#bold}}Changing project configuration requires creating a new project build.{{/bold}}\n\nThis will affect the {{#bold}}{{ installCount }} existing {{ accountText }}{{/bold}} installed your marketplace app. We strongly recommend creating a copy of this app to test your changes before proceding."
         header: "{{ warning }} To reflect these changes and continue testing:"
         stopDev: "  * Stop {{ command }}"
         runUpload: "  * Run {{ command }}"

--- a/lib/DevServerManagerV2.ts
+++ b/lib/DevServerManagerV2.ts
@@ -45,12 +45,10 @@ class DevServerManagerV2 {
 
   async setup({
     projectNodes,
-    onUploadRequired,
     accountId,
     setActiveApp,
   }: {
     projectNodes: { [key: string]: IntermediateRepresentationNodeLocalDev };
-    onUploadRequired: () => void;
     accountId: number;
     setActiveApp: (appUid: string | undefined) => Promise<void>;
   }): Promise<void> {
@@ -64,7 +62,6 @@ class DevServerManagerV2 {
       if (serverInterface.setup) {
         await serverInterface.setup({
           components: projectNodes,
-          onUploadRequired,
           promptUser,
           logger,
           urls: {

--- a/lib/LocalDevManagerV2.ts
+++ b/lib/LocalDevManagerV2.ts
@@ -350,7 +350,7 @@ class LocalDevManagerV2 {
     if (!warning) {
       warning =
         this.publicAppActiveInstalls && this.publicAppActiveInstalls > 0
-          ? i18n(`${i18nKey}.uploadWarning.defaultPublicAppWarning`, {
+          ? i18n(`${i18nKey}.uploadWarning.defaultMarketplaceAppWarning`, {
               installCount: this.publicAppActiveInstalls,
               installText:
                 this.publicAppActiveInstalls === 1 ? 'account' : 'accounts',

--- a/lib/LocalDevManagerV2.ts
+++ b/lib/LocalDevManagerV2.ts
@@ -14,13 +14,14 @@ import {
 import { Build } from '@hubspot/local-dev-lib/types/Build';
 import { PublicApp } from '@hubspot/local-dev-lib/types/Apps';
 import { Environment } from '@hubspot/local-dev-lib/types/Config';
+import { mapToUserFriendlyName } from '@hubspot/project-parsing-lib';
 
 import { APP_DISTRIBUTION_TYPES, PROJECT_CONFIG_FILE } from './constants';
 import SpinniesManager from './ui/SpinniesManager';
 import DevServerManagerV2 from './DevServerManagerV2';
 import { EXIT_CODES } from './enums/exitCodes';
 import { getProjectDetailUrl } from './projects/urls';
-import { isAppIRNode, isCardIRNode } from './projects/structure';
+import { isAppIRNode } from './projects/structure';
 import { ProjectConfig } from '../types/Projects';
 import {
   UI_COLORS,
@@ -344,17 +345,15 @@ class LocalDevManagerV2 {
   }
 
   logUploadWarning(reason?: string): void {
-    let warning: string;
+    let warning = reason;
 
-    if (reason) {
-      warning = reason;
-    } else {
+    if (!warning) {
       warning =
         this.publicAppActiveInstalls && this.publicAppActiveInstalls > 0
           ? i18n(`${i18nKey}.uploadWarning.defaultPublicAppWarning`, {
               installCount: this.publicAppActiveInstalls,
               installText:
-                this.publicAppActiveInstalls === 1 ? 'install' : 'installs',
+                this.publicAppActiveInstalls === 1 ? 'account' : 'accounts',
             })
           : i18n(`${i18nKey}.uploadWarning.defaultWarning`);
     }
@@ -439,12 +438,10 @@ class LocalDevManagerV2 {
     const missingProjectNodes: string[] = [];
 
     Object.values(this.projectNodes).forEach(node => {
-      if (isAppIRNode(node) || isCardIRNode(node)) {
-        if (!deployedComponentNames.includes(node.uid)) {
-          missingProjectNodes.push(
-            `${i18n(`${i18nKey}.uploadWarning.appLabel`)} ${node.uid}`
-          );
-        }
+      if (!deployedComponentNames.includes(node.uid)) {
+        const userFriendlyName = mapToUserFriendlyName(node.componentType);
+        const label = userFriendlyName ? `[${userFriendlyName}] ` : '';
+        missingProjectNodes.push(`${label}${node.uid}`);
       }
     });
 
@@ -462,9 +459,9 @@ class LocalDevManagerV2 {
       ignoreInitial: true,
     });
 
-    const configPaths = Object.values(this.projectNodes)
-      .filter(isAppIRNode)
-      .map(component => component.localDev.componentConfigPath);
+    const configPaths = Object.values(this.projectNodes).map(
+      component => component.localDev.componentConfigPath
+    );
 
     const projectConfigPath = path.join(this.projectDir, PROJECT_CONFIG_FILE);
     configPaths.push(projectConfigPath);
@@ -503,7 +500,6 @@ class LocalDevManagerV2 {
     try {
       await DevServerManagerV2.setup({
         projectNodes: this.projectNodes,
-        onUploadRequired: this.logUploadWarning.bind(this),
         accountId: this.targetTestingAccountId,
         setActiveApp: this.setActiveApp.bind(this),
       });

--- a/lib/LocalDevManagerV2.ts
+++ b/lib/LocalDevManagerV2.ts
@@ -352,8 +352,10 @@ class LocalDevManagerV2 {
         this.publicAppActiveInstalls && this.publicAppActiveInstalls > 0
           ? i18n(`${i18nKey}.uploadWarning.defaultMarketplaceAppWarning`, {
               installCount: this.publicAppActiveInstalls,
-              installText:
-                this.publicAppActiveInstalls === 1 ? 'account' : 'accounts',
+              accountText:
+                this.publicAppActiveInstalls === 1
+                  ? 'account that has'
+                  : 'accounts that have',
             })
           : i18n(`${i18nKey}.uploadWarning.defaultWarning`);
     }

--- a/lib/projects/structure.ts
+++ b/lib/projects/structure.ts
@@ -12,7 +12,7 @@ import {
   AppCardComponentConfig,
 } from '../../types/Projects';
 import { IntermediateRepresentationNodeLocalDev } from '@hubspot/project-parsing-lib/src/lib/types';
-import { AppIRNode, CardIRNode } from '../../types/ProjectComponents';
+import { AppIRNode } from '../../types/ProjectComponents';
 import { IR_COMPONENT_TYPES } from '../constants';
 
 export const CONFIG_FILES: {
@@ -186,10 +186,4 @@ export function isAppIRNode(
   component: IntermediateRepresentationNodeLocalDev
 ): component is AppIRNode {
   return component.componentType === IR_COMPONENT_TYPES.APPLICATION;
-}
-
-export function isCardIRNode(
-  component: IntermediateRepresentationNodeLocalDev
-): component is CardIRNode {
-  return component.componentType === IR_COMPONENT_TYPES.CARD;
 }

--- a/types/ProjectComponents.ts
+++ b/types/ProjectComponents.ts
@@ -25,24 +25,7 @@ type AppConfig = {
   };
 };
 
-type CardConfig = {
-  name: string;
-  description: string;
-  previewImage: {
-    file: string;
-    altText: string;
-  };
-  entrypoint: string;
-  location: string;
-  objectTypes: string[];
-};
-
 export interface AppIRNode extends IntermediateRepresentationNodeLocalDev {
   componentType: typeof IR_COMPONENT_TYPES.APPLICATION;
   config: AppConfig;
-}
-
-export interface CardIRNode extends IntermediateRepresentationNodeLocalDev {
-  componentType: typeof IR_COMPONENT_TYPES.CARD;
-  config: CardConfig;
 }


### PR DESCRIPTION
## Description and Context
This makes a few improvements to support new component types in `hs project dev`
* Upload warning is now logged when _any_ component config is changed. Previously, it was only logged when app and card configs were changed. 
* Similarly, the warning that is logged when you have components locally that aren't in the deployed build looks for all component types, not just apps and cards.
* Updates the copy to remove references to "public" and "production" apps

## Screenshots
<!-- Provide images of the before and after functionality -->
<img width="565" alt="Screenshot 2025-04-07 at 3 56 19 PM" src="https://github.com/user-attachments/assets/8786f834-e995-43d3-9820-8956c8250e9f" />

## TODO
This functionality is really only a temporary fix - ideally, the dev servers should either handle this logging or tell the CLI what components they know how to handle. This will work well with the current state of unified apps, though, and is better than not logging at all.

## Who to Notify
@brandenrodgers @kemmerle @joe-yeager 
