### PR TITLE
chore: Bump @hubspot/project-parsing-lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "https://github.com/HubSpot/hubspot-cli",
   "dependencies": {
     "@hubspot/local-dev-lib": "3.5.1",
-    "@hubspot/project-parsing-lib": "0.1.6",
+    "@hubspot/project-parsing-lib": "0.1.7",
     "@hubspot/serverless-dev-runtime": "7.0.2",
     "@hubspot/theme-preview-dev-server": "0.0.10",
     "@hubspot/ui-extensions-dev-server": "0.8.52",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@types/semver": "^7.5.8",
     "@types/tmp": "^0.2.6",
     "@types/yargs": "^17.0.33",
-    "@typescript-eslint/eslint-plugin": "^8.11.0",
+    "@typescript-eslint/eslint-plugin": "8.29.0",
     "@typescript-eslint/parser": "^8.11.0",
     "axios": "^1.7.2",
     "eslint": "^8.56.0",


### PR DESCRIPTION
## Description and Context
Bump the version of `@hubspot/project-parsing-lib

Also pins `@typescript-eslint/eslint-plugin` to fix the following error

```
Oops! Something went wrong! :(

ESLint: 8.57.1

ESLint couldn't find the config "./configs/base" to extend from. Please check that the name of the config is correct.

The config "./configs/base" was referenced from the config file in "/Users/jyeager/src/hubspot-cli/node_modules/@typescript-eslint/eslint-plugin/dist/index.js".

If you still have problems, please stop by https://eslint.org/chat/help to chat with the team.
```