### PR TITLE
fix: Disable hs project watch for v3 projects

### DIFF
--- a/commands/project/watch.ts
+++ b/commands/project/watch.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
-import { useV3Api } from '../../lib/projects/buildAndDeploy';
-import { uiCommandReference } from '../../lib/ui';
+const { useV3Api } = require('../../lib/projects/buildAndDeploy');
+const { uiCommandReference } = require('../../lib/ui');
 
 const { i18n } = require('../../lib/lang');
 const { createWatcher } = require('../../lib/projects/watch');

--- a/commands/project/watch.ts
+++ b/commands/project/watch.ts
@@ -1,4 +1,7 @@
 // @ts-nocheck
+import { useV3Api } from '../../lib/projects/buildAndDeploy';
+import { uiCommandReference } from '../../lib/ui';
+
 const { i18n } = require('../../lib/lang');
 const { createWatcher } = require('../../lib/projects/watch');
 const { logError, ApiErrorContext } = require('../../lib/errorHandlers/index');
@@ -90,6 +93,17 @@ exports.handler = async options => {
   trackCommandUsage('project-watch', null, derivedAccountId);
 
   const { projectConfig, projectDir } = await getProjectConfig();
+
+  if (useV3Api(projectConfig?.platformVersion)) {
+    logger.error(
+      i18n(`commands.project.subcommands.watch.errors.v3ApiError`, {
+        command: uiCommandReference('hs project watch'),
+        newCommand: uiCommandReference('hs project dev'),
+        platformVersion: projectConfig.platformVersion,
+      })
+    );
+    return process.exit(EXIT_CODES.ERROR);
+  }
 
   validateProjectConfig(projectConfig, projectDir);
 

--- a/commands/project/watch.ts
+++ b/commands/project/watch.ts
@@ -1,4 +1,6 @@
 // @ts-nocheck
+const { uiLink } = require('../../lib/ui');
+
 const { useV3Api } = require('../../lib/projects/buildAndDeploy');
 const { uiCommandReference } = require('../../lib/ui');
 
@@ -100,6 +102,10 @@ exports.handler = async options => {
         command: uiCommandReference('hs project watch'),
         newCommand: uiCommandReference('hs project dev'),
         platformVersion: projectConfig.platformVersion,
+        linkToDocs: uiLink(
+          'How to develop locally.',
+          'https://developers.hubspot.com/docs/guides/crm/ui-extensions/local-development'
+        ),
       })
     );
     return process.exit(EXIT_CODES.ERROR);

--- a/lang/en.lyaml
+++ b/lang/en.lyaml
@@ -771,7 +771,7 @@ en:
             uploadFailed: "Failed to upload file \"{{ filePath }}\" to \"{{ remotePath }}\""
             deleteFileFailed: "Failed to delete file \"{{ remotePath }}\""
             deleteFolderFailed: "Failed to delete folder \"{{ remotePath }}\""
-            v3ApiError: '{{ command }} is not supported for platform version {{ platformVersion}}, use {{ newCommand }} instead'
+            v3ApiError: "{{ command }} is not supported for platform version '{{ platformVersion}}', use {{ newCommand }} instead to develop locally. {{ linkToDocs }}"
         download:
           describe: "Download your project files from HubSpot."
           examples:

--- a/lang/en.lyaml
+++ b/lang/en.lyaml
@@ -771,6 +771,7 @@ en:
             uploadFailed: "Failed to upload file \"{{ filePath }}\" to \"{{ remotePath }}\""
             deleteFileFailed: "Failed to delete file \"{{ remotePath }}\""
             deleteFolderFailed: "Failed to delete folder \"{{ remotePath }}\""
+            v3ApiError: '{{ command }} is not supported for platform version {{ platformVersion}}, use {{ newCommand }} instead'
         download:
           describe: "Download your project files from HubSpot."
           examples:


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
Disable `hs project watch` for projects that are using a platform version that relies on v3 projects APIs
