### PR TITLE
Fix bug with `hs account auth`

### DIFF
--- a/lib/middleware/configMiddleware.ts
+++ b/lib/middleware/configMiddleware.ts
@@ -77,6 +77,15 @@ export async function loadConfigMiddleware(
   };
 
   if (
+    !configFileExists(true) &&
+    isTargetedCommand(argv._, {
+      account: { target: false, subCommands: { auth: { target: true } } },
+    })
+  ) {
+    return;
+  }
+
+  if (
     configFileExists(true) &&
     argv.config &&
     !isTargetedCommand(argv._, {
@@ -105,6 +114,7 @@ export async function loadConfigMiddleware(
 const accountsSubCommands = {
   target: false,
   subCommands: {
+    auth: { target: true },
     clean: { target: true },
     list: { target: true },
     ls: { target: true },


### PR DESCRIPTION
## Description and Context
Joe Kurien reported a bug that `hs account auth` returns an error when no global config file is present (ie. running the command for the first time). 

## Screenshots
BEFORE:

<img width="819" alt="Screenshot 2025-04-15 at 4 23 26 PM" src="https://github.com/user-attachments/assets/b35aa53d-86c9-4a0a-bb89-f5f55756e1f7" />

AFTER:

<img width="851" alt="Screenshot 2025-04-15 at 4 22 42 PM" src="https://github.com/user-attachments/assets/03e33a28-08d1-4c4f-be0f-05dda5621364" />

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

- [ ] Address feedback
- [ ] Cut patch release to pick up the bug fix. 

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@brandenrodgers @camden11 @joe-yeager 
