### PR TITLE
feat: Migrations polish

### DIFF
--- a/api/migrate.ts
+++ b/api/migrate.ts
@@ -5,8 +5,6 @@ import {
 } from '@hubspot/local-dev-lib/constants/projects';
 import { http } from '@hubspot/local-dev-lib/http';
 import { MIGRATION_STATUS } from '@hubspot/local-dev-lib/types/Migration';
-import { logger } from '@hubspot/local-dev-lib/logger';
-import util from 'util';
 
 const MIGRATIONS_API_PATH_V2 = 'dfs/migrations/v2';
 
@@ -147,11 +145,7 @@ export async function checkMigrationStatusV2(
   accountId: number,
   id: number
 ): HubSpotPromise<MigrationStatus> {
-  const response = await http.get<MigrationStatus>(accountId, {
+  return http.get<MigrationStatus>(accountId, {
     url: `${MIGRATIONS_API_PATH_V2}/migrations/${id}/status`,
   });
-
-  logger.debug(util.inspect(response.data, { depth: null }));
-
-  return response;
 }

--- a/lang/en.ts
+++ b/lang/en.ts
@@ -3432,6 +3432,9 @@ export const lib = {
       `The following component types will be migrated: ${components}`,
     componentsThatWillNotBeMigrated: components =>
       `[NOTE] These component types are not yet supported for migration but will be available later: ${components}`,
+    sourceContentsMoved: (newLocation: string) =>
+      `The contents of your old source directory have been moved to ${newLocation}, move any required files to the new source directory.`,
+    projectMigrationWarning: `Migrating a project is irreversible and cannot be undone.`,
     errors: {
       project: {
         invalidConfig:

--- a/lib/app/migrate.ts
+++ b/lib/app/migrate.ts
@@ -194,10 +194,6 @@ async function selectAppToMigrate(
 
   logger.log();
 
-  if (projectConfig?.projectConfig) {
-    logger.log(lib.migrate.projectMigrationWarning);
-  }
-
   const promptMessage = projectConfig?.projectConfig
     ? `${lib.migrate.projectMigrationWarning} ${lib.migrate.prompt.proceed}`
     : lib.migrate.prompt.proceed;

--- a/lib/app/migrate.ts
+++ b/lib/app/migrate.ts
@@ -165,29 +165,29 @@ async function selectAppToMigrate(
 
   const selectedApp = allApps.find(app => app.appId === appIdToMigrate);
 
-  const migratableComponents: string[] = [];
-  const unmigratableComponents: string[] = [];
+  const migratableComponents: Set<string> = new Set();
+  const unmigratableComponents: Set<string> = new Set();
 
   selectedApp?.migrationComponents.forEach(component => {
     if (component.isSupported) {
-      migratableComponents.push(mapToUserFacingType(component.componentType));
+      migratableComponents.add(mapToUserFacingType(component.componentType));
     } else {
-      unmigratableComponents.push(mapToUserFacingType(component.componentType));
+      unmigratableComponents.add(mapToUserFacingType(component.componentType));
     }
   });
 
-  if (migratableComponents.length !== 0) {
+  if (migratableComponents.size !== 0) {
     logger.log(
       lib.migrate.componentsToBeMigrated(
-        `\n - ${[...new Set(migratableComponents)].join('\n - ')}`
+        `\n - ${[...migratableComponents].join('\n - ')}`
       )
     );
   }
 
-  if (unmigratableComponents.length !== 0) {
+  if (unmigratableComponents.size !== 0) {
     logger.log(
       lib.migrate.componentsThatWillNotBeMigrated(
-        `\n - ${[...new Set(unmigratableComponents)].join('\n - ')}`
+        `\n - ${[...unmigratableComponents].join('\n - ')}`
       )
     );
   }

--- a/lib/prompts/promptUtils.ts
+++ b/lib/prompts/promptUtils.ts
@@ -73,7 +73,9 @@ export async function inputPrompt(
     defaultAnswer,
   }: {
     when?: boolean | (() => boolean);
-    validate?: (input: string) => boolean | string;
+    validate?: (
+      input: string
+    ) => (boolean | string) | Promise<boolean | string>;
     defaultAnswer?: string;
   } = {}
 ): Promise<string> {


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
Does the following:
- Dedupes components in the list of components will or will not be migrated
- When prompting for project name, validate the name in the prompt and don't fail the process if the project already exists
- Adds a message letting the user know projects migrations are one way
- Cleans up some debug logging
