### PR TITLE
Fix dev test account creation

### DIFF
--- a/lib/__tests__/buildAccount.test.ts
+++ b/lib/__tests__/buildAccount.test.ts
@@ -177,7 +177,7 @@ describe('lib/buildAccount', () => {
         mockParentAccountConfig.env,
         10
       );
-      expect(result).toEqual(mockDeveloperTestAccount);
+      expect(result).toEqual(mockDeveloperTestAccount.id);
     });
 
     it('should throw error if account ID is not found', async () => {

--- a/lib/localDev.ts
+++ b/lib/localDev.ts
@@ -323,14 +323,14 @@ export async function createDeveloperTestAccountForLocalDev(
       accountId
     );
 
-    const devTestAccountId = await buildDeveloperTestAccount(
+    const result = await buildDeveloperTestAccount(
       name,
       accountConfig,
       env,
       maxTestPortals
     );
 
-    return devTestAccountId;
+    return result;
   } catch (err) {
     logError(err);
     process.exit(EXIT_CODES.ERROR);

--- a/lib/localDev.ts
+++ b/lib/localDev.ts
@@ -323,14 +323,14 @@ export async function createDeveloperTestAccountForLocalDev(
       accountId
     );
 
-    const result = await buildDeveloperTestAccount(
+    const devTestAccountId = await buildDeveloperTestAccount(
       name,
       accountConfig,
       env,
       maxTestPortals
     );
 
-    return result.id;
+    return devTestAccountId;
   } catch (err) {
     logError(err);
     process.exit(EXIT_CODES.ERROR);

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": "https://github.com/HubSpot/hubspot-cli",
   "dependencies": {
-    "@hubspot/local-dev-lib": "3.5.2",
+    "@hubspot/local-dev-lib": "3.5.3",
     "@hubspot/project-parsing-lib": "0.1.7",
     "@hubspot/serverless-dev-runtime": "7.0.2",
     "@hubspot/theme-preview-dev-server": "0.0.10",


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
Relies on https://github.com/HubSpot/hubspot-local-dev-lib/pull/261

This fixes the double prompt that we get during project local dev if you opt to create a new dev test account. The api returns a personal access key, so there's no need for us to be re-prompting users for it.

This is a regression that I accidentally introduced a little while ago.

## Screenshots
<!-- Provide images of the before and after functionality -->

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
