### PR TITLE
Hide sandbox prompt for accounts with no sandbox access

### DIFF
--- a/commands/project/dev/deprecatedFlow.ts
+++ b/commands/project/dev/deprecatedFlow.ts
@@ -82,13 +82,11 @@ export async function deprecatedProjectDevFlow(
 
   if (isDeveloperTestAccount(accountConfig)) {
     bypassRecommendedAccountPrompt = true;
+  } else if (!hasPublicApps && isSandbox(accountConfig)) {
+    bypassRecommendedAccountPrompt = true;
   } else if (!hasPublicApps) {
-    if (isSandbox(accountConfig)) {
-      bypassRecommendedAccountPrompt = true;
-    } else {
-      const defaultAccountHasSandboxes = await hasSandboxes(accountConfig);
-      bypassRecommendedAccountPrompt = !defaultAccountHasSandboxes;
-    }
+    const defaultAccountHasSandboxes = await hasSandboxes(accountConfig);
+    bypassRecommendedAccountPrompt = !defaultAccountHasSandboxes;
   }
 
   // targetProjectAccountId and targetTestingAccountId are set to null if --account flag is not provided.

--- a/lang/en.lyaml
+++ b/lang/en.lyaml
@@ -1349,7 +1349,7 @@ en:
         sandboxLimit: "Your account reached the limit of {{ limit }} development sandboxes"
         sandboxLimitWithSuggestion: "Your account reached the limit of {{ limit }} development sandboxes. Run {{ authCommand }} to add an existing one to the config."
         developerTestAccountLimit: "Your account reached the limit of {{ limit }} developer test accounts."
-        confirmDefaultAccount: "Continue testing on {{#bold}}{{ accountName }} ({{ accountType }}){{/bold}}? (Y/n)"
+        confirmDefaultAccount: "Proceed with local development on {{#bold}}{{ accountName }} [{{ accountType }}]{{/bold}}? (Y/n)"
         confirmUseExistingDeveloperTestAccount: "Continue with {{ accountName }}? This account isn't currently connected to the HubSpot CLI. By continuing, you'll be prompted to generate a personal access key and connect it."
         noAccountId: "No account ID found for the selected account. Please try again."
       projectLogsPrompt:


### PR DESCRIPTION
## Description and Context
When testing legacy private app local dev on an account without sandboxes, I noticed that we still showed the sandbox prompt but the only option was to proceed with your current account. This replaces that prompt with the more generic prompt we show when your default account fits the recommended requirements (i.e. is a sandbox or dev test account).

I also updated the copy of the prompt to be more in line with the rest of the language we use in `hs project dev`

## Screenshots
Before
<img width="569" alt="Screenshot 2025-04-22 at 3 52 40 PM" src="https://github.com/user-attachments/assets/16c663c9-5937-481e-9a06-3b17584f8f0e" />

After
<img width="561" alt="Screenshot 2025-04-22 at 5 05 24 PM" src="https://github.com/user-attachments/assets/bbc7fb80-f100-457e-8fdc-f12b556dbb70" />

## Who to Notify
@brandenrodgers @joe-yeager @kemmerle 
