### PR TITLE
Fix: UX improvement for migration/merge prompt behavior in `hs account auth`

### DIFF
--- a/commands/account/auth.ts
+++ b/commands/account/auth.ts
@@ -1,14 +1,16 @@
 import { Argv, ArgumentsCamelCase } from 'yargs';
 import {
   loadConfig,
-  getConfigPath,
   updateAccountConfig,
   writeConfig,
   createEmptyConfigFile,
   deleteEmptyConfigFile,
   getConfigDefaultAccount,
 } from '@hubspot/local-dev-lib/config';
-import { configFileExists } from '@hubspot/local-dev-lib/config/migrate';
+import {
+  configFileExists,
+  getConfigPath,
+} from '@hubspot/local-dev-lib/config/migrate';
 import { getAccountIdentifier } from '@hubspot/local-dev-lib/config/getAccountIdentifier';
 import { logger } from '@hubspot/local-dev-lib/logger';
 import {

--- a/lang/en.lyaml
+++ b/lang/en.lyaml
@@ -27,7 +27,8 @@ en:
               describe: "HubSpot account to authenticate"
           errors:
             failedToUpdateConfig: "Failed to update the configuration file. Please try again."
-            bothConfigFilesNotAllowed: "Unable to create config file, because there is an existing \"{{ deprecatedConfig }}\" file. To create a new config file, delete the existing one and try again."
+            migrationNotConfirmed: "Use the {{ authCommand}} command to update the deprecated config at {{ deprecatedConfigPath }}."
+            mergeNotConfirmed: "The deprecated config file will continue to exist at {{ deprecatedConfigPath }}. This command will authorize an account and list it in the global config file at {{ globalConfigPath }}."
           success:
             configFileCreated: "Created config file \"{{ configPath }}\""
             configFileUpdated: "Connected account \"{{ account }}\" and set it as the default account"

--- a/lib/configMigrate.ts
+++ b/lib/configMigrate.ts
@@ -24,7 +24,7 @@ import { trackCommandMetadataUsage } from './usageTracking';
 export async function handleMigration(
   accountId: number | undefined,
   configPath?: string
-): Promise<void> {
+): Promise<boolean> {
   const { shouldMigrateConfig } = await promptUser({
     name: 'shouldMigrateConfig',
     type: 'confirm',
@@ -46,7 +46,7 @@ export async function handleMigration(
       },
       accountId
     );
-    return;
+    return false;
   }
 
   const deprecatedConfig = getDeprecatedConfig(configPath);
@@ -66,7 +66,7 @@ export async function handleMigration(
       globalConfigPath: GLOBAL_CONFIG_PATH,
     })
   );
-  return;
+  return true;
 }
 
 async function mergeConfigProperties(
@@ -106,7 +106,7 @@ export async function handleMerge(
   accountId: number | undefined,
   configPath?: string,
   force?: boolean
-): Promise<void> {
+): Promise<boolean> {
   const { shouldMergeConfigs } = await promptUser({
     name: 'shouldMergeConfigs',
     type: 'confirm',
@@ -128,14 +128,14 @@ export async function handleMerge(
       },
       accountId
     );
-    return;
+    return false;
   }
 
   const deprecatedConfig = getDeprecatedConfig(configPath);
   const globalConfig = getGlobalConfig();
 
   if (!deprecatedConfig || !globalConfig) {
-    return;
+    return true;
   }
 
   const mergedConfig = await mergeConfigProperties(
@@ -172,5 +172,5 @@ export async function handleMerge(
     },
     accountId
   );
-  return;
+  return true;
 }


### PR DESCRIPTION
## Description and Context
Randy S suggested this UX improvement via Slack.  

Currently, if a customer runs the `hs account auth` command and declines to migrate or merge a deprecated config, we continue to create the new global config file and add an account to it. I've changed the behavior of the command to be more intuitive for the customer and give them more info. 

## Screenshots
<!-- Provide images of the before and after functionality -->

If customer declines to migrate the deprecated config (and no global config exists):

<img width="709" alt="Screenshot 2025-04-23 at 10 41 56 AM" src="https://github.com/user-attachments/assets/fe0a11b4-b271-4ffb-9e19-ed56d6d442e3" />

If the customer declines to merge a deprecated and global config:

<img width="707" alt="Screenshot 2025-04-23 at 10 47 44 AM" src="https://github.com/user-attachments/assets/00dce5b0-d9fe-47f9-9ad5-346dd5ece1b6" />

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

- [ ] Address feedback 

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@brandenrodgers @camden11 @joe-yeager 
