### PR TITLE
Support legacy public app development in combined accounts

### DIFF
--- a/commands/project/cloneApp.ts
+++ b/commands/project/cloneApp.ts
@@ -17,7 +17,10 @@ import { poll } from '../../lib/polling';
 import { uiLine, uiAccountDescription } from '../../lib/ui';
 import { logError, ApiErrorContext } from '../../lib/errorHandlers';
 import { EXIT_CODES } from '../../lib/enums/exitCodes';
-import { isAppDeveloperAccount } from '../../lib/accountTypes';
+import {
+  isAppDeveloperAccount,
+  isUnifiedAccount,
+} from '../../lib/accountTypes';
 import { writeProjectConfig } from '../../lib/projects';
 import { PROJECT_CONFIG_FILE } from '../../lib/constants';
 import {
@@ -66,7 +69,9 @@ export const handler = async (options: ArgumentsCamelCase<CloneAppArgs>) => {
     );
   }
 
-  if (!isAppDeveloperAccount(accountConfig)) {
+  const defaultAccountIsUnified = await isUnifiedAccount(accountConfig);
+
+  if (!isAppDeveloperAccount(accountConfig) && !defaultAccountIsUnified) {
     logInvalidAccountError();
     process.exit(EXIT_CODES.SUCCESS);
   }

--- a/commands/project/dev/deprecatedFlow.ts
+++ b/commands/project/dev/deprecatedFlow.ts
@@ -27,12 +27,7 @@ import {
   checkIfParentAccountIsAuthed,
 } from '../../../lib/localDev';
 import { handleExit } from '../../../lib/process';
-import {
-  isSandbox,
-  isDeveloperTestAccount,
-  isStandardAccount,
-  isAppDeveloperAccount,
-} from '../../../lib/accountTypes';
+import { isSandbox, isDeveloperTestAccount } from '../../../lib/accountTypes';
 import { ensureProjectExists } from '../../../lib/projects';
 import { ProjectDevArgs } from '../../../types/Yargs';
 
@@ -95,7 +90,7 @@ export async function deprecatedProjectDevFlow(
       targetProjectAccountId = accountConfig.parentAccountId || null;
     }
   } else {
-    checkIfDefaultAccountIsSupported(accountConfig, hasPublicApps);
+    await checkIfDefaultAccountIsSupported(accountConfig, hasPublicApps);
   }
 
   // The user is targeting an account type that we recommend developing on
@@ -137,9 +132,8 @@ export async function deprecatedProjectDevFlow(
       await useExistingDevTestAccount(env, notInConfigAccount);
     }
 
-    createNewSandbox = isStandardAccount(accountConfig) && createNestedAccount;
-    createNewDeveloperTestAccount =
-      isAppDeveloperAccount(accountConfig) && createNestedAccount;
+    createNewSandbox = hasPrivateApps && createNestedAccount;
+    createNewDeveloperTestAccount = hasPublicApps && createNestedAccount;
   }
 
   if (createNewSandbox) {

--- a/commands/theme/preview.ts
+++ b/commands/theme/preview.ts
@@ -25,6 +25,7 @@ import { findProjectComponents } from '../../lib/projects/structure';
 import { ComponentTypes } from '../../types/Projects';
 import { hasFeature } from '../../lib/hasFeature';
 import { CommonArgs, ConfigArgs, AccountArgs } from '../../types/Yargs';
+import { FEATURES } from '../../lib/constants';
 
 const i18nKey = 'commands.theme.subcommands.preview';
 
@@ -215,7 +216,7 @@ export async function handler(
 
   const isUngatedForUnified = await hasFeature(
     derivedAccountId,
-    'cms:react:unifiedThemePreview'
+    FEATURES.UNIFIED_THEME_PREVIEW
   );
   if (isUngatedForUnified && createUnifiedDevServer) {
     if (port) {

--- a/lib/__tests__/hasFeature.test.ts
+++ b/lib/__tests__/hasFeature.test.ts
@@ -22,16 +22,19 @@ describe('lib/hasFeature', () => {
     });
 
     it('should return true if the feature is enabled', async () => {
+      // @ts-expect-error test data
       const result = await hasFeature(accountId, 'feature-1');
       expect(result).toBe(true);
     });
 
     it('should return false if the feature is not enabled', async () => {
+      // @ts-expect-error test data
       const result = await hasFeature(accountId, 'feature-2');
       expect(result).toBe(false);
     });
 
     it('should return false if the feature is not present', async () => {
+      // @ts-expect-error test data
       const result = await hasFeature(accountId, 'feature-4');
       expect(result).toBe(false);
     });

--- a/lib/accountTypes.ts
+++ b/lib/accountTypes.ts
@@ -1,5 +1,8 @@
 import { HUBSPOT_ACCOUNT_TYPES } from '@hubspot/local-dev-lib/constants/config';
 import { CLIAccount, AccountType } from '@hubspot/local-dev-lib/types/Accounts';
+import { hasFeature } from './hasFeature';
+import { FEATURES } from './constants';
+import { getAccountIdentifier } from '@hubspot/local-dev-lib/config/getAccountIdentifier';
 
 function isAccountType(
   accountConfig: CLIAccount,
@@ -39,4 +42,18 @@ export function isDeveloperTestAccount(accountConfig: CLIAccount): boolean {
 
 export function isAppDeveloperAccount(accountConfig: CLIAccount): boolean {
   return isAccountType(accountConfig, HUBSPOT_ACCOUNT_TYPES.APP_DEVELOPER);
+}
+
+export async function isUnifiedAccount(account: CLIAccount): Promise<boolean> {
+  const accountId = getAccountIdentifier(account);
+  if (!accountId) {
+    return false;
+  }
+
+  const isUngatedForUnifiedApps = await hasFeature(
+    accountId,
+    FEATURES.UNIFIED_APPS
+  );
+
+  return isStandardAccount(account) && isUngatedForUnifiedApps;
 }

--- a/lib/app/migrate.ts
+++ b/lib/app/migrate.ts
@@ -32,6 +32,7 @@ import {
   EnvironmentArgs,
 } from '../../types/Yargs';
 import { hasFeature } from '../hasFeature';
+import { FEATURES } from '../constants';
 
 export type MigrateAppArgs = CommonArgs &
   AccountArgs &
@@ -474,7 +475,7 @@ export async function migrateApp2025_2(
 
   const ungatedForUnifiedApps = await hasFeature(
     derivedAccountId,
-    'Developers:UnifiedApps:PrivateBeta'
+    FEATURES.UNIFIED_APPS
   );
 
   if (!ungatedForUnifiedApps) {

--- a/lib/app/migrate_legacy.ts
+++ b/lib/app/migrate_legacy.ts
@@ -16,7 +16,7 @@ import { ApiErrorContext, logError } from '../errorHandlers';
 import { EXIT_CODES } from '../enums/exitCodes';
 import { uiAccountDescription, uiLine, uiLink } from '../ui';
 import { i18n } from '../lang';
-import { isAppDeveloperAccount } from '../accountTypes';
+import { isAppDeveloperAccount, isUnifiedAccount } from '../accountTypes';
 import { selectPublicAppPrompt } from '../prompts/selectPublicAppPrompt';
 import { createProjectPrompt } from '../prompts/createProjectPrompt';
 import { ensureProjectExists } from '../projects';
@@ -33,7 +33,9 @@ export async function migrateApp2023_2(
 ): Promise<void> {
   const accountName = uiAccountDescription(derivedAccountId);
 
-  if (!isAppDeveloperAccount(accountConfig)) {
+  const defaultAccountIsUnified = await isUnifiedAccount(accountConfig);
+
+  if (!isAppDeveloperAccount(accountConfig) && !defaultAccountIsUnified) {
     logInvalidAccountError();
     process.exit(EXIT_CODES.SUCCESS);
   }

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -84,3 +84,8 @@ export const APP_AUTH_TYPES = {
   OAUTH: 'oauth',
   STATIC: 'static',
 } as const;
+
+export const FEATURES = {
+  UNIFIED_THEME_PREVIEW: 'cms:react:unifiedThemePreview',
+  UNIFIED_APPS: 'Developers:UnifiedApps:PrivateBeta',
+} as const;

--- a/lib/hasFeature.ts
+++ b/lib/hasFeature.ts
@@ -1,8 +1,10 @@
 import { fetchEnabledFeatures } from '@hubspot/local-dev-lib/api/localDevAuth';
+import { FEATURES } from './constants';
+import { ValueOf } from '@hubspot/local-dev-lib/types/Utils';
 
 export async function hasFeature(
   accountId: number,
-  feature: string
+  feature: ValueOf<typeof FEATURES>
 ): Promise<boolean> {
   const {
     data: { enabledFeatures },

--- a/lib/localDev.ts
+++ b/lib/localDev.ts
@@ -33,7 +33,11 @@ import SpinniesManager from './ui/SpinniesManager';
 import { i18n } from './lang';
 import { EXIT_CODES } from './enums/exitCodes';
 import { trackCommandMetadataUsage } from './usageTracking';
-import { isAppDeveloperAccount, isDeveloperTestAccount } from './accountTypes';
+import {
+  isAppDeveloperAccount,
+  isDeveloperTestAccount,
+  isUnifiedAccount,
+} from './accountTypes';
 import { handleProjectUpload } from './projects/upload';
 import { pollProjectBuildAndDeploy } from './projects/buildAndDeploy';
 import {
@@ -94,15 +98,18 @@ export async function confirmDefaultAccountIsTarget(
 }
 
 // Confirm the default account is supported for the type of apps being developed
-export function checkIfDefaultAccountIsSupported(
+export async function checkIfDefaultAccountIsSupported(
   accountConfig: CLIAccount,
   hasPublicApps: boolean
-): void {
+): Promise<void> {
+  const defaultAccountIsUnified = await isUnifiedAccount(accountConfig);
+
   if (
     hasPublicApps &&
     !(
       isAppDeveloperAccount(accountConfig) ||
-      isDeveloperTestAccount(accountConfig)
+      isDeveloperTestAccount(accountConfig) ||
+      defaultAccountIsUnified
     )
   ) {
     logger.error(
@@ -189,7 +196,7 @@ export async function suggestRecommendedNestedAccount(
   uiLine();
   logger.log();
 
-  const targetAccountPrompt = isAppDeveloperAccount(accountConfig)
+  const targetAccountPrompt = hasPublicApps
     ? selectDeveloperTestTargetAccountPrompt
     : selectSandboxTargetAccountPrompt;
 


### PR DESCRIPTION
## Description and Context
Previously, converting a developer account to a combined account meant losing the ability to run `hs project dev` on legacy public apps. This is because a combined account is technically a standard account, which `hs project dev` didn't support for public apps. This updates the logic in the legacy dev flow to allow unified apps (and also updates the legacy `clone-app` and `migrate-app` commands to work with combined accounts)

See https://git.hubteam.com/HubSpot/hubspot-cli-issues/issues/806

## Who to Notify
@brandenrodgers @kemmerle @joe-yeager 
