### PR TITLE
Add type checking to lang objects

### DIFF
--- a/lang/en.ts
+++ b/lang/en.ts
@@ -1,7 +1,7 @@
 // @ts-nocheck
 import chalk from 'chalk';
 
-type LangFunction = (...args: string[] | number[]) => string;
+type LangFunction = (...args: (string | number)[]) => string;
 
 type LangObject = {
   [key: string]: string | LangFunction | LangObject;

--- a/lang/en.ts
+++ b/lang/en.ts
@@ -1,6 +1,12 @@
 // @ts-nocheck
 import chalk from 'chalk';
 
+type LangFunction = (...args: string[] | number[]) => string;
+
+type LangObject = {
+  [key: string]: string | LangFunction | LangObject;
+};
+
 export const commands = {
   generalErrors: {
     updateNotify: {
@@ -2597,7 +2603,8 @@ export const commands = {
       },
     },
   },
-};
+} as const satisfies LangObject;
+
 export const lib = {
   process: {
     exitDebug: signal =>
@@ -3451,7 +3458,7 @@ export const lib = {
         listedInMarketplace: 'Listed apps are not currently migratable',
         generic: reasonCode => `Unable to migrate app: ${reasonCode}`,
       },
-      noAppsEligible: (accountId, reasons) =>
+      noAppsEligible: (accountId, reasons: string[]) =>
         `No apps in account ${accountId} are currently migratable${reasons.length ? `\n  - ${reasons.join('\n  - ')}` : ''}`,
 
       invalidAccountTypeTitle: () =>
@@ -3489,4 +3496,4 @@ export const lib = {
       copyingProjectFilesFailed: 'Unable to copy migrated project files',
     },
   },
-};
+} as const satisfies LangObject;


### PR DESCRIPTION
## Description and Context
Was working with the new lang objects and found another opportunity to do some type checking and reduce copy errors. With the `satisfies` operator, we can default every function in the lang objects to expect only strings or numbers as arguments. This will help reduce accidentally passing in `undefined`, objects, or anything else unexpected. We can override lang functions on a case by case basis if they need to accept other types (see `noAppsElgible`) - I think this is rare enough that the extra checks will be worth the slightly higher effort in those cases.

## Who to Notify
@brandenrodgers @joe-yeager @kemmerle 
