### PR TITLE
Organize lib/projects and use lang objects

### DIFF
--- a/commands/app/migrate.ts
+++ b/commands/app/migrate.ts
@@ -18,7 +18,7 @@ import { EXIT_CODES } from '../../lib/enums/exitCodes';
 import { migrateApp2025_2, MigrateAppArgs } from '../../lib/app/migrate';
 import { uiBetaTag, uiCommandReference, uiLink } from '../../lib/ui';
 import { migrateApp2023_2 } from '../../lib/app/migrate_legacy';
-import { getIsInProject } from '../../lib/projects';
+import { getIsInProject } from '../../lib/projects/config';
 
 const { v2023_2, v2025_2, unstable } = PLATFORM_VERSIONS;
 export const validMigrationTargets = [v2023_2, v2025_2, unstable];

--- a/commands/create/website-theme.ts
+++ b/commands/create/website-theme.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 const { cloneGithubRepo } = require('@hubspot/local-dev-lib/github');
-const { getIsInProject } = require('../../lib/projects');
+const { getIsInProject } = require('../../lib/projects/config');
 
 const PROJECT_BOILERPLATE_BRANCH = 'cms-boilerplate-developer-projects';
 

--- a/commands/project/__tests__/deploy.test.ts
+++ b/commands/project/__tests__/deploy.test.ts
@@ -10,7 +10,7 @@ import {
   addConfigOptions,
   addUseEnvironmentOptions,
 } from '../../../lib/commonOpts';
-import * as projectUtils from '../../../lib/projects';
+import * as projectUtils from '../../../lib/projects/config';
 import * as projectUrlUtils from '../../../lib/projects/urls';
 import { pollDeployStatus } from '../../../lib/projects/buildAndDeploy';
 import * as projectNamePrompt from '../../../lib/prompts/projectNamePrompt';
@@ -31,7 +31,7 @@ jest.mock('@hubspot/local-dev-lib/api/projects');
 jest.mock('@hubspot/local-dev-lib/config');
 jest.mock('../../../lib/commonOpts');
 jest.mock('../../../lib/validation');
-jest.mock('../../../lib/projects');
+jest.mock('../../../lib/projects/config');
 jest.mock('../../../lib/projects/urls');
 jest.mock('../../../lib/projects/buildAndDeploy');
 jest.mock('../../../lib/prompts/projectNamePrompt');

--- a/commands/project/__tests__/installDeps.test.ts
+++ b/commands/project/__tests__/installDeps.test.ts
@@ -1,7 +1,7 @@
 import yargs, { Argv, ArgumentsCamelCase } from 'yargs';
 import path from 'path';
 import { logger } from '@hubspot/local-dev-lib/logger';
-import * as projectUtils from '../../../lib/projects';
+import * as projectUtils from '../../../lib/projects/config';
 import { EXIT_CODES } from '../../../lib/enums/exitCodes';
 import { trackCommandUsage } from '../../../lib/usageTracking';
 import * as dependencyManagement from '../../../lib/dependencyManagement';
@@ -10,7 +10,7 @@ import * as projectInstallDepsCommand from '../installDeps';
 
 jest.mock('yargs');
 jest.mock('@hubspot/local-dev-lib/logger');
-jest.mock('../../../lib/projects');
+jest.mock('../../../lib/projects/config');
 jest.mock('../../../lib/dependencyManagement');
 jest.mock('../../../lib/prompts/promptUtils');
 jest.mock('../../../lib/usageTracking');

--- a/commands/project/add.ts
+++ b/commands/project/add.ts
@@ -9,7 +9,7 @@ import { debugError } from '../../lib/errorHandlers';
 import { trackCommandUsage } from '../../lib/usageTracking';
 import { i18n } from '../../lib/lang';
 import { projectAddPrompt } from '../../lib/prompts/projectAddPrompt';
-import { getProjectConfig } from '../../lib/projects';
+import { getProjectConfig } from '../../lib/projects/config';
 import { getProjectComponentListFromRepo } from '../../lib/projects/create';
 import { findProjectComponents } from '../../lib/projects/structure';
 import { ComponentTypes } from '../../types/Projects';

--- a/commands/project/cloneApp.ts
+++ b/commands/project/cloneApp.ts
@@ -21,7 +21,7 @@ import {
   isAppDeveloperAccount,
   isUnifiedAccount,
 } from '../../lib/accountTypes';
-import { writeProjectConfig } from '../../lib/projects';
+import { writeProjectConfig } from '../../lib/projects/config';
 import { PROJECT_CONFIG_FILE } from '../../lib/constants';
 import {
   cloneApp,

--- a/commands/project/create.ts
+++ b/commands/project/create.ts
@@ -17,7 +17,10 @@ const { trackCommandUsage } = require('../../lib/usageTracking');
 const {
   createProjectPrompt,
 } = require('../../lib/prompts/createProjectPrompt');
-const { writeProjectConfig, getProjectConfig } = require('../../lib/projects');
+const {
+  writeProjectConfig,
+  getProjectConfig,
+} = require('../../lib/projects/config');
 const {
   getProjectTemplateListFromRepo,
   EMPTY_PROJECT_TEMPLATE_NAME,

--- a/commands/project/deploy.ts
+++ b/commands/project/deploy.ts
@@ -10,7 +10,7 @@ import { isHubSpotHttpError } from '@hubspot/local-dev-lib/errors/index';
 import { useV3Api } from '../../lib/projects/buildAndDeploy';
 import { trackCommandUsage } from '../../lib/usageTracking';
 import { logError, ApiErrorContext } from '../../lib/errorHandlers/index';
-import { getProjectConfig } from '../../lib/projects';
+import { getProjectConfig } from '../../lib/projects/config';
 import { pollDeployStatus } from '../../lib/projects/buildAndDeploy';
 import { getProjectDetailUrl } from '../../lib/projects/urls';
 import { projectNamePrompt } from '../../lib/prompts/projectNamePrompt';

--- a/commands/project/dev/deprecatedFlow.ts
+++ b/commands/project/dev/deprecatedFlow.ts
@@ -13,7 +13,7 @@ import { i18n } from '../../../lib/lang';
 import { EXIT_CODES } from '../../../lib/enums/exitCodes';
 import { uiCommandReference } from '../../../lib/ui';
 import SpinniesManager from '../../../lib/ui/SpinniesManager';
-import LocalDevManager from '../../../lib/LocalDevManager';
+import LocalDevManager from '../../../lib/projects/localDev/LocalDevManager';
 import {
   confirmDefaultAccountIsTarget,
   suggestRecommendedNestedAccount,
@@ -26,10 +26,10 @@ import {
   useExistingDevTestAccount,
   checkIfParentAccountIsAuthed,
   hasSandboxes,
-} from '../../../lib/localDev';
+} from '../../../lib/projects/localDev/helpers';
 import { handleExit } from '../../../lib/process';
 import { isSandbox, isDeveloperTestAccount } from '../../../lib/accountTypes';
-import { ensureProjectExists } from '../../../lib/projects';
+import { ensureProjectExists } from '../../../lib/projects/ensureProjectExists';
 import { ProjectDevArgs } from '../../../types/Yargs';
 
 export async function deprecatedProjectDevFlow(

--- a/commands/project/dev/index.ts
+++ b/commands/project/dev/index.ts
@@ -7,7 +7,10 @@ import { trackCommandUsage } from '../../../lib/usageTracking';
 import { i18n } from '../../../lib/lang';
 import { logger } from '@hubspot/local-dev-lib/logger';
 import { getAccountConfig } from '@hubspot/local-dev-lib/config';
-import { getProjectConfig, validateProjectConfig } from '../../../lib/projects';
+import {
+  getProjectConfig,
+  validateProjectConfig,
+} from '../../../lib/projects/config';
 import { EXIT_CODES } from '../../../lib/enums/exitCodes';
 import { uiBetaTag, uiCommandReference, uiLink } from '../../../lib/ui';
 

--- a/commands/project/dev/unifiedFlow.ts
+++ b/commands/project/dev/unifiedFlow.ts
@@ -11,16 +11,16 @@ import { ProjectDevArgs } from '../../../types/Yargs';
 import { ProjectConfig } from '../../../types/Projects';
 import { logError } from '../../../lib/errorHandlers';
 import { EXIT_CODES } from '../../../lib/enums/exitCodes';
-import { ensureProjectExists } from '../../../lib/projects';
+import { ensureProjectExists } from '../../../lib/projects/ensureProjectExists';
 import {
   createInitialBuildForNewProject,
   createNewProjectForLocalDev,
   useExistingDevTestAccount,
   createDeveloperTestAccountForLocalDev,
-} from '../../../lib/localDev';
+} from '../../../lib/projects/localDev/helpers';
 import { selectDeveloperTestTargetAccountPrompt } from '../../../lib/prompts/projectDevTargetAccountPrompt';
 import SpinniesManager from '../../../lib/ui/SpinniesManager';
-import LocalDevManagerV2 from '../../../lib/LocalDevManagerV2';
+import LocalDevManagerV2 from '../../../lib/projects/localDev/LocalDevManagerV2';
 import { handleExit } from '../../../lib/process';
 import {
   isAppDeveloperAccount,

--- a/commands/project/download.ts
+++ b/commands/project/download.ts
@@ -8,7 +8,7 @@ import {
   fetchProjectBuilds,
 } from '@hubspot/local-dev-lib/api/projects';
 import { logError, ApiErrorContext } from '../../lib/errorHandlers/index';
-import { getProjectConfig } from '../../lib/projects';
+import { getProjectConfig } from '../../lib/projects/config';
 import { downloadProjectPrompt } from '../../lib/prompts/downloadProjectPrompt';
 import { i18n } from '../../lib/lang';
 import { uiBetaTag } from '../../lib/ui';

--- a/commands/project/installDeps.ts
+++ b/commands/project/installDeps.ts
@@ -5,7 +5,7 @@ import {
   getProjectPackageJsonLocations,
 } from '../../lib/dependencyManagement';
 import { EXIT_CODES } from '../../lib/enums/exitCodes';
-import { getProjectConfig } from '../../lib/projects';
+import { getProjectConfig } from '../../lib/projects/config';
 import { promptUser } from '../../lib/prompts/promptUtils';
 import path from 'path';
 import { i18n } from '../../lib/lang';

--- a/commands/project/listBuilds.ts
+++ b/commands/project/listBuilds.ts
@@ -8,7 +8,10 @@ import {
 } from '@hubspot/local-dev-lib/api/projects';
 import { getTableContents, getTableHeader } from '../../lib/ui/table';
 import { uiBetaTag, uiLink } from '../../lib/ui';
-import { getProjectConfig, validateProjectConfig } from '../../lib/projects';
+import {
+  getProjectConfig,
+  validateProjectConfig,
+} from '../../lib/projects/config';
 import { getProjectDetailUrl } from '../../lib/projects/urls';
 import moment from 'moment';
 import { promptUser } from '../../lib/prompts/promptUtils';

--- a/commands/project/migrate.ts
+++ b/commands/project/migrate.ts
@@ -14,7 +14,7 @@ import {
   addGlobalOptions,
 } from '../../lib/commonOpts';
 import { migrateApp2025_2 } from '../../lib/app/migrate';
-import { getProjectConfig } from '../../lib/projects';
+import { getProjectConfig } from '../../lib/projects/config';
 import { PLATFORM_VERSIONS } from '@hubspot/local-dev-lib/constants/projects';
 import { logError } from '../../lib/errorHandlers';
 import { EXIT_CODES } from '../../lib/enums/exitCodes';

--- a/commands/project/open.ts
+++ b/commands/project/open.ts
@@ -9,7 +9,8 @@ import {
 import { trackCommandUsage } from '../../lib/usageTracking';
 import { i18n } from '../../lib/lang';
 import { logger } from '@hubspot/local-dev-lib/logger';
-import { getProjectConfig, ensureProjectExists } from '../../lib/projects';
+import { getProjectConfig } from '../../lib/projects/config';
+import { ensureProjectExists } from '../../lib/projects/ensureProjectExists';
 import { getProjectDetailUrl } from '../../lib/projects/urls';
 import { projectNamePrompt } from '../../lib/prompts/projectNamePrompt';
 import { uiBetaTag } from '../../lib/ui';

--- a/commands/project/upload.ts
+++ b/commands/project/upload.ts
@@ -7,11 +7,11 @@ import { useV3Api } from '../../lib/projects/buildAndDeploy';
 import { uiBetaTag, uiCommandReference } from '../../lib/ui';
 import { trackCommandUsage } from '../../lib/usageTracking';
 import {
-  ensureProjectExists,
   getProjectConfig,
-  logFeedbackMessage,
   validateProjectConfig,
-} from '../../lib/projects';
+} from '../../lib/projects/config';
+import { ensureProjectExists } from '../../lib/projects/ensureProjectExists';
+import { logFeedbackMessage } from '../../lib/projects/ui';
 import { handleProjectUpload } from '../../lib/projects/upload';
 import {
   displayWarnLogs,

--- a/commands/project/watch.ts
+++ b/commands/project/watch.ts
@@ -17,11 +17,13 @@ const {
 const { trackCommandUsage } = require('../../lib/usageTracking');
 const { uiBetaTag } = require('../../lib/ui');
 const {
-  ensureProjectExists,
   getProjectConfig,
   validateProjectConfig,
-  logFeedbackMessage,
-} = require('../../lib/projects');
+} = require('../../lib/projects/config');
+const {
+  ensureProjectExists,
+} = require('../../lib/projects/ensureProjectExists');
+const { logFeedbackMessage } = require('../../lib/projects/ui');
 const { handleProjectUpload } = require('../../lib/projects/upload');
 const {
   pollBuildStatus,

--- a/commands/theme/preview.ts
+++ b/commands/theme/preview.ts
@@ -20,7 +20,7 @@ import {
 import { EXIT_CODES } from '../../lib/enums/exitCodes';
 import { ApiErrorContext, logError } from '../../lib/errorHandlers/index';
 import { handleExit, handleKeypress } from '../../lib/process';
-import { getProjectConfig } from '../../lib/projects';
+import { getProjectConfig } from '../../lib/projects/config';
 import { findProjectComponents } from '../../lib/projects/structure';
 import { ComponentTypes } from '../../types/Projects';
 import { hasFeature } from '../../lib/hasFeature';

--- a/lang/en.ts
+++ b/lang/en.ts
@@ -1128,8 +1128,8 @@ export const commands = {
         failedToFetchProjectDetails:
           'There was an error fetching project details',
         noFunctionsLinkText: 'Visit developer docs',
-        noFunctionsInProject: link =>
-          `There aren't any functions in this project\n\t- Run ${chalk.orange('hs project logs --help')} to learn more about logs\n\t- ${link} to learn more about serverless functions`,
+        noFunctionsInProject: (helpCommand, link) =>
+          `There aren't any functions in this project\n\t- Run ${helpCommand} to learn more about logs\n\t- ${link} to learn more about serverless functions`,
         noFunctionWithName: name => `No function with name "${name}"`,
         functionNotDeployed: name =>
           `The function with name "${name}" is not deployed`,
@@ -1211,12 +1211,11 @@ export const commands = {
         watchCancelledFromUi: () =>
           `The watch process has been cancelled from the UI. Any changes made since cancelling have not been uploaded. To resume watching, rerun ${chalk.yellow('`hs project watch`')}.`,
         resuming: 'Resuming watcher...',
-        uploadSucceeded: ({ filePath, remotePath }) =>
+        uploadSucceeded: (remotePath, filePath) =>
           `Uploaded file "${filePath}" to "${remotePath}"`,
-        deleteFileSucceeded: ({ remotePath }) => `Deleted file "${remotePath}"`,
-        deleteFolderSucceeded: ({ remotePath }) =>
-          `Deleted folder "${remotePath}"`,
-        watching: ({ projectDir }) =>
+        deleteFileSucceeded: remotePath => `Deleted file "${remotePath}"`,
+        deleteFolderSucceeded: remotePath => `Deleted folder "${remotePath}"`,
+        watching: projectDir =>
           `Watcher is ready and watching "${projectDir}". Any changes detected will be automatically uploaded.`,
         previousStagingBuildCancelled:
           'Killed the previous watch process. Please try running `hs project watch` again',
@@ -1229,22 +1228,20 @@ export const commands = {
       debug: {
         pause: 'Pausing watcher, attempting to queue build',
         buildStarted: 'Build queued.',
-        extensionNotAllowed: ({ filePath }) =>
+        extensionNotAllowed: filePath =>
           `Skipping "${filePath}" due to unsupported extension`,
-        ignored: ({ filePath }) =>
-          `Skipping "${filePath}" due to an ignore rule`,
-        uploading: ({ filePath, remotePath }) =>
+        ignored: filePath => `Skipping "${filePath}" due to an ignore rule`,
+        uploading: (filePath, remotePath) =>
           `Attempting to upload file "${filePath}" to "${remotePath}"`,
         attemptNewBuild: 'Attempting to create a new build',
-        fileAlreadyQueued: ({ filePath }) =>
+        fileAlreadyQueued: filePath =>
           `File "${filePath}" is already queued for upload`,
       },
       errors: {
-        uploadFailed: ({ filePath, remotePath }) =>
+        uploadFailed: (remotePath, filePath) =>
           `Failed to upload file "${filePath}" to "${remotePath}"`,
-        deleteFileFailed: ({ remotePath }) =>
-          `Failed to delete file "${remotePath}"`,
-        deleteFolderFailed: ({ remotePath }) =>
+        deleteFileFailed: remotePath => `Failed to delete file "${remotePath}"`,
+        deleteFolderFailed: remotePath =>
           `Failed to delete folder "${remotePath}"`,
       },
     },
@@ -1255,12 +1252,12 @@ export const commands = {
       },
       logs: {
         downloadCancelled: 'Cancelling project download',
-        downloadSucceeded: ({ buildId, projectName }) =>
+        downloadSucceeded: (buildId, projectName) =>
           `Downloaded build "${buildId}" from project "${projectName}"`,
       },
       errors: {
         downloadFailed: 'Something went wrong downloading the project',
-        projectNotFound: ({ projectName, accountId }) =>
+        projectNotFound: (projectName, accountId) =>
           `Your project ${chalk.bold(projectName)} could not be found in ${accountId}`,
       },
       warnings: {
@@ -1725,18 +1722,18 @@ export const commands = {
       },
     },
     success: {
-      fileUploaded: ({ src, dest, accountId }) =>
+      fileUploaded: (src, dest, accountId) =>
         `Uploaded file from "${src}" to "${dest}" in the Design Manager of account ${accountId}`,
-      uploadComplete: ({ dest }) =>
+      uploadComplete: dest =>
         `Uploading files to "${dest}" in the Design Manager is complete`,
     },
-    uploading: ({ src, dest, accountId }) =>
+    uploading: (src, dest, accountId) =>
       `Uploading files from "${src}" to "${dest}" in the Design Manager of account ${accountId}`,
-    notUploaded: ({ src }) =>
+    notUploaded: src =>
       `There was an error processing "${src}". The file has not been uploaded.`,
-    cleaning: ({ filePath, accountId }) =>
+    cleaning: (filePath, accountId) =>
       `Removing "${filePath}" from account ${accountId} and uploading local...`,
-    confirmCleanUpload: ({ filePath, accountId }) =>
+    confirmCleanUpload: (filePath, accountId) =>
       `You are about to delete the directory "${filePath}" and its contents on HubSpot account ${accountId} before uploading. This will also clear the global content associated with any global partial templates and modules. Are you sure you want to do this?`,
   },
   watch: {

--- a/lang/en.ts
+++ b/lang/en.ts
@@ -2762,9 +2762,9 @@ export const lib = {
   },
   projectBuildAndDeploy: {
     makePollTaskStatusFunc: {
-      componentCountSingular: 'Found 1 component in this project',
+      componentCountSingular: 'Found 1 component in this project\n',
       componentCount: numComponents =>
-        `Found ${numComponents} components in this project`,
+        `Found ${numComponents} components in this project\n`,
       successStatusText: 'DONE',
       failedStatusText: 'FAILED',
       errorFetchingTaskStatus: taskType => `Error fetching ${taskType} status`,

--- a/lang/en.ts
+++ b/lang/en.ts
@@ -1,7 +1,7 @@
 // @ts-nocheck
 import chalk from 'chalk';
 
-type LangFunction = (...args: string[] | number[]) => string;
+type LangFunction = (...args: (string | number)[]) => string;
 
 type LangObject = {
   [key: string]: string | LangFunction | LangObject;

--- a/lang/en.ts
+++ b/lang/en.ts
@@ -2650,6 +2650,8 @@ export const lib = {
       runUpload: command => `  * Run ${command}`,
       restartDev: command => `  * Re-run ${command}`,
       pushToGithub: '  * Commit and push your changes to GitHub',
+      defaultMarketplaceAppWarning: (installCount, accountText) =>
+        `${chalk.bold('Changing project configuration requires creating a new project build.')}\n\nYour marketplace app is currently installed in ${chalk.bold(`${installCount} ${accountText}`)}. Any uploaded changes will impact your app's users. We strongly recommend creating a copy of this app to test your changes before proceding.`,
     },
     activeInstallWarning: {
       installCount: (appName, installCount, installText) =>
@@ -2667,7 +2669,7 @@ export const lib = {
         `Failed to notify local dev server of file change: ${message}`,
     },
   },
-  localDev: {
+  localDevHelpers: {
     confirmDefaultAccountIsTarget: {
       configError: authCommand =>
         `An error occurred while reading the default account from your config. Run ${authCommand} to re-auth this account`,
@@ -3252,6 +3254,7 @@ export const lib = {
             instructions: (accountName, url) =>
               `To update CLI permissions for "${accountName}": \n- Go to ${url}, deactivate the existing personal access key, and create a new one that includes developer sandbox permissions. \n- Update the CLI config for this account by running ${chalk.bold('hs auth')} and entering the new key.\n`,
           },
+          generic: 'An error occured while creating a developer sandbox',
         },
       },
       standard: {

--- a/lang/en.ts
+++ b/lang/en.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import chalk from 'chalk';
-import { uiAccountDescription, uiCommandReference } from '../lib/ui';
+import { uiAccountDescription, uiCommandReference, uiLink } from '../lib/ui';
 
 type LangFunction = (...args: (string | number)[]) => string;
 

--- a/lang/en.ts
+++ b/lang/en.ts
@@ -1,6 +1,12 @@
 // @ts-nocheck
 import chalk from 'chalk';
 
+type LangFunction = (...args: string[] | number[]) => string;
+
+type LangObject = {
+  [key: string]: string | LangFunction | LangObject;
+};
+
 export const commands = {
   generalErrors: {
     updateNotify: {
@@ -2597,7 +2603,8 @@ export const commands = {
       },
     },
   },
-};
+} as const satisfies LangObject;
+
 export const lib = {
   process: {
     exitDebug: signal =>
@@ -3451,7 +3458,7 @@ export const lib = {
         listedInMarketplace: 'Listed apps are not currently migratable',
         generic: reasonCode => `Unable to migrate app: ${reasonCode}`,
       },
-      noAppsEligible: (accountId, reasons) =>
+      noAppsEligible: (accountId, reasons: string[]) =>
         `No apps in account ${accountId} are currently migratable${reasons.length ? `\n  - ${reasons.join('\n  - ')}` : ''}`,
 
       invalidAccountTypeTitle: () =>
@@ -3489,4 +3496,4 @@ export const lib = {
       copyingProjectFilesFailed: 'Unable to copy migrated project files',
     },
   },
-};
+} as const satisfies LangObject;

--- a/lang/en.ts
+++ b/lang/en.ts
@@ -1128,8 +1128,10 @@ export const commands = {
         failedToFetchProjectDetails:
           'There was an error fetching project details',
         noFunctionsLinkText: 'Visit developer docs',
-        noFunctionsInProject: (helpCommand, link) =>
-          `There aren't any functions in this project\n\t- Run ${helpCommand} to learn more about logs\n\t- ${link} to learn more about serverless functions`,
+        noFunctionsInProject: `There aren't any functions in this project\n\t- Run ${uiCommandReference('hs project logs --help')} to learn more about logs\n\t- ${uiLink(
+          'Visit developer docs',
+          'https://developers.hubspot.com/docs/platform/serverless-functions'
+        )} to learn more about serverless functions`,
         noFunctionWithName: name => `No function with name "${name}"`,
         functionNotDeployed: name =>
           `The function with name "${name}" is not deployed`,
@@ -2629,8 +2631,7 @@ export const lib = {
     exitingStart: 'Stopping local dev server ...',
     exitingSucceed: 'Successfully exited',
     exitingFail: 'Failed to cleanup before exiting',
-    missingUid: devCommand =>
-      `Could not find a uid for the selected app. Confirm that the app config file contains the uid field and re-run ${devCommand}.`,
+    missingUid: `Could not find a uid for the selected app. Confirm that the app config file contains the uid field and re-run ${uiCommandReference('hs project dev')}.`,
     uploadWarning: {
       appLabel: '[App]',
       uiExtensionLabel: '[UI Extension]',
@@ -2643,9 +2644,9 @@ export const lib = {
         `${chalk.bold('Changing project configuration requires a new project build.')}\n\nThis will affect your public app's ${chalk.bold(`${installCount} existing ${installText}`)}. If your app has users in production, we strongly recommend creating a copy of this app to test your changes before proceding.`,
       header: warning =>
         `${warning} To reflect these changes and continue testing:`,
-      stopDev: command => `  * Stop ${command}`,
+      stopDev: `  * Stop ${uiCommandReference('hs project dev')}`,
       runUpload: command => `  * Run ${command}`,
-      restartDev: command => `  * Re-run ${command}`,
+      restartDev: `  * Re-run ${uiCommandReference('hs project dev')}`,
       pushToGithub: '  * Commit and push your changes to GitHub',
       defaultMarketplaceAppWarning: (installCount, accountText) =>
         `${chalk.bold('Changing project configuration requires creating a new project build.')}\n\nYour marketplace app is currently installed in ${chalk.bold(`${installCount} ${accountText}`)}. Any uploaded changes will impact your app's users. We strongly recommend creating a copy of this app to test your changes before proceding.`,
@@ -2668,22 +2669,16 @@ export const lib = {
   },
   localDevHelpers: {
     confirmDefaultAccountIsTarget: {
-      configError: authCommand =>
-        `An error occurred while reading the default account from your config. Run ${authCommand} to re-auth this account`,
-      declineDefaultAccountExplanation: (useCommand, devCommand) =>
-        `To develop on a different account, run ${useCommand} to change your default account, then re-run ${devCommand}.`,
+      configError: `An error occurred while reading the default account from your config. Run ${uiCommandReference('hs auth')} to re-auth this account`,
+      declineDefaultAccountExplanation: `To develop on a different account, run ${uiCommandReference('hs accounts use')} to change your default account, then re-run ${uiCommandReference('hs project dev')}.`,
     },
     checkIfDefaultAccountIsSupported: {
-      publicApp: (useCommand, authCommand) =>
-        `This project contains a public app. Local development of public apps is only supported on developer accounts and developer test accounts. Change your default account using ${useCommand}, or link a new account with ${authCommand}.`,
-      privateApp: (useCommand, authCommand) =>
-        `This project contains a private app. Local development of private apps is not supported in developer accounts. Change your default account using ${useCommand}, or link a new account with ${authCommand}.`,
+      publicApp: `This project contains a public app. Local development of public apps is only supported on developer accounts and developer test accounts. Change your default account using ${uiCommandReference('hs accounts use')}, or link a new account with ${uiCommandReference('hs auth')}.`,
+      privateApp: `This project contains a private app. Local development of private apps is not supported in developer accounts. Change your default account using ${uiCommandReference('hs accounts use')}, or link a new account with ${uiCommandReference('hs auth')}.`,
     },
     validateAccountOption: {
-      invalidPublicAppAccount: (useCommand, devCommand) =>
-        `This project contains a public app. The "--account" flag must point to a developer test account to develop this project locally. Alternatively, change your default account to an App Developer Account using ${useCommand} and run ${devCommand} to set up a new Developer Test Account.`,
-      invalidPrivateAppAccount: useCommand =>
-        `This project contains a private app. The account specified with the "--account" flag points to a developer account, which do not support the local development of private apps. Update the "--account" flag to point to a standard, sandbox, or developer test account, or change your default account by running ${useCommand}.`,
+      invalidPublicAppAccount: `This project contains a public app. The "--account" flag must point to a developer test account to develop this project locally. Alternatively, change your default account to an App Developer Account using ${uiCommandReference('hs accounts use')} and run ${uiCommandReference('hs project dev')} to set up a new Developer Test Account.`,
+      invalidPrivateAppAccount: `This project contains a private app. The account specified with the "--account" flag points to a developer account, which do not support the local development of private apps. Update the "--account" flag to point to a standard, sandbox, or developer test account, or change your default account by running ${uiCommandReference('hs accounts use')}.`,
       nonSandboxWarning: command =>
         `Testing in a sandbox is strongly recommended. To switch the target account, select an option below or run ${chalk.bold(command)} before running the command again.`,
       publicAppNonDeveloperTestAccountWarning: () =>
@@ -2708,12 +2703,13 @@ export const lib = {
       initialUploadMessage: 'HubSpot Local Dev Server Startup',
       projectLockedError:
         'Your project is locked. This may mean that another user is running the `hs project watch` command for this project. If this is you, unlock the project in Projects UI.',
-      genericError: uploadCommand =>
-        `An error occurred while creating the initial build for this project. Run ${uploadCommand} to try again.`,
+      genericError: `An error occurred while creating the initial build for this project. Run ${uiCommandReference('hs project upload')} to try again.`,
     },
     checkIfParentAccountIsAuthed: {
-      notAuthedError: (authCommand, accountId, accountIdentifier) =>
-        `To develop this project locally, run ${authCommand} to authenticate the App Developer Account ${accountId} associated with ${accountIdentifier}.`,
+      notAuthedError: (parentAccountId, accountIdentifier) =>
+        `To develop this project locally, run ${uiCommandReference(
+          `hs auth --account=${parentAccountId}`
+        )} to authenticate the App Developer Account ${parentAccountId} associated with ${accountIdentifier}.`,
     },
   },
   projects: {
@@ -2728,8 +2724,7 @@ export const lib = {
       },
     },
     validateProjectConfig: {
-      configNotFound: createCommand =>
-        `Unable to locate a project configuration file. Try running again from a project directory, or run ${createCommand} to create a new project.`,
+      configNotFound: `Unable to locate a project configuration file. Try running again from a project directory, or run ${uiCommandReference('hs project create')} to create a new project.`,
       configMissingFields:
         'The project configuration file is missing required fields.',
       srcDirNotFound: (srcDir, projectDir) =>
@@ -2789,8 +2784,8 @@ export const lib = {
         `Project "${projectName}" uploaded and build #${buildId} created`,
     },
     handleProjectUpload: {
-      emptySource: (srcDir, command) =>
-        `Source directory "${srcDir}" is empty. Add files to your project and rerun ${chalk.yellow(command)} to upload them to HubSpot.`,
+      emptySource: srcDir =>
+        `Source directory "${srcDir}" is empty. Add files to your project and rerun ${uiCommandReference('hs project upload')} to upload them to HubSpot.`,
       compressed: byteCount => `Project files compressed: ${byteCount} bytes`,
       compressing: path => `Compressing build files to "${path}"`,
       fileFiltered: filename => `Ignore rule triggered for "${filename}"`,

--- a/lib/__tests__/dependencyManagement.test.ts
+++ b/lib/__tests__/dependencyManagement.test.ts
@@ -1,4 +1,4 @@
-jest.mock('../projects');
+jest.mock('../projects/config');
 jest.mock('@hubspot/local-dev-lib/logger');
 jest.mock('@hubspot/local-dev-lib/fs');
 jest.mock('../ui/SpinniesManager');
@@ -16,7 +16,7 @@ import {
 } from '../dependencyManagement';
 import { walk } from '@hubspot/local-dev-lib/fs';
 import path from 'path';
-import { getProjectConfig } from '../projects';
+import { getProjectConfig } from '../projects/config';
 import SpinniesManager from '../ui/SpinniesManager';
 import { existsSync } from 'fs';
 

--- a/lib/app/migrate.ts
+++ b/lib/app/migrate.ts
@@ -11,7 +11,8 @@ import { MIGRATION_STATUS } from '@hubspot/local-dev-lib/types/Migration';
 import { downloadProject } from '@hubspot/local-dev-lib/api/projects';
 import { confirmPrompt, inputPrompt, listPrompt } from '../prompts/promptUtils';
 import { uiAccountDescription, uiCommandReference, uiLine } from '../ui';
-import { ensureProjectExists, LoadedProjectConfig } from '../projects';
+import { LoadedProjectConfig } from '../projects/config';
+import { ensureProjectExists } from '../projects/ensureProjectExists';
 import SpinniesManager from '../ui/SpinniesManager';
 import { DEFAULT_POLLING_STATUS_LOOKUP, poll } from '../polling';
 import {

--- a/lib/app/migrate_legacy.ts
+++ b/lib/app/migrate_legacy.ts
@@ -19,7 +19,7 @@ import { i18n } from '../lang';
 import { isAppDeveloperAccount, isUnifiedAccount } from '../accountTypes';
 import { selectPublicAppPrompt } from '../prompts/selectPublicAppPrompt';
 import { createProjectPrompt } from '../prompts/createProjectPrompt';
-import { ensureProjectExists } from '../projects';
+import { ensureProjectExists } from '../projects/ensureProjectExists';
 import { trackCommandMetadataUsage } from '../usageTracking';
 import SpinniesManager from '../ui/SpinniesManager';
 import { handleKeypress } from '../process';

--- a/lib/dependencyManagement.ts
+++ b/lib/dependencyManagement.ts
@@ -1,5 +1,5 @@
 import { logger } from '@hubspot/local-dev-lib/logger';
-import { getProjectConfig } from './projects';
+import { getProjectConfig } from './projects/config';
 import { exec as execAsync } from 'child_process';
 import { walk } from '@hubspot/local-dev-lib/fs';
 import path from 'path';

--- a/lib/doctor/DiagnosticInfoBuilder.ts
+++ b/lib/doctor/DiagnosticInfoBuilder.ts
@@ -1,4 +1,4 @@
-import { getProjectConfig } from '../projects';
+import { getProjectConfig } from '../projects/config';
 import { fetchProject } from '@hubspot/local-dev-lib/api/projects';
 import path from 'path';
 import pkg from '../../package.json';

--- a/lib/doctor/__tests__/DiagnosticInfoBuilder.test.ts
+++ b/lib/doctor/__tests__/DiagnosticInfoBuilder.test.ts
@@ -3,7 +3,7 @@ import util from 'util';
 jest.mock('@hubspot/local-dev-lib/fs');
 jest.mock('@hubspot/local-dev-lib/config');
 jest.mock('@hubspot/local-dev-lib/personalAccessKey');
-jest.mock('../../projects');
+jest.mock('../../projects/config');
 jest.mock('@hubspot/local-dev-lib/api/projects');
 jest.mock('util', () => ({
   ...jest.requireActual('util'),
@@ -25,7 +25,7 @@ import {
 import { getAccessToken as _getAccessToken } from '@hubspot/local-dev-lib/personalAccessKey';
 import { walk as _walk } from '@hubspot/local-dev-lib/fs';
 import { AccessToken, CLIAccount } from '@hubspot/local-dev-lib/types/Accounts';
-import { getProjectConfig as _getProjectConfig } from '../../projects';
+import { getProjectConfig as _getProjectConfig } from '../../projects/config';
 import { fetchProject as _fetchProject } from '@hubspot/local-dev-lib/api/projects';
 import { Project } from '@hubspot/local-dev-lib/types/Project';
 import { HubSpotPromise } from '@hubspot/local-dev-lib/types/Http';

--- a/lib/middleware/__test__/yargsChecksMiddleware.test.ts
+++ b/lib/middleware/__test__/yargsChecksMiddleware.test.ts
@@ -1,7 +1,7 @@
 import { Arguments } from 'yargs';
 import { logger } from '@hubspot/local-dev-lib/logger';
 import { EXIT_CODES } from '../../enums/exitCodes';
-import * as projects from '../../projects';
+import * as projectsConfig from '../../projects/config';
 import { performChecks } from '../yargsChecksMiddleware';
 
 jest.mock('@hubspot/local-dev-lib/logger', () => ({
@@ -9,12 +9,12 @@ jest.mock('@hubspot/local-dev-lib/logger', () => ({
     error: jest.fn(),
   },
 }));
-jest.mock('../../projects');
+jest.mock('../../projects/config');
 jest.mock('../../lang', () => ({
   i18n: jest.fn(key => key),
 }));
 
-const getIsInProjectSpy = jest.spyOn(projects, 'getIsInProject');
+const getIsInProjectSpy = jest.spyOn(projectsConfig, 'getIsInProject');
 const processExitSpy = jest.spyOn(process, 'exit');
 
 describe('lib/middleware/yargsChecksMiddleware', () => {

--- a/lib/middleware/yargsChecksMiddleware.ts
+++ b/lib/middleware/yargsChecksMiddleware.ts
@@ -2,7 +2,7 @@ import { Arguments } from 'yargs';
 import { logger } from '@hubspot/local-dev-lib/logger';
 import { EXIT_CODES } from '../enums/exitCodes';
 import { i18n } from '../lang';
-import { getIsInProject } from '../projects';
+import { getIsInProject } from '../projects/config';
 import { isTargetedCommand } from './utils';
 
 const UPLOAD_AND_WATCH_COMMANDS = {

--- a/lib/projects/ProjectLogsManager.ts
+++ b/lib/projects/ProjectLogsManager.ts
@@ -3,7 +3,6 @@ import { ensureProjectExists } from './ensureProjectExists';
 import { fetchProjectComponentsMetadata } from '@hubspot/local-dev-lib/api/projects';
 import { AppFunctionComponentMetadata } from '@hubspot/local-dev-lib/types/ComponentStructure';
 import { logger } from '@hubspot/local-dev-lib/logger';
-import { uiCommandReference, uiLink } from '../ui';
 import { commands } from '../../lang/en';
 
 class _ProjectLogsManager {
@@ -97,15 +96,7 @@ class _ProjectLogsManager {
     });
 
     if (this.functions.length === 0) {
-      throw new Error(
-        commands.project.logs.errors.noFunctionsInProject(
-          uiCommandReference('hs project logs --help'),
-          uiLink(
-            commands.project.logs.errors.noFunctionsLinkText,
-            'https://developers.hubspot.com/docs/platform/serverless-functions'
-          )
-        )
-      );
+      throw new Error(commands.project.logs.errors.noFunctionsInProject);
     }
   }
 
@@ -117,15 +108,7 @@ class _ProjectLogsManager {
 
   setFunction(functionName?: string) {
     if (!functionName || this.functions.length === 0) {
-      throw new Error(
-        commands.project.logs.errors.noFunctionsInProject(
-          uiCommandReference('hs project logs --help'),
-          uiLink(
-            commands.project.logs.errors.noFunctionsLinkText,
-            'https://developers.hubspot.com/docs/platform/serverless-functions'
-          )
-        )
-      );
+      throw new Error(commands.project.logs.errors.noFunctionsInProject);
     }
 
     this.selectedFunction = this.functions.find(

--- a/lib/projects/ProjectLogsManager.ts
+++ b/lib/projects/ProjectLogsManager.ts
@@ -1,4 +1,5 @@
-import { getProjectConfig, ensureProjectExists } from './index';
+import { getProjectConfig } from './config';
+import { ensureProjectExists } from './ensureProjectExists';
 import { fetchProjectComponentsMetadata } from '@hubspot/local-dev-lib/api/projects';
 import { AppFunctionComponentMetadata } from '@hubspot/local-dev-lib/types/ComponentStructure';
 import { logger } from '@hubspot/local-dev-lib/logger';

--- a/lib/projects/ProjectLogsManager.ts
+++ b/lib/projects/ProjectLogsManager.ts
@@ -3,10 +3,8 @@ import { ensureProjectExists } from './ensureProjectExists';
 import { fetchProjectComponentsMetadata } from '@hubspot/local-dev-lib/api/projects';
 import { AppFunctionComponentMetadata } from '@hubspot/local-dev-lib/types/ComponentStructure';
 import { logger } from '@hubspot/local-dev-lib/logger';
-import { i18n } from '../lang';
 import { uiLink } from '../ui';
-
-const i18nKey = 'commands.project.subcommands.logs';
+import { commands } from '../../lang/en';
 
 class _ProjectLogsManager {
   projectName: string | undefined;
@@ -39,7 +37,7 @@ class _ProjectLogsManager {
     const { projectConfig } = await getProjectConfig();
 
     if (!projectConfig || !projectConfig.name) {
-      throw new Error(i18n(`${i18nKey}.errors.noProjectConfig`));
+      throw new Error(commands.project.logs.errors.noProjectConfig);
     }
 
     const { name: projectName } = projectConfig;
@@ -61,7 +59,7 @@ class _ProjectLogsManager {
       !project.deployedBuild ||
       !project.deployedBuild.subbuildStatuses
     ) {
-      throw new Error(i18n(`${i18nKey}.errors.failedToFetchProjectDetails`));
+      throw new Error(commands.project.logs.errors.failedToFetchProjectDetails);
     }
 
     this.projectId = project.id;
@@ -70,12 +68,14 @@ class _ProjectLogsManager {
 
   async fetchFunctionDetails(): Promise<void> {
     if (!this.projectId) {
-      throw new Error(i18n(`${i18nKey}.errors.noProjectConfig`));
+      throw new Error(commands.project.logs.errors.noProjectConfig);
     }
 
     if (!this.accountId) {
-      logger.debug(i18n(`${i18nKey}.errors.projectLogsManagerNotInitialized`));
-      throw new Error(i18n(`${i18nKey}.errors.generic`));
+      logger.debug(
+        commands.project.logs.errors.projectLogsManagerNotInitialized
+      );
+      throw new Error(commands.project.logs.errors.generic);
     }
 
     const {
@@ -98,12 +98,12 @@ class _ProjectLogsManager {
 
     if (this.functions.length === 0) {
       throw new Error(
-        i18n(`${i18nKey}.errors.noFunctionsInProject`, {
-          link: uiLink(
-            i18n(`${i18nKey}.errors.noFunctionsLinkText`),
+        commands.project.logs.errors.noFunctionsInProject(
+          uiLink(
+            commands.project.logs.errors.noFunctionsLinkText,
             'https://developers.hubspot.com/docs/platform/serverless-functions'
-          ),
-        })
+          )
+        )
       );
     }
   }
@@ -117,12 +117,12 @@ class _ProjectLogsManager {
   setFunction(functionName?: string) {
     if (!functionName || this.functions.length === 0) {
       throw new Error(
-        i18n(`${i18nKey}.errors.noFunctionsInProject`, {
-          link: uiLink(
-            i18n(`${i18nKey}.errors.noFunctionsLinkText`),
+        commands.project.logs.errors.noFunctionsInProject(
+          uiLink(
+            commands.project.logs.errors.noFunctionsLinkText,
             'https://developers.hubspot.com/docs/platform/serverless-functions'
-          ),
-        })
+          )
+        )
       );
     }
 
@@ -132,7 +132,7 @@ class _ProjectLogsManager {
 
     if (!this.selectedFunction) {
       throw new Error(
-        i18n(`${i18nKey}.errors.noFunctionWithName`, { name: functionName })
+        commands.project.logs.errors.noFunctionWithName(functionName)
       );
     }
 
@@ -140,7 +140,7 @@ class _ProjectLogsManager {
 
     if (!this.selectedFunction.deployOutput) {
       throw new Error(
-        i18n(`${i18nKey}.errors.functionNotDeployed`, { name: functionName })
+        commands.project.logs.errors.functionNotDeployed(functionName)
       );
     }
     this.appId = this.selectedFunction.deployOutput.appId;

--- a/lib/projects/ProjectLogsManager.ts
+++ b/lib/projects/ProjectLogsManager.ts
@@ -3,7 +3,7 @@ import { ensureProjectExists } from './ensureProjectExists';
 import { fetchProjectComponentsMetadata } from '@hubspot/local-dev-lib/api/projects';
 import { AppFunctionComponentMetadata } from '@hubspot/local-dev-lib/types/ComponentStructure';
 import { logger } from '@hubspot/local-dev-lib/logger';
-import { uiLink } from '../ui';
+import { uiCommandReference, uiLink } from '../ui';
 import { commands } from '../../lang/en';
 
 class _ProjectLogsManager {
@@ -99,6 +99,7 @@ class _ProjectLogsManager {
     if (this.functions.length === 0) {
       throw new Error(
         commands.project.logs.errors.noFunctionsInProject(
+          uiCommandReference('hs project logs --help'),
           uiLink(
             commands.project.logs.errors.noFunctionsLinkText,
             'https://developers.hubspot.com/docs/platform/serverless-functions'
@@ -118,6 +119,7 @@ class _ProjectLogsManager {
     if (!functionName || this.functions.length === 0) {
       throw new Error(
         commands.project.logs.errors.noFunctionsInProject(
+          uiCommandReference('hs project logs --help'),
           uiLink(
             commands.project.logs.errors.noFunctionsLinkText,
             'https://developers.hubspot.com/docs/platform/serverless-functions'

--- a/lib/projects/__tests__/ProjectLogsManager.test.ts
+++ b/lib/projects/__tests__/ProjectLogsManager.test.ts
@@ -1,5 +1,6 @@
 import { ProjectLogsManager } from '../ProjectLogsManager';
-import { getProjectConfig, ensureProjectExists } from '..';
+import { getProjectConfig } from '../config';
+import { ensureProjectExists } from '../ensureProjectExists';
 import { fetchProjectComponentsMetadata } from '@hubspot/local-dev-lib/api/projects';
 
 const SUBCOMPONENT_TYPES = {
@@ -15,7 +16,8 @@ const SUBCOMPONENT_TYPES = {
   REACT_EXTENSION: 'REACT_EXTENSION',
 } as const;
 
-jest.mock('../../projects');
+jest.mock('../../projects/config');
+jest.mock('../../projects/ensureProjectExists');
 jest.mock('@hubspot/local-dev-lib/api/projects');
 
 describe('lib/projects/ProjectLogsManager', () => {

--- a/lib/projects/__tests__/projects.test.ts
+++ b/lib/projects/__tests__/projects.test.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { EXIT_CODES } from '../../enums/exitCodes';
-import { validateProjectConfig } from '../../projects';
+import { validateProjectConfig } from '../../projects/config';
 import { logger } from '@hubspot/local-dev-lib/logger';
 
 jest.mock('@hubspot/local-dev-lib/logger');

--- a/lib/projects/buildAndDeploy.ts
+++ b/lib/projects/buildAndDeploy.ts
@@ -23,14 +23,8 @@ import {
   PROJECT_ERROR_TYPES,
 } from '../constants';
 import SpinniesManager from '../ui/SpinniesManager';
-import { i18n } from '../lang';
 import { logError, ApiErrorContext } from '../errorHandlers';
-import {
-  uiLine,
-  uiLink,
-  uiAccountDescription,
-  uiCommandReference,
-} from '../ui';
+import { uiLine, uiLink, uiAccountDescription } from '../ui';
 import {
   getProjectBuildDetailUrl,
   getProjectDeployDetailUrl,
@@ -44,8 +38,7 @@ import {
   ProjectPollResult,
 } from '../../types/Projects';
 import { EXIT_CODES } from '../enums/exitCodes';
-
-const i18nKey = 'lib.projectBuildAndDeploy';
+import { lib } from '../../lang/en';
 
 const SPINNER_STATUS = {
   SPINNING: 'spinning',
@@ -124,13 +117,9 @@ function handleTaskStatusError(
   statusText: ProjectPollStatusFunctionText
 ): never {
   logger.error(
-    i18n(`${i18nKey}.makePollTaskStatusFunc.errorFetchingTaskStatus`, {
-      taskType:
-        statusText.TYPE_KEY === PROJECT_BUILD_TEXT.TYPE_KEY
-          ? 'build'
-          : 'deploy',
-      openCommand: uiCommandReference('hs project open'),
-    })
+    lib.projectBuildAndDeploy.makePollTaskStatusFunc.errorFetchingTaskStatus(
+      statusText.TYPE_KEY === PROJECT_BUILD_TEXT.TYPE_KEY ? 'build' : 'deploy'
+    )
   );
   process.exit(EXIT_CODES.ERROR);
 }
@@ -203,12 +192,12 @@ function makePollTaskStatusFunc<T extends ProjectTask>({
     const numComponents = structuredTasks.length;
     const componentCountText = silenceLogs
       ? ''
-      : i18n(
-          numComponents === 1
-            ? `${i18nKey}.makePollTaskStatusFunc.componentCountSingular`
-            : `${i18nKey}.makePollTaskStatusFunc.componentCount`,
-          { numComponents }
-        ) + '\n';
+      : numComponents === 1
+        ? lib.projectBuildAndDeploy.makePollTaskStatusFunc
+            .componentCountSingular
+        : lib.projectBuildAndDeploy.makePollTaskStatusFunc.componentCount(
+            numComponents
+          );
 
     SpinniesManager.update(overallTaskSpinniesKey, {
       text: `${statusStrings.INITIALIZE(
@@ -292,8 +281,10 @@ function makePollTaskStatusFunc<T extends ProjectTask>({
             ) {
               const taskStatusText =
                 subtask.status === statusText.STATES.SUCCESS
-                  ? i18n(`${i18nKey}.makePollTaskStatusFunc.successStatusText`)
-                  : i18n(`${i18nKey}.makePollTaskStatusFunc.failedStatusText`);
+                  ? lib.projectBuildAndDeploy.makePollTaskStatusFunc
+                      .successStatusText
+                  : lib.projectBuildAndDeploy.makePollTaskStatusFunc
+                      .failedStatusText;
               const hasNewline =
                 spinner?.text?.includes('\n') || Boolean(topLevelTask);
               const updatedText = `${spinner?.text?.replace(
@@ -397,7 +388,7 @@ function pollBuildAutodeployStatus(
         logger.debug(e);
         return reject(
           new Error(
-            i18n(`${i18nKey}.pollBuildAutodeployStatusError`, { buildId })
+            lib.projectBuildAndDeploy.pollBuildAutodeployStatusError(buildId)
           )
         );
       }
@@ -405,7 +396,7 @@ function pollBuildAutodeployStatus(
       if (!build || !build.status) {
         return reject(
           new Error(
-            i18n(`${i18nKey}.pollBuildAutodeployStatusError`, { buildId })
+            lib.projectBuildAndDeploy.pollBuildAutodeployStatusError(buildId)
           )
         );
       }
@@ -534,12 +525,9 @@ export async function pollProjectBuildAndDeploy(
   } else if (buildStatus.isAutoDeployEnabled) {
     if (!silenceLogs) {
       logger.log(
-        i18n(
-          `${i18nKey}.pollProjectBuildAndDeploy.buildSucceededAutomaticallyDeploying`,
-          {
-            accountIdentifier: uiAccountDescription(accountId),
-            buildId,
-          }
+        lib.projectBuildAndDeploy.pollProjectBuildAndDeploy.buildSucceededAutomaticallyDeploying(
+          buildId,
+          uiAccountDescription(accountId)
         )
       );
 
@@ -574,15 +562,12 @@ export async function pollProjectBuildAndDeploy(
       }
     } else if (!silenceLogs) {
       logger.log(
-        i18n(
-          `${i18nKey}.pollProjectBuildAndDeploy.unableToFindAutodeployStatus`,
-          {
-            buildId,
-            viewDeploysLink: uiLink(
-              i18n(`${i18nKey}.pollProjectBuildAndDeploy.viewDeploys`),
-              getProjectActivityUrl(projectConfig.name, accountId)
-            ),
-          }
+        lib.projectBuildAndDeploy.pollProjectBuildAndDeploy.unableToFindAutodeployStatus(
+          buildId,
+          uiLink(
+            lib.projectBuildAndDeploy.pollProjectBuildAndDeploy.viewDeploys,
+            getProjectActivityUrl(projectConfig.name, accountId)
+          )
         )
       );
     }
@@ -592,9 +577,9 @@ export async function pollProjectBuildAndDeploy(
     if (tempFile) {
       tempFile.removeCallback();
       logger.debug(
-        i18n(`${i18nKey}.pollProjectBuildAndDeploy.cleanedUpTempFile`, {
-          path: tempFile.name,
-        })
+        lib.projectBuildAndDeploy.pollProjectBuildAndDeploy.cleanedUpTempFile(
+          tempFile.name
+        )
       );
     }
   } catch (e) {

--- a/lib/projects/config.ts
+++ b/lib/projects/config.ts
@@ -1,0 +1,113 @@
+import fs from 'fs-extra';
+import path from 'path';
+import findup from 'findup-sync';
+import { logger } from '@hubspot/local-dev-lib/logger';
+import { getAbsoluteFilePath, getCwd } from '@hubspot/local-dev-lib/path';
+
+import { ProjectConfig } from '../../types/Projects';
+import { PROJECT_CONFIG_FILE } from '../constants';
+import { lib } from '../../lang/en';
+import { uiCommandReference } from '../ui';
+import { EXIT_CODES } from '../enums/exitCodes';
+
+export function writeProjectConfig(
+  configPath: string,
+  config: ProjectConfig
+): boolean {
+  try {
+    fs.ensureFileSync(configPath);
+    fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+    logger.debug(`Wrote project config at ${configPath}`);
+  } catch (e) {
+    logger.debug(e);
+    return false;
+  }
+  return true;
+}
+
+export function getIsInProject(dir?: string): boolean {
+  const configPath = getProjectConfigPath(dir);
+  return !!configPath;
+}
+
+function getProjectConfigPath(dir?: string): string | null {
+  const projectDir = dir ? getAbsoluteFilePath(dir) : getCwd();
+
+  const configPath = findup(PROJECT_CONFIG_FILE, {
+    cwd: projectDir,
+    nocase: true,
+  });
+
+  return configPath;
+}
+
+export interface LoadedProjectConfig {
+  projectDir: string | null;
+  projectConfig: ProjectConfig | null;
+}
+
+export async function getProjectConfig(
+  dir?: string
+): Promise<LoadedProjectConfig> {
+  const configPath = getProjectConfigPath(dir);
+  if (!configPath) {
+    return { projectConfig: null, projectDir: null };
+  }
+
+  try {
+    const config = fs.readFileSync(configPath);
+    const projectConfig: ProjectConfig = JSON.parse(config.toString());
+    return {
+      projectDir: path.dirname(configPath),
+      projectConfig,
+    };
+  } catch (e) {
+    logger.error('Could not read from project config');
+    return { projectConfig: null, projectDir: null };
+  }
+}
+
+export function validateProjectConfig(
+  projectConfig: ProjectConfig | null,
+  projectDir: string | null
+): asserts projectConfig is ProjectConfig {
+  if (!projectConfig || !projectDir) {
+    logger.error(
+      lib.projects.validateProjectConfig.configNotFound(
+        uiCommandReference('hs project create')
+      )
+    );
+    return process.exit(EXIT_CODES.ERROR);
+  }
+
+  if (!projectConfig.name || !projectConfig.srcDir) {
+    logger.error(lib.projects.validateProjectConfig.configMissingFields);
+    return process.exit(EXIT_CODES.ERROR);
+  }
+
+  const resolvedPath = path.resolve(projectDir, projectConfig.srcDir);
+  if (!resolvedPath.startsWith(projectDir)) {
+    const projectConfigFile = path.relative(
+      '.',
+      path.join(projectDir, PROJECT_CONFIG_FILE)
+    );
+    logger.error(
+      lib.projects.validateProjectConfig.srcOutsideProjectDir(
+        projectConfigFile,
+        projectConfig.srcDir
+      )
+    );
+    return process.exit(EXIT_CODES.ERROR);
+  }
+
+  if (!fs.existsSync(resolvedPath)) {
+    logger.error(
+      lib.projects.validateProjectConfig.srcDirNotFound(
+        projectConfig.srcDir,
+        projectDir
+      )
+    );
+
+    return process.exit(EXIT_CODES.ERROR);
+  }
+}

--- a/lib/projects/config.ts
+++ b/lib/projects/config.ts
@@ -7,7 +7,6 @@ import { getAbsoluteFilePath, getCwd } from '@hubspot/local-dev-lib/path';
 import { ProjectConfig } from '../../types/Projects';
 import { PROJECT_CONFIG_FILE } from '../constants';
 import { lib } from '../../lang/en';
-import { uiCommandReference } from '../ui';
 import { EXIT_CODES } from '../enums/exitCodes';
 
 export function writeProjectConfig(
@@ -72,11 +71,7 @@ export function validateProjectConfig(
   projectDir: string | null
 ): asserts projectConfig is ProjectConfig {
   if (!projectConfig || !projectDir) {
-    logger.error(
-      lib.projects.validateProjectConfig.configNotFound(
-        uiCommandReference('hs project create')
-      )
-    );
+    logger.error(lib.projects.validateProjectConfig.configNotFound);
     return process.exit(EXIT_CODES.ERROR);
   }
 

--- a/lib/projects/create.ts
+++ b/lib/projects/create.ts
@@ -6,15 +6,13 @@ import {
   PROJECT_COMPONENT_TYPES,
 } from '../constants';
 import { EXIT_CODES } from '../enums/exitCodes';
-import { i18n } from '../lang';
 import {
   ProjectTemplate,
   ComponentTemplate,
   ProjectTemplateRepoConfig,
 } from '../../types/Projects';
 import { debugError } from '../errorHandlers/index';
-
-const i18nKey = 'lib.projects.create';
+import { lib } from '../../lang/en';
 
 export const EMPTY_PROJECT_TEMPLATE_NAME = 'no-template';
 const PROJECT_TEMPLATE_PROPERTIES = ['name', 'label', 'path', 'insertPath'];
@@ -56,12 +54,12 @@ export async function getProjectTemplateListFromRepo(
     config = data;
   } catch (e) {
     debugError(e);
-    logger.error(i18n(`${i18nKey}.errors.missingConfigFileTemplateSource`));
+    logger.error(lib.projects.create.errors.missingConfigFileTemplateSource);
     return process.exit(EXIT_CODES.ERROR);
   }
 
   if (!config || !config[PROJECT_COMPONENT_TYPES.PROJECTS]) {
-    logger.error(i18n(`${i18nKey}.errors.noProjectsInConfig`));
+    logger.error(lib.projects.create.errors.noProjectsInConfig);
     return process.exit(EXIT_CODES.ERROR);
   }
 
@@ -74,7 +72,7 @@ export async function getProjectTemplateListFromRepo(
   );
 
   if (!templatesContainAllProperties) {
-    logger.error(i18n(`${i18nKey}.errors.missingPropertiesInConfig`));
+    logger.error(lib.projects.create.errors.missingPropertiesInConfig);
     return process.exit(EXIT_CODES.ERROR);
   }
 

--- a/lib/projects/ensureProjectExists.ts
+++ b/lib/projects/ensureProjectExists.ts
@@ -11,11 +11,9 @@ import { DEFAULT_POLLING_DELAY } from '../constants';
 import { promptUser } from '../prompts/promptUtils';
 import { EXIT_CODES } from '../enums/exitCodes';
 import { uiAccountDescription } from '../ui';
-import { i18n } from '../lang';
 import SpinniesManager from '../ui/SpinniesManager';
 import { logError, ApiErrorContext } from '../errorHandlers/index';
-
-const i18nKey = 'lib.projects';
+import { lib } from '../../lang/en';
 
 async function pollFetchProject(
   accountId: number,
@@ -26,9 +24,9 @@ async function pollFetchProject(
     let pollCount = 0;
     SpinniesManager.init();
     SpinniesManager.add('pollFetchProject', {
-      text: i18n(`${i18nKey}.pollFetchProject.checkingProject`, {
-        accountIdentifier: uiAccountDescription(accountId),
-      }),
+      text: lib.projects.pollFetchProject.checkingProject(
+        uiAccountDescription(accountId)
+      ),
     });
     const pollInterval = setInterval(async () => {
       try {
@@ -82,15 +80,14 @@ export async function ensureProjectExists(
     if (isSpecifiedError(err, { statusCode: 404 })) {
       let shouldCreateProject = forceCreate;
       if (allowCreate && !shouldCreateProject) {
-        const promptKey = uploadCommand ? 'createPromptUpload' : 'createPrompt';
+        const promptLangFunction = uploadCommand
+          ? lib.projects.ensureProjectExists.createPromptUpload
+          : lib.projects.ensureProjectExists.createPrompt;
         const promptResult = await promptUser<{ shouldCreateProject: boolean }>(
           [
             {
               name: 'shouldCreateProject',
-              message: i18n(`${i18nKey}.ensureProjectExists.${promptKey}`, {
-                projectName,
-                accountIdentifier,
-              }),
+              message: promptLangFunction(projectName, accountIdentifier),
               type: 'confirm',
             },
           ]
@@ -102,10 +99,10 @@ export async function ensureProjectExists(
         try {
           const { data: project } = await createProject(accountId, projectName);
           logger.success(
-            i18n(`${i18nKey}.ensureProjectExists.createSuccess`, {
+            lib.projects.ensureProjectExists.createSuccess(
               projectName,
-              accountIdentifier,
-            })
+              accountIdentifier
+            )
           );
           return { projectExists: true, project };
         } catch (err) {
@@ -115,10 +112,10 @@ export async function ensureProjectExists(
       } else {
         if (!noLogs) {
           logger.log(
-            i18n(`${i18nKey}.ensureProjectExists.notFound`, {
+            lib.projects.ensureProjectExists.notFound(
               projectName,
-              accountIdentifier,
-            })
+              accountIdentifier
+            )
           );
         }
         return { projectExists: false };

--- a/lib/projects/ensureProjectExists.ts
+++ b/lib/projects/ensureProjectExists.ts
@@ -1,132 +1,21 @@
-import fs from 'fs-extra';
-import path from 'path';
-import findup from 'findup-sync';
 import { logger } from '@hubspot/local-dev-lib/logger';
 import {
   createProject,
   fetchProject,
 } from '@hubspot/local-dev-lib/api/projects';
 import { isSpecifiedError } from '@hubspot/local-dev-lib/errors/index';
-import { getCwd, getAbsoluteFilePath } from '@hubspot/local-dev-lib/path';
 import { Project } from '@hubspot/local-dev-lib/types/Project';
 import { HubSpotPromise } from '@hubspot/local-dev-lib/types/Http';
 
-import {
-  FEEDBACK_INTERVAL,
-  DEFAULT_POLLING_DELAY,
-  PROJECT_CONFIG_FILE,
-} from '../constants';
+import { DEFAULT_POLLING_DELAY } from '../constants';
 import { promptUser } from '../prompts/promptUtils';
 import { EXIT_CODES } from '../enums/exitCodes';
-import { uiLine, uiAccountDescription, uiCommandReference } from '../ui';
+import { uiAccountDescription } from '../ui';
 import { i18n } from '../lang';
 import SpinniesManager from '../ui/SpinniesManager';
-import { ProjectConfig } from '../../types/Projects';
 import { logError, ApiErrorContext } from '../errorHandlers/index';
 
 const i18nKey = 'lib.projects';
-
-export function writeProjectConfig(
-  configPath: string,
-  config: ProjectConfig
-): boolean {
-  try {
-    fs.ensureFileSync(configPath);
-    fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
-    logger.debug(`Wrote project config at ${configPath}`);
-  } catch (e) {
-    logger.debug(e);
-    return false;
-  }
-  return true;
-}
-
-export function getIsInProject(dir?: string): boolean {
-  const configPath = getProjectConfigPath(dir);
-  return !!configPath;
-}
-
-function getProjectConfigPath(dir?: string): string | null {
-  const projectDir = dir ? getAbsoluteFilePath(dir) : getCwd();
-
-  const configPath = findup(PROJECT_CONFIG_FILE, {
-    cwd: projectDir,
-    nocase: true,
-  });
-
-  return configPath;
-}
-
-export interface LoadedProjectConfig {
-  projectDir: string | null;
-  projectConfig: ProjectConfig | null;
-}
-
-export async function getProjectConfig(
-  dir?: string
-): Promise<LoadedProjectConfig> {
-  const configPath = getProjectConfigPath(dir);
-  if (!configPath) {
-    return { projectConfig: null, projectDir: null };
-  }
-
-  try {
-    const config = fs.readFileSync(configPath);
-    const projectConfig: ProjectConfig = JSON.parse(config.toString());
-    return {
-      projectDir: path.dirname(configPath),
-      projectConfig,
-    };
-  } catch (e) {
-    logger.error('Could not read from project config');
-    return { projectConfig: null, projectDir: null };
-  }
-}
-
-export function validateProjectConfig(
-  projectConfig: ProjectConfig | null,
-  projectDir: string | null
-): asserts projectConfig is ProjectConfig {
-  if (!projectConfig || !projectDir) {
-    logger.error(
-      i18n(`${i18nKey}.validateProjectConfig.configNotFound`, {
-        createCommand: uiCommandReference('hs project create'),
-      })
-    );
-    return process.exit(EXIT_CODES.ERROR);
-  }
-
-  if (!projectConfig.name || !projectConfig.srcDir) {
-    logger.error(i18n(`${i18nKey}.validateProjectConfig.configMissingFields`));
-    return process.exit(EXIT_CODES.ERROR);
-  }
-
-  const resolvedPath = path.resolve(projectDir, projectConfig.srcDir);
-  if (!resolvedPath.startsWith(projectDir)) {
-    const projectConfigFile = path.relative(
-      '.',
-      path.join(projectDir, PROJECT_CONFIG_FILE)
-    );
-    logger.error(
-      i18n(`${i18nKey}.validateProjectConfig.srcOutsideProjectDir`, {
-        srcDir: projectConfig.srcDir,
-        projectConfig: projectConfigFile,
-      })
-    );
-    return process.exit(EXIT_CODES.ERROR);
-  }
-
-  if (!fs.existsSync(resolvedPath)) {
-    logger.error(
-      i18n(`${i18nKey}.validateProjectConfig.srcDirNotFound`, {
-        srcDir: projectConfig.srcDir,
-        projectDir: projectDir,
-      })
-    );
-
-    return process.exit(EXIT_CODES.ERROR);
-  }
-}
 
 async function pollFetchProject(
   accountId: number,
@@ -237,14 +126,5 @@ export async function ensureProjectExists(
     }
     logError(err, new ApiErrorContext({ accountId }));
     process.exit(EXIT_CODES.ERROR);
-  }
-}
-
-export function logFeedbackMessage(buildId: number): void {
-  if (buildId > 0 && buildId % FEEDBACK_INTERVAL === 0) {
-    uiLine();
-    logger.log(i18n(`${i18nKey}.logFeedbackMessage.feedbackHeader`));
-    uiLine();
-    logger.log(i18n(`${i18nKey}.logFeedbackMessage.feedbackMessage`));
   }
 }

--- a/lib/projects/localDev/DevServerManager.ts
+++ b/lib/projects/localDev/DevServerManager.ts
@@ -1,7 +1,6 @@
 import { logger } from '@hubspot/local-dev-lib/logger';
 import { Environment } from '@hubspot/local-dev-lib/types/Config';
-import { i18n } from './lang';
-import { promptUser } from './prompts/promptUtils';
+import { promptUser } from '../../prompts/promptUtils';
 import { DevModeInterface as UIEDevModeInterface } from '@hubspot/ui-extensions-dev-server';
 import {
   startPortManagerServer,
@@ -13,9 +12,12 @@ import {
   getHubSpotWebsiteOrigin,
 } from '@hubspot/local-dev-lib/urls';
 import { getAccountConfig } from '@hubspot/local-dev-lib/config';
-import { ProjectConfig, ComponentTypes, Component } from '../types/Projects';
-
-const i18nKey = 'lib.DevServerManager';
+import {
+  ProjectConfig,
+  ComponentTypes,
+  Component,
+} from '../../../types/Projects';
+import { lib } from '../../../lang/en';
 
 const SERVER_KEYS = {
   privateApp: 'privateApp',
@@ -83,7 +85,7 @@ class DevServerManager {
       if (Object.keys(compatibleComponents).length) {
         await callback(devServer.serverInterface, compatibleComponents);
       } else {
-        logger.debug(i18n(`${i18nKey}.noCompatibleComponents`, { serverKey }));
+        logger.debug(lib.DevServerManager.noCompatibleComponents(serverKey));
       }
     }
   }
@@ -159,7 +161,7 @@ class DevServerManager {
         }
       });
     } else {
-      throw new Error(i18n(`${i18nKey}.notInitialized`));
+      throw new Error(lib.DevServerManager.notInitialized);
     }
 
     this.started = true;

--- a/lib/projects/localDev/DevServerManagerV2.ts
+++ b/lib/projects/localDev/DevServerManagerV2.ts
@@ -1,7 +1,6 @@
 import { logger } from '@hubspot/local-dev-lib/logger';
 import { Environment } from '@hubspot/local-dev-lib/types/Config';
-import { i18n } from './lang';
-import { promptUser } from './prompts/promptUtils';
+import { promptUser } from '../../prompts/promptUtils';
 import { DevModeUnifiedInterface as UIEDevModeInterface } from '@hubspot/ui-extensions-dev-server';
 import {
   startPortManagerServer,
@@ -13,10 +12,9 @@ import {
   getHubSpotWebsiteOrigin,
 } from '@hubspot/local-dev-lib/urls';
 import { getAccountConfig } from '@hubspot/local-dev-lib/config';
-import { ProjectConfig } from '../types/Projects';
+import { ProjectConfig } from '../../../types/Projects';
 import { IntermediateRepresentationNodeLocalDev } from '@hubspot/project-parsing-lib/src/lib/types';
-
-const i18nKey = 'lib.DevServerManager';
+import { lib } from '../../../lang/en';
 
 type DevServerInterface = {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
@@ -94,7 +92,7 @@ class DevServerManagerV2 {
         }
       });
     } else {
-      throw new Error(i18n(`${i18nKey}.notInitialized`));
+      throw new Error(lib.DevServerManager.notInitialized);
     }
 
     this.started = true;

--- a/lib/projects/localDev/LocalDevManager.ts
+++ b/lib/projects/localDev/LocalDevManager.ts
@@ -14,15 +14,25 @@ import {
 import { Build } from '@hubspot/local-dev-lib/types/Build';
 import { PublicApp } from '@hubspot/local-dev-lib/types/Apps';
 import { Environment } from '@hubspot/local-dev-lib/types/Config';
-import { mapToUserFriendlyName } from '@hubspot/project-parsing-lib';
 
-import { APP_DISTRIBUTION_TYPES, PROJECT_CONFIG_FILE } from './constants';
-import SpinniesManager from './ui/SpinniesManager';
-import DevServerManagerV2 from './DevServerManagerV2';
-import { EXIT_CODES } from './enums/exitCodes';
-import { getProjectDetailUrl } from './projects/urls';
-import { isAppIRNode } from './projects/structure';
-import { ProjectConfig } from '../types/Projects';
+import { PROJECT_CONFIG_FILE } from '../../constants';
+import SpinniesManager from '../../ui/SpinniesManager';
+import DevServerManager from './DevServerManager';
+import { EXIT_CODES } from '../../enums/exitCodes';
+import { getProjectDetailUrl } from '../../projects/urls';
+import { getAccountHomeUrl } from './helpers';
+import {
+  componentIsApp,
+  componentIsPublicApp,
+  CONFIG_FILES,
+  getAppCardConfigs,
+  getComponentUid,
+} from '../../projects/structure';
+import {
+  Component,
+  ComponentTypes,
+  ProjectConfig,
+} from '../../../types/Projects';
 import {
   UI_COLORS,
   uiCommandReference,
@@ -30,14 +40,12 @@ import {
   uiBetaTag,
   uiLink,
   uiLine,
-} from './ui';
-import { logError } from './errorHandlers/index';
-import { installPublicAppPrompt } from './prompts/installPublicAppPrompt';
-import { confirmPrompt } from './prompts/promptUtils';
-import { i18n } from './lang';
-import { handleKeypress } from './process';
-import { IntermediateRepresentationNodeLocalDev } from '@hubspot/project-parsing-lib/src/lib/types';
-import { AppIRNode } from '../types/ProjectComponents';
+} from '../../ui';
+import { logError } from '../../errorHandlers/index';
+import { installPublicAppPrompt } from '../../prompts/installPublicAppPrompt';
+import { confirmPrompt } from '../../prompts/promptUtils';
+import { handleKeypress } from '../../process';
+import { lib } from '../../../lang/en';
 
 const WATCH_EVENTS = {
   add: 'add',
@@ -46,24 +54,22 @@ const WATCH_EVENTS = {
   unlinkDir: 'unlinkDir',
 };
 
-const i18nKey = 'lib.LocalDevManager';
-
 type LocalDevManagerConstructorOptions = {
-  targetProjectAccountId: number;
-  targetTestingAccountId: number;
+  targetAccountId: number;
+  parentAccountId: number;
   projectConfig: ProjectConfig;
   projectDir: string;
   projectId: number;
   debug?: boolean;
   deployedBuild?: Build;
   isGithubLinked: boolean;
-  projectNodes: { [key: string]: IntermediateRepresentationNodeLocalDev };
+  runnableComponents: Component[];
   env: Environment;
 };
 
-class LocalDevManagerV2 {
+class LocalDevManager {
+  targetAccountId: number;
   targetProjectAccountId: number;
-  targetTestingAccountId: number;
   projectConfig: ProjectConfig;
   projectDir: string;
   projectId: number;
@@ -72,8 +78,8 @@ class LocalDevManagerV2 {
   isGithubLinked: boolean;
   watcher: FSWatcher | null;
   uploadWarnings: { [key: string]: boolean };
-  projectNodes: { [key: string]: IntermediateRepresentationNodeLocalDev };
-  activeApp: AppIRNode | null;
+  runnableComponents: Component[];
+  activeApp: Component | null;
   activePublicAppData: PublicApp | null;
   env: Environment;
   publicAppActiveInstalls: number | null;
@@ -81,8 +87,10 @@ class LocalDevManagerV2 {
   mostRecentUploadWarning: string | null;
 
   constructor(options: LocalDevManagerConstructorOptions) {
-    this.targetProjectAccountId = options.targetProjectAccountId;
-    this.targetTestingAccountId = options.targetTestingAccountId;
+    this.targetAccountId = options.targetAccountId;
+    // The account that the project exists in. This is not always the targetAccountId
+    this.targetProjectAccountId = options.parentAccountId;
+
     this.projectConfig = options.projectConfig;
     this.projectDir = options.projectDir;
     this.projectId = options.projectId;
@@ -91,7 +99,7 @@ class LocalDevManagerV2 {
     this.isGithubLinked = options.isGithubLinked;
     this.watcher = null;
     this.uploadWarnings = {};
-    this.projectNodes = options.projectNodes;
+    this.runnableComponents = options.runnableComponents;
     this.activeApp = null;
     this.activePublicAppData = null;
     this.env = options.env;
@@ -103,12 +111,8 @@ class LocalDevManagerV2 {
       this.projectConfig.srcDir
     );
 
-    if (
-      !this.targetProjectAccountId ||
-      !this.projectConfig ||
-      !this.projectDir
-    ) {
-      logger.log(i18n(`${i18nKey}.failedToInitialize`));
+    if (!this.targetAccountId || !this.projectConfig || !this.projectDir) {
+      logger.log(lib.LocalDevManager.failedToInitialize);
       process.exit(EXIT_CODES.ERROR);
     }
   }
@@ -116,41 +120,37 @@ class LocalDevManagerV2 {
   async setActiveApp(appUid?: string): Promise<void> {
     if (!appUid) {
       logger.error(
-        i18n(`${i18nKey}.missingUid`, {
-          devCommand: uiCommandReference('hs project dev'),
-        })
+        lib.LocalDevManager.missingUid(uiCommandReference('hs project dev'))
       );
       process.exit(EXIT_CODES.ERROR);
     }
-    const app =
-      Object.values(this.projectNodes).find(
-        component => component.uid === appUid
-      ) || null;
+    this.activeApp =
+      this.runnableComponents.find(component => {
+        return getComponentUid(component) === appUid;
+      }) || null;
 
-    if (app && isAppIRNode(app)) {
-      this.activeApp = app;
-
-      if (app.config.distribution === APP_DISTRIBUTION_TYPES.MARKETPLACE) {
-        try {
-          await this.setActivePublicAppData();
-          await this.checkActivePublicAppInstalls();
-          await this.checkPublicAppInstallation();
-        } catch (e) {
-          logError(e);
-        }
+    if (componentIsPublicApp(this.activeApp)) {
+      try {
+        await this.setActivePublicAppData();
+        await this.checkActivePublicAppInstalls();
+        await this.checkPublicAppInstallation();
+      } catch (e) {
+        logError(e);
       }
     }
-
-    return;
   }
 
   async setActivePublicAppData(): Promise<void> {
+    if (!this.activeApp) {
+      return;
+    }
+
     const {
       data: { results: portalPublicApps },
     } = await fetchPublicAppsForPortal(this.targetProjectAccountId);
 
     const activePublicAppData = portalPublicApps.find(
-      ({ sourceId }) => sourceId === this.activeApp?.uid
+      ({ sourceId }) => sourceId === getComponentUid(this.activeApp)
     );
 
     if (!activePublicAppData) {
@@ -179,18 +179,17 @@ class LocalDevManagerV2 {
     uiLine();
 
     logger.warn(
-      i18n(`${i18nKey}.activeInstallWarning.installCount`, {
-        appName: this.activePublicAppData.name,
-        installCount: this.publicAppActiveInstalls,
-        accountText:
-          this.publicAppActiveInstalls === 1 ? 'account' : 'accounts',
-      })
+      lib.LocalDevManager.activeInstallWarning.installCount(
+        this.activePublicAppData.name,
+        this.publicAppActiveInstalls,
+        this.publicAppActiveInstalls === 1 ? 'account' : 'accounts'
+      )
     );
-    logger.log(i18n(`${i18nKey}.activeInstallWarning.explanation`));
+    logger.log(lib.LocalDevManager.activeInstallWarning.explanation);
     uiLine();
 
     const proceed = await confirmPrompt(
-      i18n(`${i18nKey}.activeInstallWarning.confirmationPrompt`),
+      lib.LocalDevManager.activeInstallWarning.confirmationPrompt,
       { defaultAnswer: false }
     );
 
@@ -206,11 +205,11 @@ class LocalDevManagerV2 {
     // Local dev currently relies on the existence of a deployed build in the target account
     if (!this.deployedBuild) {
       logger.error(
-        i18n(`${i18nKey}.noDeployedBuild`, {
-          projectName: this.projectConfig.name,
-          accountIdentifier: uiAccountDescription(this.targetProjectAccountId),
-          uploadCommand: this.getUploadCommand(),
-        })
+        lib.LocalDevManager.noDeployedBuild(
+          this.projectConfig.name,
+          uiAccountDescription(this.targetProjectAccountId),
+          this.getUploadCommand()
+        )
       );
       logger.log();
       process.exit(EXIT_CODES.SUCCESS);
@@ -224,11 +223,11 @@ class LocalDevManagerV2 {
       console.clear();
     }
 
-    uiBetaTag(i18n(`${i18nKey}.betaMessage`));
+    uiBetaTag(lib.LocalDevManager.betaMessage);
 
     logger.log(
       uiLink(
-        i18n(`${i18nKey}.learnMoreLocalDevServer`),
+        lib.LocalDevManager.learnMoreLocalDevServer,
         'https://developers.hubspot.com/docs/platform/project-cli-commands#start-a-local-development-server'
       )
     );
@@ -236,15 +235,15 @@ class LocalDevManagerV2 {
     logger.log();
     logger.log(
       chalk.hex(UI_COLORS.SORBET)(
-        i18n(`${i18nKey}.running`, {
-          accountIdentifier: uiAccountDescription(this.targetProjectAccountId),
-          projectName: this.projectConfig.name,
-        })
+        lib.LocalDevManager.running(
+          this.projectConfig.name,
+          uiAccountDescription(this.targetAccountId)
+        )
       )
     );
     logger.log(
       uiLink(
-        i18n(`${i18nKey}.viewProjectLink`),
+        lib.LocalDevManager.viewProjectLink,
         getProjectDetailUrl(
           this.projectConfig.name,
           this.targetProjectAccountId
@@ -252,8 +251,17 @@ class LocalDevManagerV2 {
       )
     );
 
+    if (this.activeApp?.type === ComponentTypes.PublicApp) {
+      logger.log(
+        uiLink(
+          lib.LocalDevManager.viewTestAccountLink,
+          getAccountHomeUrl(this.targetAccountId)
+        )
+      );
+    }
+
     logger.log();
-    logger.log(i18n(`${i18nKey}.quitHelper`));
+    logger.log(lib.LocalDevManager.quitHelper);
     uiLine();
     logger.log();
 
@@ -274,7 +282,7 @@ class LocalDevManagerV2 {
   async stop(showProgress = true): Promise<void> {
     if (showProgress) {
       SpinniesManager.add('cleanupMessage', {
-        text: i18n(`${i18nKey}.exitingStart`),
+        text: lib.LocalDevManager.exitingStart,
       });
     }
     await this.stopWatching();
@@ -284,7 +292,7 @@ class LocalDevManagerV2 {
     if (!cleanupSucceeded) {
       if (showProgress) {
         SpinniesManager.fail('cleanupMessage', {
-          text: i18n(`${i18nKey}.exitingFail`),
+          text: lib.LocalDevManager.exitingFail,
         });
       }
       process.exit(EXIT_CODES.ERROR);
@@ -292,23 +300,23 @@ class LocalDevManagerV2 {
 
     if (showProgress) {
       SpinniesManager.succeed('cleanupMessage', {
-        text: i18n(`${i18nKey}.exitingSucceed`),
+        text: lib.LocalDevManager.exitingSucceed,
       });
     }
     process.exit(EXIT_CODES.SUCCESS);
   }
 
   async checkPublicAppInstallation(): Promise<void> {
-    if (!this.activeApp || !this.activePublicAppData) {
+    if (!componentIsPublicApp(this.activeApp) || !this.activePublicAppData) {
       return;
     }
 
     const {
       data: { isInstalledWithScopeGroups, previouslyAuthorizedScopeGroups },
     } = await fetchAppInstallationData(
-      this.targetTestingAccountId,
+      this.targetAccountId,
       this.projectId,
-      this.activeApp.uid,
+      this.activeApp.config.uid,
       this.activeApp.config.auth.requiredScopes,
       this.activeApp.config.auth.optionalScopes
     );
@@ -317,7 +325,7 @@ class LocalDevManagerV2 {
     if (!isInstalledWithScopeGroups) {
       await installPublicAppPrompt(
         this.env,
-        this.targetTestingAccountId,
+        this.targetAccountId,
         this.activePublicAppData.clientId,
         this.activeApp.config.auth.requiredScopes,
         this.activeApp.config.auth.redirectUrls,
@@ -345,42 +353,43 @@ class LocalDevManagerV2 {
   }
 
   logUploadWarning(reason?: string): void {
-    let warning = reason;
+    let warning: string;
 
-    if (!warning) {
+    if (reason) {
+      warning = reason;
+    } else {
       warning =
-        this.publicAppActiveInstalls && this.publicAppActiveInstalls > 0
-          ? i18n(`${i18nKey}.uploadWarning.defaultMarketplaceAppWarning`, {
-              installCount: this.publicAppActiveInstalls,
-              accountText:
-                this.publicAppActiveInstalls === 1 ? 'account' : 'accounts',
-            })
-          : i18n(`${i18nKey}.uploadWarning.defaultWarning`);
+        componentIsPublicApp(this.activeApp) &&
+        this.publicAppActiveInstalls &&
+        this.publicAppActiveInstalls > 0
+          ? lib.LocalDevManager.uploadWarning.defaultPublicAppWarning(
+              this.publicAppActiveInstalls,
+              this.publicAppActiveInstalls === 1 ? 'install' : 'installs'
+            )
+          : lib.LocalDevManager.uploadWarning.defaultWarning;
     }
 
     // Avoid logging the warning to the console if it is currently the most
     // recently logged warning. We do not want to spam the console with the same message.
     if (!this.uploadWarnings[warning]) {
       logger.log();
-      logger.warn(i18n(`${i18nKey}.uploadWarning.header`, { warning }));
+      logger.warn(lib.LocalDevManager.uploadWarning.header(warning));
       logger.log(
-        i18n(`${i18nKey}.uploadWarning.stopDev`, {
-          command: uiCommandReference('hs project dev'),
-        })
+        lib.LocalDevManager.uploadWarning.stopDev(
+          uiCommandReference('hs project dev')
+        )
       );
       if (this.isGithubLinked) {
-        logger.log(i18n(`${i18nKey}.uploadWarning.pushToGithub`));
+        logger.log(lib.LocalDevManager.uploadWarning.pushToGithub);
       } else {
         logger.log(
-          i18n(`${i18nKey}.uploadWarning.runUpload`, {
-            command: this.getUploadCommand(),
-          })
+          lib.LocalDevManager.uploadWarning.runUpload(this.getUploadCommand())
         );
       }
       logger.log(
-        i18n(`${i18nKey}.uploadWarning.restartDev`, {
-          command: uiCommandReference('hs project dev'),
-        })
+        lib.LocalDevManager.uploadWarning.restartDev(
+          uiCommandReference('hs project dev')
+        )
       );
 
       this.mostRecentUploadWarning = warning;
@@ -395,18 +404,18 @@ class LocalDevManagerV2 {
 
     // Need to provide both overloads for process.stdout.write to satisfy TS
     function customStdoutWrite(
-      this: LocalDevManagerV2,
+      this: LocalDevManager,
       buffer: Uint8Array | string,
       cb?: StdoutCallback
     ): boolean;
     function customStdoutWrite(
-      this: LocalDevManagerV2,
+      this: LocalDevManager,
       str: Uint8Array | string,
       encoding?: BufferEncoding,
       cb?: StdoutCallback
     ): boolean;
     function customStdoutWrite(
-      this: LocalDevManagerV2,
+      this: LocalDevManager,
       chunk: Uint8Array | string,
       encoding?: BufferEncoding | StdoutCallback,
       callback?: StdoutCallback
@@ -435,21 +444,41 @@ class LocalDevManagerV2 {
       subbuildStatus => subbuildStatus.buildName
     );
 
-    const missingProjectNodes: string[] = [];
+    const missingComponents: string[] = [];
 
-    Object.values(this.projectNodes).forEach(node => {
-      if (!deployedComponentNames.includes(node.uid)) {
-        const userFriendlyName = mapToUserFriendlyName(node.componentType);
-        const label = userFriendlyName ? `[${userFriendlyName}] ` : '';
-        missingProjectNodes.push(`${label}${node.uid}`);
-      }
-    });
+    this.runnableComponents
+      .filter(componentIsApp)
+      .forEach(({ type, config, path }) => {
+        if (Object.values(ComponentTypes).includes(type)) {
+          const cardConfigs = getAppCardConfigs(config, path);
 
-    if (missingProjectNodes.length) {
+          if (!deployedComponentNames.includes(config.name)) {
+            missingComponents.push(
+              `${lib.LocalDevManager.uploadWarning.appLabel} ${config.name}`
+            );
+          }
+
+          cardConfigs.forEach(cardConfig => {
+            if (
+              cardConfig.data &&
+              cardConfig.data.title &&
+              !deployedComponentNames.includes(cardConfig.data.title)
+            ) {
+              missingComponents.push(
+                `${lib.LocalDevManager.uploadWarning.uiExtensionLabel} ${
+                  cardConfig.data.title
+                }`
+              );
+            }
+          });
+        }
+      });
+
+    if (missingComponents.length) {
       this.logUploadWarning(
-        i18n(`${i18nKey}.uploadWarning.missingComponents`, {
-          missingComponents: missingProjectNodes.join(', '),
-        })
+        lib.LocalDevManager.uploadWarning.missingComponents(
+          missingComponents.join(', ')
+        )
       );
     }
   }
@@ -459,9 +488,15 @@ class LocalDevManagerV2 {
       ignoreInitial: true,
     });
 
-    const configPaths = Object.values(this.projectNodes).map(
-      component => component.localDev.componentConfigPath
-    );
+    const configPaths = this.runnableComponents
+      .filter(({ type }) => Object.values(ComponentTypes).includes(type))
+      .map(component => {
+        const appConfigPath = path.join(
+          component.path,
+          CONFIG_FILES[component.type]
+        );
+        return appConfigPath;
+      });
 
     const projectConfigPath = path.join(this.projectDir, PROJECT_CONFIG_FILE);
     configPaths.push(projectConfigPath);
@@ -498,9 +533,10 @@ class LocalDevManagerV2 {
 
   async devServerSetup(): Promise<boolean> {
     try {
-      await DevServerManagerV2.setup({
-        projectNodes: this.projectNodes,
-        accountId: this.targetTestingAccountId,
+      await DevServerManager.setup({
+        components: this.runnableComponents,
+        onUploadRequired: this.logUploadWarning.bind(this),
+        accountId: this.targetAccountId,
         setActiveApp: this.setActiveApp.bind(this),
       });
       return true;
@@ -508,11 +544,10 @@ class LocalDevManagerV2 {
       if (this.debug) {
         logger.error(e);
       }
-
       logger.error(
-        i18n(`${i18nKey}.devServer.setupError`, {
-          message: e instanceof Error ? e.message : '',
-        })
+        lib.LocalDevManager.devServer.setupError(
+          e instanceof Error ? e.message : ''
+        )
       );
       return false;
     }
@@ -520,8 +555,8 @@ class LocalDevManagerV2 {
 
   async devServerStart(): Promise<void> {
     try {
-      await DevServerManagerV2.start({
-        accountId: this.targetTestingAccountId,
+      await DevServerManager.start({
+        accountId: this.targetAccountId,
         projectConfig: this.projectConfig,
       });
     } catch (e) {
@@ -529,9 +564,9 @@ class LocalDevManagerV2 {
         logger.error(e);
       }
       logger.error(
-        i18n(`${i18nKey}.devServer.startError`, {
-          message: e instanceof Error ? e.message : '',
-        })
+        lib.LocalDevManager.devServer.startError(
+          e instanceof Error ? e.message : ''
+        )
       );
       process.exit(EXIT_CODES.ERROR);
     }
@@ -539,35 +574,35 @@ class LocalDevManagerV2 {
 
   devServerFileChange(filePath: string, event: string): void {
     try {
-      DevServerManagerV2.fileChange({ filePath, event });
+      DevServerManager.fileChange({ filePath, event });
     } catch (e) {
       if (this.debug) {
         logger.error(e);
       }
       logger.error(
-        i18n(`${i18nKey}.devServer.fileChangeError`, {
-          message: e instanceof Error ? e.message : '',
-        })
+        lib.LocalDevManager.devServer.fileChangeError(
+          e instanceof Error ? e.message : ''
+        )
       );
     }
   }
 
   async devServerCleanup(): Promise<boolean> {
     try {
-      await DevServerManagerV2.cleanup();
+      await DevServerManager.cleanup();
       return true;
     } catch (e) {
       if (this.debug) {
         logger.error(e);
       }
       logger.error(
-        i18n(`${i18nKey}.devServer.cleanupError`, {
-          message: e instanceof Error ? e.message : '',
-        })
+        lib.LocalDevManager.devServer.cleanupError(
+          e instanceof Error ? e.message : ''
+        )
       );
       return false;
     }
   }
 }
 
-export default LocalDevManagerV2;
+export default LocalDevManager;

--- a/lib/projects/localDev/LocalDevManager.ts
+++ b/lib/projects/localDev/LocalDevManager.ts
@@ -119,9 +119,7 @@ class LocalDevManager {
 
   async setActiveApp(appUid?: string): Promise<void> {
     if (!appUid) {
-      logger.error(
-        lib.LocalDevManager.missingUid(uiCommandReference('hs project dev'))
-      );
+      logger.error(lib.LocalDevManager.missingUid);
       process.exit(EXIT_CODES.ERROR);
     }
     this.activeApp =
@@ -374,11 +372,7 @@ class LocalDevManager {
     if (!this.uploadWarnings[warning]) {
       logger.log();
       logger.warn(lib.LocalDevManager.uploadWarning.header(warning));
-      logger.log(
-        lib.LocalDevManager.uploadWarning.stopDev(
-          uiCommandReference('hs project dev')
-        )
-      );
+      logger.log(lib.LocalDevManager.uploadWarning.stopDev);
       if (this.isGithubLinked) {
         logger.log(lib.LocalDevManager.uploadWarning.pushToGithub);
       } else {
@@ -386,11 +380,7 @@ class LocalDevManager {
           lib.LocalDevManager.uploadWarning.runUpload(this.getUploadCommand())
         );
       }
-      logger.log(
-        lib.LocalDevManager.uploadWarning.restartDev(
-          uiCommandReference('hs project dev')
-        )
-      );
+      logger.log(lib.LocalDevManager.uploadWarning.restartDev);
 
       this.mostRecentUploadWarning = warning;
       this.uploadWarnings[warning] = true;

--- a/lib/projects/localDev/LocalDevManagerV2.ts
+++ b/lib/projects/localDev/LocalDevManagerV2.ts
@@ -14,21 +14,15 @@ import {
 import { Build } from '@hubspot/local-dev-lib/types/Build';
 import { PublicApp } from '@hubspot/local-dev-lib/types/Apps';
 import { Environment } from '@hubspot/local-dev-lib/types/Config';
+import { mapToUserFriendlyName } from '@hubspot/project-parsing-lib';
 
-import { PROJECT_CONFIG_FILE } from './constants';
-import SpinniesManager from './ui/SpinniesManager';
-import DevServerManager from './DevServerManager';
-import { EXIT_CODES } from './enums/exitCodes';
-import { getProjectDetailUrl } from './projects/urls';
-import { getAccountHomeUrl } from './localDev';
-import {
-  componentIsApp,
-  componentIsPublicApp,
-  CONFIG_FILES,
-  getAppCardConfigs,
-  getComponentUid,
-} from './projects/structure';
-import { Component, ComponentTypes, ProjectConfig } from '../types/Projects';
+import { APP_DISTRIBUTION_TYPES, PROJECT_CONFIG_FILE } from '../../constants';
+import SpinniesManager from '../../ui/SpinniesManager';
+import DevServerManagerV2 from './DevServerManagerV2';
+import { EXIT_CODES } from '../../enums/exitCodes';
+import { getProjectDetailUrl } from '../../projects/urls';
+import { isAppIRNode } from '../../projects/structure';
+import { ProjectConfig } from '../../../types/Projects';
 import {
   UI_COLORS,
   uiCommandReference,
@@ -36,12 +30,14 @@ import {
   uiBetaTag,
   uiLink,
   uiLine,
-} from './ui';
-import { logError } from './errorHandlers/index';
-import { installPublicAppPrompt } from './prompts/installPublicAppPrompt';
-import { confirmPrompt } from './prompts/promptUtils';
-import { i18n } from './lang';
-import { handleKeypress } from './process';
+} from '../../ui';
+import { logError } from '../../errorHandlers/index';
+import { installPublicAppPrompt } from '../../prompts/installPublicAppPrompt';
+import { confirmPrompt } from '../../prompts/promptUtils';
+import { handleKeypress } from '../../process';
+import { IntermediateRepresentationNodeLocalDev } from '@hubspot/project-parsing-lib/src/lib/types';
+import { AppIRNode } from '../../../types/ProjectComponents';
+import { lib } from '../../../lang/en';
 
 const WATCH_EVENTS = {
   add: 'add',
@@ -50,24 +46,22 @@ const WATCH_EVENTS = {
   unlinkDir: 'unlinkDir',
 };
 
-const i18nKey = 'lib.LocalDevManager';
-
 type LocalDevManagerConstructorOptions = {
-  targetAccountId: number;
-  parentAccountId: number;
+  targetProjectAccountId: number;
+  targetTestingAccountId: number;
   projectConfig: ProjectConfig;
   projectDir: string;
   projectId: number;
   debug?: boolean;
   deployedBuild?: Build;
   isGithubLinked: boolean;
-  runnableComponents: Component[];
+  projectNodes: { [key: string]: IntermediateRepresentationNodeLocalDev };
   env: Environment;
 };
 
-class LocalDevManager {
-  targetAccountId: number;
+class LocalDevManagerV2 {
   targetProjectAccountId: number;
+  targetTestingAccountId: number;
   projectConfig: ProjectConfig;
   projectDir: string;
   projectId: number;
@@ -76,8 +70,8 @@ class LocalDevManager {
   isGithubLinked: boolean;
   watcher: FSWatcher | null;
   uploadWarnings: { [key: string]: boolean };
-  runnableComponents: Component[];
-  activeApp: Component | null;
+  projectNodes: { [key: string]: IntermediateRepresentationNodeLocalDev };
+  activeApp: AppIRNode | null;
   activePublicAppData: PublicApp | null;
   env: Environment;
   publicAppActiveInstalls: number | null;
@@ -85,10 +79,8 @@ class LocalDevManager {
   mostRecentUploadWarning: string | null;
 
   constructor(options: LocalDevManagerConstructorOptions) {
-    this.targetAccountId = options.targetAccountId;
-    // The account that the project exists in. This is not always the targetAccountId
-    this.targetProjectAccountId = options.parentAccountId;
-
+    this.targetProjectAccountId = options.targetProjectAccountId;
+    this.targetTestingAccountId = options.targetTestingAccountId;
     this.projectConfig = options.projectConfig;
     this.projectDir = options.projectDir;
     this.projectId = options.projectId;
@@ -97,7 +89,7 @@ class LocalDevManager {
     this.isGithubLinked = options.isGithubLinked;
     this.watcher = null;
     this.uploadWarnings = {};
-    this.runnableComponents = options.runnableComponents;
+    this.projectNodes = options.projectNodes;
     this.activeApp = null;
     this.activePublicAppData = null;
     this.env = options.env;
@@ -109,8 +101,12 @@ class LocalDevManager {
       this.projectConfig.srcDir
     );
 
-    if (!this.targetAccountId || !this.projectConfig || !this.projectDir) {
-      logger.log(i18n(`${i18nKey}.failedToInitialize`));
+    if (
+      !this.targetProjectAccountId ||
+      !this.projectConfig ||
+      !this.projectDir
+    ) {
+      logger.log(lib.LocalDevManager.failedToInitialize);
       process.exit(EXIT_CODES.ERROR);
     }
   }
@@ -118,39 +114,39 @@ class LocalDevManager {
   async setActiveApp(appUid?: string): Promise<void> {
     if (!appUid) {
       logger.error(
-        i18n(`${i18nKey}.missingUid`, {
-          devCommand: uiCommandReference('hs project dev'),
-        })
+        lib.LocalDevManager.missingUid(uiCommandReference('hs project dev'))
       );
       process.exit(EXIT_CODES.ERROR);
     }
-    this.activeApp =
-      this.runnableComponents.find(component => {
-        return getComponentUid(component) === appUid;
-      }) || null;
+    const app =
+      Object.values(this.projectNodes).find(
+        component => component.uid === appUid
+      ) || null;
 
-    if (componentIsPublicApp(this.activeApp)) {
-      try {
-        await this.setActivePublicAppData();
-        await this.checkActivePublicAppInstalls();
-        await this.checkPublicAppInstallation();
-      } catch (e) {
-        logError(e);
+    if (app && isAppIRNode(app)) {
+      this.activeApp = app;
+
+      if (app.config.distribution === APP_DISTRIBUTION_TYPES.MARKETPLACE) {
+        try {
+          await this.setActivePublicAppData();
+          await this.checkActivePublicAppInstalls();
+          await this.checkPublicAppInstallation();
+        } catch (e) {
+          logError(e);
+        }
       }
     }
+
+    return;
   }
 
   async setActivePublicAppData(): Promise<void> {
-    if (!this.activeApp) {
-      return;
-    }
-
     const {
       data: { results: portalPublicApps },
     } = await fetchPublicAppsForPortal(this.targetProjectAccountId);
 
     const activePublicAppData = portalPublicApps.find(
-      ({ sourceId }) => sourceId === getComponentUid(this.activeApp)
+      ({ sourceId }) => sourceId === this.activeApp?.uid
     );
 
     if (!activePublicAppData) {
@@ -179,18 +175,18 @@ class LocalDevManager {
     uiLine();
 
     logger.warn(
-      i18n(`${i18nKey}.activeInstallWarning.installCount`, {
-        appName: this.activePublicAppData.name,
-        installCount: this.publicAppActiveInstalls,
-        accountText:
-          this.publicAppActiveInstalls === 1 ? 'account' : 'accounts',
-      })
+      lib.LocalDevManager.activeInstallWarning.installCount(
+        this.activePublicAppData.name,
+        this.publicAppActiveInstalls,
+
+        this.publicAppActiveInstalls === 1 ? 'account' : 'accounts'
+      )
     );
-    logger.log(i18n(`${i18nKey}.activeInstallWarning.explanation`));
+    logger.log(lib.LocalDevManager.activeInstallWarning.explanation);
     uiLine();
 
     const proceed = await confirmPrompt(
-      i18n(`${i18nKey}.activeInstallWarning.confirmationPrompt`),
+      lib.LocalDevManager.activeInstallWarning.confirmationPrompt,
       { defaultAnswer: false }
     );
 
@@ -206,11 +202,11 @@ class LocalDevManager {
     // Local dev currently relies on the existence of a deployed build in the target account
     if (!this.deployedBuild) {
       logger.error(
-        i18n(`${i18nKey}.noDeployedBuild`, {
-          projectName: this.projectConfig.name,
-          accountIdentifier: uiAccountDescription(this.targetProjectAccountId),
-          uploadCommand: this.getUploadCommand(),
-        })
+        lib.LocalDevManager.noDeployedBuild(
+          this.projectConfig.name,
+          uiAccountDescription(this.targetProjectAccountId),
+          this.getUploadCommand()
+        )
       );
       logger.log();
       process.exit(EXIT_CODES.SUCCESS);
@@ -224,11 +220,11 @@ class LocalDevManager {
       console.clear();
     }
 
-    uiBetaTag(i18n(`${i18nKey}.betaMessage`));
+    uiBetaTag(lib.LocalDevManager.betaMessage);
 
     logger.log(
       uiLink(
-        i18n(`${i18nKey}.learnMoreLocalDevServer`),
+        lib.LocalDevManager.learnMoreLocalDevServer,
         'https://developers.hubspot.com/docs/platform/project-cli-commands#start-a-local-development-server'
       )
     );
@@ -236,15 +232,15 @@ class LocalDevManager {
     logger.log();
     logger.log(
       chalk.hex(UI_COLORS.SORBET)(
-        i18n(`${i18nKey}.running`, {
-          accountIdentifier: uiAccountDescription(this.targetAccountId),
-          projectName: this.projectConfig.name,
-        })
+        lib.LocalDevManager.running(
+          this.projectConfig.name,
+          uiAccountDescription(this.targetProjectAccountId)
+        )
       )
     );
     logger.log(
       uiLink(
-        i18n(`${i18nKey}.viewProjectLink`),
+        lib.LocalDevManager.viewProjectLink,
         getProjectDetailUrl(
           this.projectConfig.name,
           this.targetProjectAccountId
@@ -252,17 +248,8 @@ class LocalDevManager {
       )
     );
 
-    if (this.activeApp?.type === ComponentTypes.PublicApp) {
-      logger.log(
-        uiLink(
-          i18n(`${i18nKey}.viewTestAccountLink`),
-          getAccountHomeUrl(this.targetAccountId)
-        )
-      );
-    }
-
     logger.log();
-    logger.log(i18n(`${i18nKey}.quitHelper`));
+    logger.log(lib.LocalDevManager.quitHelper);
     uiLine();
     logger.log();
 
@@ -283,7 +270,7 @@ class LocalDevManager {
   async stop(showProgress = true): Promise<void> {
     if (showProgress) {
       SpinniesManager.add('cleanupMessage', {
-        text: i18n(`${i18nKey}.exitingStart`),
+        text: lib.LocalDevManager.exitingStart,
       });
     }
     await this.stopWatching();
@@ -293,7 +280,7 @@ class LocalDevManager {
     if (!cleanupSucceeded) {
       if (showProgress) {
         SpinniesManager.fail('cleanupMessage', {
-          text: i18n(`${i18nKey}.exitingFail`),
+          text: lib.LocalDevManager.exitingFail,
         });
       }
       process.exit(EXIT_CODES.ERROR);
@@ -301,23 +288,23 @@ class LocalDevManager {
 
     if (showProgress) {
       SpinniesManager.succeed('cleanupMessage', {
-        text: i18n(`${i18nKey}.exitingSucceed`),
+        text: lib.LocalDevManager.exitingSucceed,
       });
     }
     process.exit(EXIT_CODES.SUCCESS);
   }
 
   async checkPublicAppInstallation(): Promise<void> {
-    if (!componentIsPublicApp(this.activeApp) || !this.activePublicAppData) {
+    if (!this.activeApp || !this.activePublicAppData) {
       return;
     }
 
     const {
       data: { isInstalledWithScopeGroups, previouslyAuthorizedScopeGroups },
     } = await fetchAppInstallationData(
-      this.targetAccountId,
+      this.targetTestingAccountId,
       this.projectId,
-      this.activeApp.config.uid,
+      this.activeApp.uid,
       this.activeApp.config.auth.requiredScopes,
       this.activeApp.config.auth.optionalScopes
     );
@@ -326,7 +313,7 @@ class LocalDevManager {
     if (!isInstalledWithScopeGroups) {
       await installPublicAppPrompt(
         this.env,
-        this.targetAccountId,
+        this.targetTestingAccountId,
         this.activePublicAppData.clientId,
         this.activeApp.config.auth.requiredScopes,
         this.activeApp.config.auth.redirectUrls,
@@ -354,46 +341,39 @@ class LocalDevManager {
   }
 
   logUploadWarning(reason?: string): void {
-    let warning: string;
+    let warning = reason;
 
-    if (reason) {
-      warning = reason;
-    } else {
+    if (!warning) {
       warning =
-        componentIsPublicApp(this.activeApp) &&
-        this.publicAppActiveInstalls &&
-        this.publicAppActiveInstalls > 0
-          ? i18n(`${i18nKey}.uploadWarning.defaultPublicAppWarning`, {
-              installCount: this.publicAppActiveInstalls,
-              installText:
-                this.publicAppActiveInstalls === 1 ? 'install' : 'installs',
-            })
-          : i18n(`${i18nKey}.uploadWarning.defaultWarning`);
+        this.publicAppActiveInstalls && this.publicAppActiveInstalls > 0
+          ? lib.LocalDevManager.uploadWarning.defaultMarketplaceAppWarning(
+              this.publicAppActiveInstalls,
+              this.publicAppActiveInstalls === 1 ? 'account' : 'accounts'
+            )
+          : lib.LocalDevManager.uploadWarning.defaultWarning;
     }
 
     // Avoid logging the warning to the console if it is currently the most
     // recently logged warning. We do not want to spam the console with the same message.
     if (!this.uploadWarnings[warning]) {
       logger.log();
-      logger.warn(i18n(`${i18nKey}.uploadWarning.header`, { warning }));
+      logger.warn(lib.LocalDevManager.uploadWarning.header(warning));
       logger.log(
-        i18n(`${i18nKey}.uploadWarning.stopDev`, {
-          command: uiCommandReference('hs project dev'),
-        })
+        lib.LocalDevManager.uploadWarning.stopDev(
+          uiCommandReference('hs project dev')
+        )
       );
       if (this.isGithubLinked) {
-        logger.log(i18n(`${i18nKey}.uploadWarning.pushToGithub`));
+        logger.log(lib.LocalDevManager.uploadWarning.pushToGithub);
       } else {
         logger.log(
-          i18n(`${i18nKey}.uploadWarning.runUpload`, {
-            command: this.getUploadCommand(),
-          })
+          lib.LocalDevManager.uploadWarning.runUpload(this.getUploadCommand())
         );
       }
       logger.log(
-        i18n(`${i18nKey}.uploadWarning.restartDev`, {
-          command: uiCommandReference('hs project dev'),
-        })
+        lib.LocalDevManager.uploadWarning.restartDev(
+          uiCommandReference('hs project dev')
+        )
       );
 
       this.mostRecentUploadWarning = warning;
@@ -408,18 +388,18 @@ class LocalDevManager {
 
     // Need to provide both overloads for process.stdout.write to satisfy TS
     function customStdoutWrite(
-      this: LocalDevManager,
+      this: LocalDevManagerV2,
       buffer: Uint8Array | string,
       cb?: StdoutCallback
     ): boolean;
     function customStdoutWrite(
-      this: LocalDevManager,
+      this: LocalDevManagerV2,
       str: Uint8Array | string,
       encoding?: BufferEncoding,
       cb?: StdoutCallback
     ): boolean;
     function customStdoutWrite(
-      this: LocalDevManager,
+      this: LocalDevManagerV2,
       chunk: Uint8Array | string,
       encoding?: BufferEncoding | StdoutCallback,
       callback?: StdoutCallback
@@ -448,41 +428,21 @@ class LocalDevManager {
       subbuildStatus => subbuildStatus.buildName
     );
 
-    const missingComponents: string[] = [];
+    const missingProjectNodes: string[] = [];
 
-    this.runnableComponents
-      .filter(componentIsApp)
-      .forEach(({ type, config, path }) => {
-        if (Object.values(ComponentTypes).includes(type)) {
-          const cardConfigs = getAppCardConfigs(config, path);
+    Object.values(this.projectNodes).forEach(node => {
+      if (!deployedComponentNames.includes(node.uid)) {
+        const userFriendlyName = mapToUserFriendlyName(node.componentType);
+        const label = userFriendlyName ? `[${userFriendlyName}] ` : '';
+        missingProjectNodes.push(`${label}${node.uid}`);
+      }
+    });
 
-          if (!deployedComponentNames.includes(config.name)) {
-            missingComponents.push(
-              `${i18n(`${i18nKey}.uploadWarning.appLabel`)} ${config.name}`
-            );
-          }
-
-          cardConfigs.forEach(cardConfig => {
-            if (
-              cardConfig.data &&
-              cardConfig.data.title &&
-              !deployedComponentNames.includes(cardConfig.data.title)
-            ) {
-              missingComponents.push(
-                `${i18n(`${i18nKey}.uploadWarning.uiExtensionLabel`)} ${
-                  cardConfig.data.title
-                }`
-              );
-            }
-          });
-        }
-      });
-
-    if (missingComponents.length) {
+    if (missingProjectNodes.length) {
       this.logUploadWarning(
-        i18n(`${i18nKey}.uploadWarning.missingComponents`, {
-          missingComponents: missingComponents.join(', '),
-        })
+        lib.LocalDevManager.uploadWarning.missingComponents(
+          missingProjectNodes.join(', ')
+        )
       );
     }
   }
@@ -492,15 +452,9 @@ class LocalDevManager {
       ignoreInitial: true,
     });
 
-    const configPaths = this.runnableComponents
-      .filter(({ type }) => Object.values(ComponentTypes).includes(type))
-      .map(component => {
-        const appConfigPath = path.join(
-          component.path,
-          CONFIG_FILES[component.type]
-        );
-        return appConfigPath;
-      });
+    const configPaths = Object.values(this.projectNodes).map(
+      component => component.localDev.componentConfigPath
+    );
 
     const projectConfigPath = path.join(this.projectDir, PROJECT_CONFIG_FILE);
     configPaths.push(projectConfigPath);
@@ -537,10 +491,9 @@ class LocalDevManager {
 
   async devServerSetup(): Promise<boolean> {
     try {
-      await DevServerManager.setup({
-        components: this.runnableComponents,
-        onUploadRequired: this.logUploadWarning.bind(this),
-        accountId: this.targetAccountId,
+      await DevServerManagerV2.setup({
+        projectNodes: this.projectNodes,
+        accountId: this.targetTestingAccountId,
         setActiveApp: this.setActiveApp.bind(this),
       });
       return true;
@@ -548,10 +501,11 @@ class LocalDevManager {
       if (this.debug) {
         logger.error(e);
       }
+
       logger.error(
-        i18n(`${i18nKey}.devServer.setupError`, {
-          message: e instanceof Error ? e.message : '',
-        })
+        lib.LocalDevManager.devServer.setupError(
+          e instanceof Error ? e.message : ''
+        )
       );
       return false;
     }
@@ -559,8 +513,8 @@ class LocalDevManager {
 
   async devServerStart(): Promise<void> {
     try {
-      await DevServerManager.start({
-        accountId: this.targetAccountId,
+      await DevServerManagerV2.start({
+        accountId: this.targetTestingAccountId,
         projectConfig: this.projectConfig,
       });
     } catch (e) {
@@ -568,9 +522,9 @@ class LocalDevManager {
         logger.error(e);
       }
       logger.error(
-        i18n(`${i18nKey}.devServer.startError`, {
-          message: e instanceof Error ? e.message : '',
-        })
+        lib.LocalDevManager.devServer.startError(
+          e instanceof Error ? e.message : ''
+        )
       );
       process.exit(EXIT_CODES.ERROR);
     }
@@ -578,36 +532,35 @@ class LocalDevManager {
 
   devServerFileChange(filePath: string, event: string): void {
     try {
-      DevServerManager.fileChange({ filePath, event });
+      DevServerManagerV2.fileChange({ filePath, event });
     } catch (e) {
       if (this.debug) {
         logger.error(e);
       }
       logger.error(
-        i18n(`${i18nKey}.devServer.fileChangeError`, {
-          message: e instanceof Error ? e.message : '',
-        })
+        lib.LocalDevManager.devServer.fileChangeError(
+          e instanceof Error ? e.message : ''
+        )
       );
     }
   }
 
   async devServerCleanup(): Promise<boolean> {
     try {
-      await DevServerManager.cleanup();
+      await DevServerManagerV2.cleanup();
       return true;
     } catch (e) {
       if (this.debug) {
         logger.error(e);
       }
       logger.error(
-        i18n(`${i18nKey}.devServer.cleanupError`, {
-          message: e instanceof Error ? e.message : '',
-        })
+        lib.LocalDevManager.devServer.cleanupError(
+          e instanceof Error ? e.message : ''
+        )
       );
       return false;
     }
   }
 }
 
-export default LocalDevManager;
-module.exports = LocalDevManager;
+export default LocalDevManagerV2;

--- a/lib/projects/localDev/LocalDevManagerV2.ts
+++ b/lib/projects/localDev/LocalDevManagerV2.ts
@@ -113,9 +113,7 @@ class LocalDevManagerV2 {
 
   async setActiveApp(appUid?: string): Promise<void> {
     if (!appUid) {
-      logger.error(
-        lib.LocalDevManager.missingUid(uiCommandReference('hs project dev'))
-      );
+      logger.error(lib.LocalDevManager.missingUid);
       process.exit(EXIT_CODES.ERROR);
     }
     const app =
@@ -358,11 +356,7 @@ class LocalDevManagerV2 {
     if (!this.uploadWarnings[warning]) {
       logger.log();
       logger.warn(lib.LocalDevManager.uploadWarning.header(warning));
-      logger.log(
-        lib.LocalDevManager.uploadWarning.stopDev(
-          uiCommandReference('hs project dev')
-        )
-      );
+      logger.log(lib.LocalDevManager.uploadWarning.stopDev);
       if (this.isGithubLinked) {
         logger.log(lib.LocalDevManager.uploadWarning.pushToGithub);
       } else {
@@ -370,11 +364,7 @@ class LocalDevManagerV2 {
           lib.LocalDevManager.uploadWarning.runUpload(this.getUploadCommand())
         );
       }
-      logger.log(
-        lib.LocalDevManager.uploadWarning.restartDev(
-          uiCommandReference('hs project dev')
-        )
-      );
+      logger.log(lib.LocalDevManager.uploadWarning.restartDev);
 
       this.mostRecentUploadWarning = warning;
       this.uploadWarnings[warning] = true;

--- a/lib/projects/localDev/helpers.ts
+++ b/lib/projects/localDev/helpers.ts
@@ -40,7 +40,7 @@ import {
 } from '../../sandboxes';
 import { syncSandbox } from '../../sandboxSync';
 import { validateDevTestAccountUsageLimits } from '../../developerTestAccounts';
-import { uiCommandReference, uiLine, uiAccountDescription } from '../../ui';
+import { uiLine, uiAccountDescription } from '../../ui';
 import SpinniesManager from '../../ui/SpinniesManager';
 import { EXIT_CODES } from '../../enums/exitCodes';
 import { trackCommandMetadataUsage } from '../../usageTracking';
@@ -76,11 +76,7 @@ export async function confirmDefaultAccountIsTarget(
   accountConfig: CLIAccount
 ): Promise<void> {
   if (!accountConfig.name || !accountConfig.accountType) {
-    logger.error(
-      lib.localDevHelpers.confirmDefaultAccountIsTarget.configError(
-        uiCommandReference('hs auth')
-      )
-    );
+    logger.error(lib.localDevHelpers.confirmDefaultAccountIsTarget.configError);
     process.exit(EXIT_CODES.ERROR);
   }
 
@@ -92,10 +88,8 @@ export async function confirmDefaultAccountIsTarget(
 
   if (!useDefaultAccount) {
     logger.log(
-      lib.localDevHelpers.confirmDefaultAccountIsTarget.declineDefaultAccountExplanation(
-        uiCommandReference('hs accounts use'),
-        uiCommandReference('hs project dev')
-      )
+      lib.localDevHelpers.confirmDefaultAccountIsTarget
+        .declineDefaultAccountExplanation
     );
     process.exit(EXIT_CODES.SUCCESS);
   }
@@ -117,18 +111,12 @@ export async function checkIfDefaultAccountIsSupported(
     )
   ) {
     logger.error(
-      lib.localDevHelpers.checkIfDefaultAccountIsSupported.publicApp(
-        uiCommandReference('hs accounts use'),
-        uiCommandReference('hs auth')
-      )
+      lib.localDevHelpers.checkIfDefaultAccountIsSupported.publicApp
     );
     process.exit(EXIT_CODES.SUCCESS);
   } else if (!hasPublicApps && isAppDeveloperAccount(accountConfig)) {
     logger.error(
-      lib.localDevHelpers.checkIfDefaultAccountIsSupported.privateApp(
-        uiCommandReference('hs accounts use'),
-        uiCommandReference('hs auth')
-      )
+      lib.localDevHelpers.checkIfDefaultAccountIsSupported.privateApp
     );
     process.exit(EXIT_CODES.SUCCESS);
   }
@@ -141,9 +129,6 @@ export function checkIfParentAccountIsAuthed(accountConfig: CLIAccount): void {
   ) {
     logger.error(
       lib.localDevHelpers.checkIfParentAccountIsAuthed.notAuthedError(
-        uiCommandReference(
-          `hs auth --account=${accountConfig.parentAccountId}`
-        ),
         accountConfig.parentAccountId || '',
         uiAccountDescription(getAccountIdentifier(accountConfig))
       )
@@ -160,19 +145,14 @@ export function checkIfAccountFlagIsSupported(
   if (hasPublicApps) {
     if (!isDeveloperTestAccount(accountConfig)) {
       logger.error(
-        lib.localDevHelpers.validateAccountOption.invalidPublicAppAccount(
-          uiCommandReference('hs accounts use'),
-          uiCommandReference('hs project dev')
-        )
+        lib.localDevHelpers.validateAccountOption.invalidPublicAppAccount
       );
       process.exit(EXIT_CODES.SUCCESS);
     }
     checkIfParentAccountIsAuthed(accountConfig);
   } else if (isAppDeveloperAccount(accountConfig)) {
     logger.error(
-      lib.localDevHelpers.validateAccountOption.invalidPrivateAppAccount(
-        uiCommandReference('hs accounts use')
-      )
+      lib.localDevHelpers.validateAccountOption.invalidPrivateAppAccount
     );
     process.exit(EXIT_CODES.SUCCESS);
   }
@@ -347,10 +327,8 @@ export async function useExistingDevTestAccount(
   if (!useExistingDevTestAcct) {
     logger.log('');
     logger.log(
-      lib.localDevHelpers.confirmDefaultAccountIsTarget.declineDefaultAccountExplanation(
-        uiCommandReference('hs accounts use'),
-        uiCommandReference('hs project dev')
-      )
+      lib.localDevHelpers.confirmDefaultAccountIsTarget
+        .declineDefaultAccountExplanation
     );
     logger.log('');
     process.exit(EXIT_CODES.SUCCESS);
@@ -449,9 +427,7 @@ function projectUploadCallback(
 ): Promise<ProjectPollResult> {
   if (!buildId) {
     logger.error(
-      lib.localDevHelpers.createInitialBuildForNewProject.genericError(
-        uiCommandReference('hs project upload')
-      )
+      lib.localDevHelpers.createInitialBuildForNewProject.genericError
     );
     process.exit(EXIT_CODES.ERROR);
   }

--- a/lib/projects/localDev/helpers.ts
+++ b/lib/projects/localDev/helpers.ts
@@ -17,52 +17,58 @@ import { CLIAccount } from '@hubspot/local-dev-lib/types/Accounts';
 import { Environment } from '@hubspot/local-dev-lib/types/Config';
 import { DeveloperTestAccount } from '@hubspot/local-dev-lib/types/developerTestAccounts';
 import { Project } from '@hubspot/local-dev-lib/types/Project';
+import { Build } from '@hubspot/local-dev-lib/types/Build';
+import { getSandboxUsageLimits } from '@hubspot/local-dev-lib/api/sandboxHubs';
+
+import {
+  ProjectConfig,
+  ProjectPollResult,
+  ProjectSubtask,
+} from '../../../types/Projects';
+import { ProjectDevTargetAccountPromptResponse } from '../../../types/Prompts';
 
 import {
   confirmDefaultAccountPrompt,
   selectSandboxTargetAccountPrompt,
   selectDeveloperTestTargetAccountPrompt,
   confirmUseExistingDeveloperTestAccountPrompt,
-} from './prompts/projectDevTargetAccountPrompt';
-import { confirmPrompt } from './prompts/promptUtils';
-import { validateSandboxUsageLimits, getAvailableSyncTypes } from './sandboxes';
-import { syncSandbox } from './sandboxSync';
-import { validateDevTestAccountUsageLimits } from './developerTestAccounts';
-import { uiCommandReference, uiLine, uiAccountDescription } from './ui';
-import SpinniesManager from './ui/SpinniesManager';
-import { i18n } from './lang';
-import { EXIT_CODES } from './enums/exitCodes';
-import { trackCommandMetadataUsage } from './usageTracking';
+} from '../../prompts/projectDevTargetAccountPrompt';
+import { confirmPrompt } from '../../prompts/promptUtils';
+import {
+  validateSandboxUsageLimits,
+  getAvailableSyncTypes,
+} from '../../sandboxes';
+import { syncSandbox } from '../../sandboxSync';
+import { validateDevTestAccountUsageLimits } from '../../developerTestAccounts';
+import { uiCommandReference, uiLine, uiAccountDescription } from '../../ui';
+import SpinniesManager from '../../ui/SpinniesManager';
+import { EXIT_CODES } from '../../enums/exitCodes';
+import { trackCommandMetadataUsage } from '../../usageTracking';
 import {
   isAppDeveloperAccount,
   isDeveloperTestAccount,
   isUnifiedAccount,
-} from './accountTypes';
-import { handleProjectUpload } from './projects/upload';
-import { pollProjectBuildAndDeploy } from './projects/buildAndDeploy';
+} from '../../accountTypes';
+import { handleProjectUpload } from '../../projects/upload';
+import { pollProjectBuildAndDeploy } from '../../projects/buildAndDeploy';
 import {
   PROJECT_ERROR_TYPES,
   PROJECT_BUILD_TEXT,
   PROJECT_DEPLOY_TEXT,
-} from './constants';
-import { logError, ApiErrorContext, debugError } from './errorHandlers/index';
+} from '../../constants';
+import {
+  logError,
+  ApiErrorContext,
+  debugError,
+} from '../../errorHandlers/index';
 import {
   buildSandbox,
   buildDeveloperTestAccount,
   saveAccountToConfig,
-} from './buildAccount';
-import { hubspotAccountNamePrompt } from './prompts/accountNamePrompt';
-import {
-  ProjectConfig,
-  ProjectPollResult,
-  ProjectSubtask,
-} from '../types/Projects';
-import { ProjectDevTargetAccountPromptResponse } from '../types/Prompts';
+} from '../../buildAccount';
+import { hubspotAccountNamePrompt } from '../../prompts/accountNamePrompt';
+import { lib } from '../../../lang/en';
 import { FileResult } from 'tmp';
-import { Build } from '@hubspot/local-dev-lib/types/Build';
-import { getSandboxUsageLimits } from '@hubspot/local-dev-lib/api/sandboxHubs';
-
-const i18nKey = 'lib.localDev';
 
 // If the user passed in the --account flag, confirm they want to use that account as
 // their target account, otherwise exit
@@ -71,9 +77,9 @@ export async function confirmDefaultAccountIsTarget(
 ): Promise<void> {
   if (!accountConfig.name || !accountConfig.accountType) {
     logger.error(
-      i18n(`${i18nKey}.confirmDefaultAccountIsTarget.configError`, {
-        authCommand: uiCommandReference('hs auth'),
-      })
+      lib.localDevHelpers.confirmDefaultAccountIsTarget.configError(
+        uiCommandReference('hs auth')
+      )
     );
     process.exit(EXIT_CODES.ERROR);
   }
@@ -86,12 +92,9 @@ export async function confirmDefaultAccountIsTarget(
 
   if (!useDefaultAccount) {
     logger.log(
-      i18n(
-        `${i18nKey}.confirmDefaultAccountIsTarget.declineDefaultAccountExplanation`,
-        {
-          useCommand: uiCommandReference('hs accounts use'),
-          devCommand: uiCommandReference('hs project dev'),
-        }
+      lib.localDevHelpers.confirmDefaultAccountIsTarget.declineDefaultAccountExplanation(
+        uiCommandReference('hs accounts use'),
+        uiCommandReference('hs project dev')
       )
     );
     process.exit(EXIT_CODES.SUCCESS);
@@ -114,18 +117,18 @@ export async function checkIfDefaultAccountIsSupported(
     )
   ) {
     logger.error(
-      i18n(`${i18nKey}.checkIfDefaultAccountIsSupported.publicApp`, {
-        useCommand: uiCommandReference('hs accounts use'),
-        authCommand: uiCommandReference('hs auth'),
-      })
+      lib.localDevHelpers.checkIfDefaultAccountIsSupported.publicApp(
+        uiCommandReference('hs accounts use'),
+        uiCommandReference('hs auth')
+      )
     );
     process.exit(EXIT_CODES.SUCCESS);
   } else if (!hasPublicApps && isAppDeveloperAccount(accountConfig)) {
     logger.error(
-      i18n(`${i18nKey}.checkIfDefaultAccountIsSupported.privateApp`, {
-        useCommand: uiCommandReference('hs accounts use'),
-        authCommand: uiCommandReference('hs auth'),
-      })
+      lib.localDevHelpers.checkIfDefaultAccountIsSupported.privateApp(
+        uiCommandReference('hs accounts use'),
+        uiCommandReference('hs auth')
+      )
     );
     process.exit(EXIT_CODES.SUCCESS);
   }
@@ -137,15 +140,13 @@ export function checkIfParentAccountIsAuthed(accountConfig: CLIAccount): void {
     !getAccountConfig(accountConfig.parentAccountId)
   ) {
     logger.error(
-      i18n(`${i18nKey}.checkIfParentAccountIsAuthed.notAuthedError`, {
-        accountId: accountConfig.parentAccountId || '',
-        accountIdentifier: uiAccountDescription(
-          getAccountIdentifier(accountConfig)
-        ),
-        authCommand: uiCommandReference(
+      lib.localDevHelpers.checkIfParentAccountIsAuthed.notAuthedError(
+        uiCommandReference(
           `hs auth --account=${accountConfig.parentAccountId}`
         ),
-      })
+        accountConfig.parentAccountId || '',
+        uiAccountDescription(getAccountIdentifier(accountConfig))
+      )
     );
     process.exit(EXIT_CODES.SUCCESS);
   }
@@ -159,19 +160,19 @@ export function checkIfAccountFlagIsSupported(
   if (hasPublicApps) {
     if (!isDeveloperTestAccount(accountConfig)) {
       logger.error(
-        i18n(`${i18nKey}.validateAccountOption.invalidPublicAppAccount`, {
-          useCommand: uiCommandReference('hs accounts use'),
-          devCommand: uiCommandReference('hs project dev'),
-        })
+        lib.localDevHelpers.validateAccountOption.invalidPublicAppAccount(
+          uiCommandReference('hs accounts use'),
+          uiCommandReference('hs project dev')
+        )
       );
       process.exit(EXIT_CODES.SUCCESS);
     }
     checkIfParentAccountIsAuthed(accountConfig);
   } else if (isAppDeveloperAccount(accountConfig)) {
     logger.error(
-      i18n(`${i18nKey}.validateAccountOption.invalidPrivateAppAccount`, {
-        useCommand: uiCommandReference('hs accounts use'),
-      })
+      lib.localDevHelpers.validateAccountOption.invalidPrivateAppAccount(
+        uiCommandReference('hs accounts use')
+      )
     );
     process.exit(EXIT_CODES.SUCCESS);
   }
@@ -187,12 +188,11 @@ export async function suggestRecommendedNestedAccount(
   uiLine();
   if (hasPublicApps) {
     logger.log(
-      i18n(
-        `${i18nKey}.validateAccountOption.publicAppNonDeveloperTestAccountWarning`
-      )
+      lib.localDevHelpers.validateAccountOption
+        .publicAppNonDeveloperTestAccountWarning
     );
   } else {
-    logger.log(i18n(`${i18nKey}.validateAccountOption.nonSandboxWarning`));
+    logger.log(lib.localDevHelpers.validateAccountOption.nonSandboxWarning);
   }
   uiLine();
   logger.log();
@@ -218,18 +218,14 @@ export async function createSandboxForLocalDev(
     );
   } catch (err) {
     if (isMissingScopeError(err)) {
-      logger.error(
-        i18n('lib.sandbox.create.failure.scopes.message', {
-          accountName: accountConfig.name || accountId,
-        })
-      );
+      logger.error(lib.sandbox.create.developer.failure.scopes.message);
       const websiteOrigin = getHubSpotWebsiteOrigin(env);
       const url = `${websiteOrigin}/personal-access-key/${accountId}`;
       logger.info(
-        i18n('lib.sandbox.create.failure.scopes.instructions', {
-          accountName: accountConfig.name || accountId,
-          url,
-        })
+        lib.sandbox.create.developer.failure.scopes.instructions(
+          accountConfig.name || accountId,
+          url
+        )
       );
     } else {
       logError(err);
@@ -259,7 +255,7 @@ export async function createSandboxForLocalDev(
     const sandboxAccountConfig = getAccountConfig(result.sandbox.sandboxHubId);
 
     if (!sandboxAccountConfig) {
-      logger.error(i18n('lib.sandbox.create.failure.generic'));
+      logger.error(lib.sandbox.create.developer.failure.generic);
       process.exit(EXIT_CODES.ERROR);
     }
 
@@ -301,18 +297,14 @@ export async function createDeveloperTestAccountForLocalDev(
     }
   } catch (err) {
     if (isMissingScopeError(err)) {
-      logger.error(
-        i18n('lib.developerTestAccount.create.failure.scopes.message', {
-          accountName: accountConfig.name || accountId,
-        })
-      );
+      logger.error(lib.developerTestAccount.create.failure.scopes.message);
       const websiteOrigin = getHubSpotWebsiteOrigin(env);
       const url = `${websiteOrigin}/personal-access-key/${accountId}`;
       logger.info(
-        i18n('lib.developerTestAccount.create.failure.scopes.instructions', {
-          accountName: accountConfig.name || accountId,
-          url,
-        })
+        lib.developerTestAccount.create.failure.scopes.instructions(
+          accountConfig.name || accountId,
+          url
+        )
       );
     } else {
       logError(err);
@@ -355,12 +347,9 @@ export async function useExistingDevTestAccount(
   if (!useExistingDevTestAcct) {
     logger.log('');
     logger.log(
-      i18n(
-        `${i18nKey}.confirmDefaultAccountIsTarget.declineDefaultAccountExplanation`,
-        {
-          useCommand: uiCommandReference('hs accounts use'),
-          devCommand: uiCommandReference('hs project dev'),
-        }
+      lib.localDevHelpers.confirmDefaultAccountIsTarget.declineDefaultAccountExplanation(
+        uiCommandReference('hs accounts use'),
+        uiCommandReference('hs project dev')
       )
     );
     logger.log('');
@@ -372,10 +361,10 @@ export async function useExistingDevTestAccount(
     env
   );
   logger.success(
-    i18n(`lib.developerTestAccount.create.success.configFileUpdated`, {
-      accountName: devTestAcctConfigName,
-      authType: PERSONAL_ACCESS_KEY_AUTH_METHOD.name,
-    })
+    lib.developerTestAccount.create.success.configFileUpdated(
+      devTestAcctConfigName,
+      PERSONAL_ACCESS_KEY_AUTH_METHOD.name
+    )
   );
 }
 
@@ -390,34 +379,36 @@ export async function createNewProjectForLocalDev(
   let shouldCreateProject = shouldCreateWithoutConfirmation;
 
   if (!shouldCreateProject) {
-    const explanationString = i18n(
-      hasPublicApps
-        ? `${i18nKey}.createNewProjectForLocalDev.publicAppProjectMustExistExplanation`
-        : `${i18nKey}.createNewProjectForLocalDev.projectMustExistExplanation`,
-      {
-        accountIdentifier: uiAccountDescription(targetAccountId),
-        projectName: projectConfig.name,
-      }
+    const explanationLangFunction = hasPublicApps
+      ? lib.localDevHelpers.createNewProjectForLocalDev
+          .publicAppProjectMustExistExplanation
+      : lib.localDevHelpers.createNewProjectForLocalDev
+          .projectMustExistExplanation;
+
+    const explanationString = explanationLangFunction(
+      uiAccountDescription(targetAccountId),
+      projectConfig.name
     );
+
     logger.log();
     uiLine();
     logger.log(explanationString);
     uiLine();
 
     shouldCreateProject = await confirmPrompt(
-      i18n(`${i18nKey}.createNewProjectForLocalDev.createProject`, {
-        accountIdentifier: uiAccountDescription(targetAccountId),
-        projectName: projectConfig.name,
-      })
+      lib.localDevHelpers.createNewProjectForLocalDev.createProject(
+        projectConfig.name,
+        uiAccountDescription(targetAccountId)
+      )
     );
   }
 
   if (shouldCreateProject) {
     SpinniesManager.add('createProject', {
-      text: i18n(`${i18nKey}.createNewProjectForLocalDev.creatingProject`, {
-        accountIdentifier: uiAccountDescription(targetAccountId),
-        projectName: projectConfig.name,
-      }),
+      text: lib.localDevHelpers.createNewProjectForLocalDev.creatingProject(
+        projectConfig.name,
+        uiAccountDescription(targetAccountId)
+      ),
     });
 
     try {
@@ -426,17 +417,17 @@ export async function createNewProjectForLocalDev(
         projectConfig.name
       );
       SpinniesManager.succeed('createProject', {
-        text: i18n(`${i18nKey}.createNewProjectForLocalDev.createdProject`, {
-          accountIdentifier: uiAccountDescription(targetAccountId),
-          projectName: projectConfig.name,
-        }),
+        text: lib.localDevHelpers.createNewProjectForLocalDev.createdProject(
+          projectConfig.name,
+          uiAccountDescription(targetAccountId)
+        ),
         succeedColor: 'white',
       });
       return project;
     } catch (err) {
       SpinniesManager.fail('createProject');
       logger.log(
-        i18n(`${i18nKey}.createNewProjectForLocalDev.failedToCreateProject`)
+        lib.localDevHelpers.createNewProjectForLocalDev.failedToCreateProject
       );
       process.exit(EXIT_CODES.ERROR);
     }
@@ -444,7 +435,7 @@ export async function createNewProjectForLocalDev(
     // We cannot continue if the project does not exist in the target account
     logger.log();
     logger.log(
-      i18n(`${i18nKey}.createNewProjectForLocalDev.choseNotToCreateProject`)
+      lib.localDevHelpers.createNewProjectForLocalDev.choseNotToCreateProject
     );
     process.exit(EXIT_CODES.SUCCESS);
   }
@@ -458,9 +449,9 @@ function projectUploadCallback(
 ): Promise<ProjectPollResult> {
   if (!buildId) {
     logger.error(
-      i18n(`${i18nKey}.createInitialBuildForNewProject.initialUploadMessage`, {
-        uploadCommand: uiCommandReference('hs project upload'),
-      })
+      lib.localDevHelpers.createInitialBuildForNewProject.genericError(
+        uiCommandReference('hs project upload')
+      )
     );
     process.exit(EXIT_CODES.ERROR);
   }
@@ -488,7 +479,7 @@ export async function createInitialBuildForNewProject(
       projectConfig,
       projectDir,
       projectUploadCallback,
-      i18n(`${i18nKey}.createInitialBuildForNewProject.initialUploadMessage`),
+      lib.localDevHelpers.createInitialBuildForNewProject.initialUploadMessage,
       sendIr
     );
 
@@ -500,7 +491,7 @@ export async function createInitialBuildForNewProject(
     ) {
       logger.log();
       logger.error(
-        i18n(`${i18nKey}.createInitialBuildForNewProject.projectLockedError`)
+        lib.localDevHelpers.createInitialBuildForNewProject.projectLockedError
       );
       logger.log();
     } else {

--- a/lib/projects/ui.ts
+++ b/lib/projects/ui.ts
@@ -1,0 +1,13 @@
+import { logger } from '@hubspot/local-dev-lib/logger';
+import { FEEDBACK_INTERVAL } from '../constants';
+import { uiLine } from '../ui';
+import { lib } from '../../lang/en';
+
+export function logFeedbackMessage(buildId: number): void {
+  if (buildId > 0 && buildId % FEEDBACK_INTERVAL === 0) {
+    uiLine();
+    logger.log(lib.projects.logFeedbackMessage.feedbackHeader);
+    uiLine();
+    logger.log(lib.projects.logFeedbackMessage.feedbackMessage);
+  }
+}

--- a/lib/projects/upload.ts
+++ b/lib/projects/upload.ts
@@ -7,15 +7,13 @@ import { shouldIgnoreFile } from '@hubspot/local-dev-lib/ignoreRules';
 import { logger } from '@hubspot/local-dev-lib/logger';
 
 import SpinniesManager from '../ui/SpinniesManager';
-import { uiAccountDescription } from '../ui';
-import { i18n } from '../lang';
+import { uiAccountDescription, uiCommandReference } from '../ui';
 import { EXIT_CODES } from '../enums/exitCodes';
 import { ProjectConfig } from '../../types/Projects';
 import { isTranslationError, translate } from '@hubspot/project-parsing-lib';
 import { logError } from '../errorHandlers';
 import util from 'node:util';
-
-const i18nKey = 'lib.projectUpload';
+import { lib } from '../../lang/en';
 
 async function uploadProjectFiles(
   accountId: number,
@@ -29,10 +27,10 @@ async function uploadProjectFiles(
   const accountIdentifier = uiAccountDescription(accountId);
 
   SpinniesManager.add('upload', {
-    text: i18n(`${i18nKey}.uploadProjectFiles.add`, {
-      accountIdentifier,
+    text: lib.projectUpload.uploadProjectFiles.add(
       projectName,
-    }),
+      accountIdentifier
+    ),
     succeedColor: 'white',
   });
 
@@ -52,26 +50,23 @@ async function uploadProjectFiles(
     buildId = upload.buildId;
 
     SpinniesManager.succeed('upload', {
-      text: i18n(`${i18nKey}.uploadProjectFiles.succeed`, {
-        accountIdentifier,
+      text: lib.projectUpload.uploadProjectFiles.succeed(
         projectName,
-      }),
+        accountIdentifier
+      ),
     });
 
     if (buildId) {
       logger.debug(
-        i18n(`${i18nKey}.uploadProjectFiles.buildCreated`, {
-          buildId,
-          projectName,
-        })
+        lib.projectUpload.uploadProjectFiles.buildCreated(projectName, buildId)
       );
     }
   } catch (err) {
     SpinniesManager.fail('upload', {
-      text: i18n(`${i18nKey}.uploadProjectFiles.fail`, {
-        accountIdentifier,
+      text: lib.projectUpload.uploadProjectFiles.fail(
         projectName,
-      }),
+        accountIdentifier
+      ),
     });
 
     error = err;
@@ -106,9 +101,10 @@ export async function handleProjectUpload<T>(
   const filenames = fs.readdirSync(srcDir);
   if (!filenames || filenames.length === 0) {
     logger.log(
-      i18n(`${i18nKey}.handleProjectUpload.emptySource`, {
-        srcDir: projectConfig.srcDir,
-      })
+      lib.projectUpload.handleProjectUpload.emptySource(
+        projectConfig.srcDir,
+        uiCommandReference('hs project upload')
+      )
     );
     process.exit(EXIT_CODES.SUCCESS);
   }
@@ -116,9 +112,7 @@ export async function handleProjectUpload<T>(
   const tempFile = tmp.fileSync({ postfix: '.zip' });
 
   logger.debug(
-    i18n(`${i18nKey}.handleProjectUpload.compressing`, {
-      path: tempFile.name,
-    })
+    lib.projectUpload.handleProjectUpload.compressing(tempFile.name)
   );
 
   const output = fs.createWriteStream(tempFile.name);
@@ -127,9 +121,7 @@ export async function handleProjectUpload<T>(
   const result = new Promise<ProjectUploadResult<T>>(resolve =>
     output.on('close', async function () {
       logger.debug(
-        i18n(`${i18nKey}.handleProjectUpload.compressed`, {
-          byteCount: archive.pointer(),
-        })
+        lib.projectUpload.handleProjectUpload.compressed(archive.pointer())
       );
 
       let intermediateRepresentation;
@@ -192,9 +184,7 @@ export async function handleProjectUpload<T>(
 
       if (!isNodeModule || !loggedIgnoredNodeModule) {
         logger.debug(
-          i18n(`${i18nKey}.handleProjectUpload.fileFiltered`, {
-            filename: file.name,
-          })
+          lib.projectUpload.handleProjectUpload.fileFiltered(file.name)
         );
       }
 

--- a/lib/projects/upload.ts
+++ b/lib/projects/upload.ts
@@ -7,7 +7,7 @@ import { shouldIgnoreFile } from '@hubspot/local-dev-lib/ignoreRules';
 import { logger } from '@hubspot/local-dev-lib/logger';
 
 import SpinniesManager from '../ui/SpinniesManager';
-import { uiAccountDescription, uiCommandReference } from '../ui';
+import { uiAccountDescription } from '../ui';
 import { EXIT_CODES } from '../enums/exitCodes';
 import { ProjectConfig } from '../../types/Projects';
 import { isTranslationError, translate } from '@hubspot/project-parsing-lib';
@@ -101,10 +101,7 @@ export async function handleProjectUpload<T>(
   const filenames = fs.readdirSync(srcDir);
   if (!filenames || filenames.length === 0) {
     logger.log(
-      lib.projectUpload.handleProjectUpload.emptySource(
-        projectConfig.srcDir,
-        uiCommandReference('hs project upload')
-      )
+      lib.projectUpload.handleProjectUpload.emptySource(projectConfig.srcDir)
     );
     process.exit(EXIT_CODES.SUCCESS);
   }

--- a/lib/prompts/projectNamePrompt.ts
+++ b/lib/prompts/projectNamePrompt.ts
@@ -1,6 +1,6 @@
 import { promptUser } from './promptUtils';
 import { i18n } from '../lang';
-import { ensureProjectExists } from '../projects';
+import { ensureProjectExists } from '../projects/ensureProjectExists';
 import { uiAccountDescription } from '../ui';
 
 const i18nKey = 'lib.prompts.projectNamePrompt';


### PR DESCRIPTION
## Description and Context
The upcoming work to support the Local Dev UI will require a lot of additions to the `lib/projects` folder, so I figured now would be a good time to clean things up there a bit. This PR makes a variety of housekeeping changes
* Moves all project local dev related files from`/lib` into `lib/projects/localDev``
  * `localDev` renamed to `helpers`
  * `LocalDevManager` and `LocalDevManagerV2`
  * `DevServerManager` and `DevServerManagerV2`
* Splits up `lib/projects/index` since it wasn't actually an index file
  * Most of the functions in this file are now in `lib/projects/config`
  * `ensureProjectExists` moved to `lib/projects/ensureProjectExists`
  * `logFeedbackMessage` moved to `lib/projects/ui`
* Updates all project files to use the new lang objects
  * this surfaced a lot of lang errors, so those have now been fixed

## TODO
Due to file renaming, some files lang keys no longer match their file names. I didn't want to do even more in this PR, so we can update that at a later time if it ever becomes a problem

## Who to Notify
@brandenrodgers @kemmerle @joe-yeager 
