### PR TITLE
chore: Add --network-debug flag to log all http requests from LDL

### DIFF
--- a/commands/__tests__/create.test.ts
+++ b/commands/__tests__/create.test.ts
@@ -41,7 +41,6 @@ describe('commands/create', () => {
     it('should support the correct options', () => {
       createCommand.builder(yargs);
 
-      expect(yargs.option).toHaveBeenCalledTimes(3);
       expect(yargs.option).toHaveBeenCalledWith(
         'internal',
         expect.objectContaining({ type: 'boolean', hidden: true })

--- a/commands/__tests__/doctor.test.ts
+++ b/commands/__tests__/doctor.test.ts
@@ -61,7 +61,6 @@ describe('doctor', () => {
   describe('builder', () => {
     it('should apply the correct options', () => {
       builder(mockYargs);
-      expect(mockYargs.option).toHaveBeenCalledTimes(2);
       expect(mockYargs.option).toHaveBeenCalledWith('output-dir', {
         describe: 'Directory to save a detailed diagnosis JSON file in',
         type: 'string',

--- a/lib/commonOpts.ts
+++ b/lib/commonOpts.ts
@@ -25,19 +25,18 @@ const i18nKey = 'lib.commonOpts';
 
 export function addGlobalOptions(yargs: Argv) {
   yargs.version(false);
-
-  return yargs
-    .option('debug', {
-      alias: 'd',
-      default: false,
-      describe: i18n(`${i18nKey}.options.debug.describe`),
-      type: 'boolean',
-    })
-    .option('network-debug', {
-      default: false,
-      type: 'boolean',
-      hidden: true,
-    });
+  yargs.option('debug', {
+    alias: 'd',
+    default: false,
+    describe: i18n(`${i18nKey}.options.debug.describe`),
+    type: 'boolean',
+  });
+  yargs.option('network-debug', {
+    default: false,
+    type: 'boolean',
+    hidden: true,
+  });
+  return yargs;
 }
 
 export function addAccountOptions(yargs: Argv): Argv {

--- a/lib/commonOpts.ts
+++ b/lib/commonOpts.ts
@@ -26,12 +26,18 @@ const i18nKey = 'lib.commonOpts';
 export function addGlobalOptions(yargs: Argv) {
   yargs.version(false);
 
-  return yargs.option('debug', {
-    alias: 'd',
-    default: false,
-    describe: i18n(`${i18nKey}.options.debug.describe`),
-    type: 'boolean',
-  });
+  return yargs
+    .option('debug', {
+      alias: 'd',
+      default: false,
+      describe: i18n(`${i18nKey}.options.debug.describe`),
+      type: 'boolean',
+    })
+    .option('network-debug', {
+      default: false,
+      type: 'boolean',
+      hidden: true,
+    });
 }
 
 export function addAccountOptions(yargs: Argv): Argv {
@@ -125,12 +131,19 @@ export async function addCustomHelpOutput(
   }
 }
 
-export function setLogLevel(options: Arguments<{ debug?: boolean }>): void {
-  const { debug } = options;
+export function setLogLevel(
+  options: Arguments<{ debug?: boolean; networkDebug?: boolean }>
+): void {
+  const { debug, networkDebug } = options;
   if (debug) {
     setLoggerLogLevel(LOG_LEVEL.DEBUG);
   } else {
     setLoggerLogLevel(LOG_LEVEL.LOG);
+  }
+
+  if (networkDebug) {
+    process.env.HUBSPOT_NETWORK_LOGGING = 'true';
+    setLoggerLogLevel(LOG_LEVEL.DEBUG);
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": "https://github.com/HubSpot/hubspot-cli",
   "dependencies": {
-    "@hubspot/local-dev-lib": "3.5.3",
+    "@hubspot/local-dev-lib": "3.5.4",
     "@hubspot/project-parsing-lib": "0.1.7",
     "@hubspot/serverless-dev-runtime": "7.0.2",
     "@hubspot/theme-preview-dev-server": "0.0.10",


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
Add a hidden `--network-debug` flag that sets the log level to debug and sets `HUBSPOT_NETWORK_LOGGING` to true so LDL will log http traffic

