### PR TITLE
Fix hs project dev copy bug

### DIFF
--- a/lang/en.ts
+++ b/lang/en.ts
@@ -2681,8 +2681,7 @@ export const lib = {
       invalidPrivateAppAccount: `This project contains a private app. The account specified with the "--account" flag points to a developer account, which do not support the local development of private apps. Update the "--account" flag to point to a standard, sandbox, or developer test account, or change your default account by running ${uiCommandReference('hs accounts use')}.`,
       nonSandboxWarning: command =>
         `Testing in a sandbox is strongly recommended. To switch the target account, select an option below or run ${chalk.bold(command)} before running the command again.`,
-      publicAppNonDeveloperTestAccountWarning: () =>
-        `Local development of public apps is only supported in ${chalk.bold('developer test accounts')}.`,
+      publicAppNonDeveloperTestAccountWarning: `Local development of public apps is only supported in ${chalk.bold('developer test accounts')}.`,
     },
     createNewProjectForLocalDev: {
       projectMustExistExplanation: (projectName, accountIdentifier) =>


### PR DESCRIPTION
## Description and Context
This fixes a bug in `hs project dev` where we were logging a function rather than actual copy.

Going to look into ways to update the logger to make sure this doesn't happen again, but I'll do that in a separate PR. I think we could probably create a wrapper around the logger that, at least for `logger.log`, only accepts strings

## Who to Notify
@brandenrodgers @kemmerle @joe-yeager 
