### PR TITLE
Fix local dev logger bug

### DIFF
--- a/lib/projects/localDev/DevServerManager.ts
+++ b/lib/projects/localDev/DevServerManager.ts
@@ -1,4 +1,5 @@
 import { Environment } from '@hubspot/local-dev-lib/types/Config';
+import { logger } from '@hubspot/local-dev-lib/logger';
 import { promptUser } from '../../prompts/promptUtils';
 import { DevModeInterface as UIEDevModeInterface } from '@hubspot/ui-extensions-dev-server';
 import {
@@ -129,7 +130,7 @@ class DevServerManager {
             components: compatibleComponents,
             onUploadRequired,
             promptUser,
-            uiLogger,
+            logger,
             urls: {
               api: getHubSpotApiOrigin(env),
               web: getHubSpotWebsiteOrigin(env),

--- a/lib/projects/localDev/DevServerManagerV2.ts
+++ b/lib/projects/localDev/DevServerManagerV2.ts
@@ -1,4 +1,5 @@
 import { Environment } from '@hubspot/local-dev-lib/types/Config';
+import { logger } from '@hubspot/local-dev-lib/logger';
 import { promptUser } from '../../prompts/promptUtils';
 import { DevModeUnifiedInterface as UIEDevModeInterface } from '@hubspot/ui-extensions-dev-server';
 import {
@@ -14,7 +15,6 @@ import { getAccountConfig } from '@hubspot/local-dev-lib/config';
 import { ProjectConfig } from '../../../types/Projects';
 import { IntermediateRepresentationNodeLocalDev } from '@hubspot/project-parsing-lib/src/lib/types';
 import { lib } from '../../../lang/en';
-import { uiLogger } from '../../ui/logger';
 
 type DevServerInterface = {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
@@ -61,7 +61,7 @@ class DevServerManagerV2 {
         await serverInterface.setup({
           components: projectNodes,
           promptUser,
-          uiLogger,
+          logger,
           urls: {
             api: getHubSpotApiOrigin(env),
             web: getHubSpotWebsiteOrigin(env),


### PR DESCRIPTION
## Description and Context
When I updated the CLI to use the new `uiLogger` rather than `logger` from local dev lib, I accidentally passed `uiLogger` to the UIE dev server as well, which breaks local dev.

### Todo
It would be nice to get the CLI and UIE dev server to share types for the dev mode interface - would help prevent bugs like this from happening in the future. This would require a bit of a lift in both repos though, so going to hold off on doing that now.

## Who to Notify
@brandenrodgers @kemmerle @joe-yeager 
