### PR TITLE
fix: The auth command is failing when token.hubName is null

### DIFF
--- a/commands/auth.ts
+++ b/commands/auth.ts
@@ -132,7 +132,7 @@ export async function handler(
 
       try {
         token = await getAccessToken(configData.personalAccessKey, env);
-        defaultName = toKebabCase(token.hubName);
+        defaultName = token.hubName ? toKebabCase(token.hubName) : undefined;
 
         updatedConfig = await updateConfigWithAccessToken(
           token,

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": "https://github.com/HubSpot/hubspot-cli",
   "dependencies": {
-    "@hubspot/local-dev-lib": "3.5.4",
+    "@hubspot/local-dev-lib": "3.5.5",
     "@hubspot/project-parsing-lib": "0.1.7",
     "@hubspot/serverless-dev-runtime": "7.0.2",
     "@hubspot/theme-preview-dev-server": "0.0.10",


### PR DESCRIPTION
There are some `hs auth` failures happening when the `hubName` that gets returned with the token is null