### PR TITLE
fix: Fix platform version logs

### DIFF
--- a/lib/errorHandlers/suppressError.ts
+++ b/lib/errorHandlers/suppressError.ts
@@ -20,23 +20,17 @@ function createPlatformVersionError(
 ): void {
   let translationKey = 'unspecifiedPlatformVersion';
   let platformVersion = 'unspecified platformVersion';
-  const errorContext = err.data.context;
+  const errorContext = err?.data?.context;
 
-  switch (subCategory) {
-    case PLATFORM_VERSION_ERROR_TYPES.PLATFORM_VERSION_RETIRED:
-      translationKey = 'platformVersionRetired';
-      if (errorContext && errorContext[subCategory]) {
-        platformVersion = errorContext[subCategory];
-      }
-      break;
-    case PLATFORM_VERSION_ERROR_TYPES.PLATFORM_VERSION_SPECIFIED_DOES_NOT_EXIST:
-      translationKey = 'nonExistentPlatformVersion';
-      if (errorContext && errorContext[subCategory]) {
-        platformVersion = errorContext[subCategory];
-      }
-      break;
-    default:
-      break;
+  if (subCategory === PLATFORM_VERSION_ERROR_TYPES.PLATFORM_VERSION_RETIRED) {
+    platformVersion = errorContext?.RETIRED_PLATFORM_VERSION ?? platformVersion;
+    translationKey = 'platformVersionRetired';
+  } else if (
+    subCategory ===
+    PLATFORM_VERSION_ERROR_TYPES.PLATFORM_VERSION_SPECIFIED_DOES_NOT_EXIST
+  ) {
+    platformVersion = errorContext?.PLATFORM_VERSION ?? platformVersion;
+    translationKey = 'nonExistentPlatformVersion';
   }
 
   uiLine();
@@ -88,7 +82,7 @@ export function shouldSuppressError(
     })
   ) {
     createPlatformVersionError(
-      err.data,
+      err,
       PLATFORM_VERSION_ERROR_TYPES.PLATFORM_VERSION_NOT_SPECIFIED
     );
     return true;
@@ -100,7 +94,7 @@ export function shouldSuppressError(
     })
   ) {
     createPlatformVersionError(
-      err.data,
+      err,
       PLATFORM_VERSION_ERROR_TYPES.PLATFORM_VERSION_RETIRED
     );
     return true;
@@ -113,7 +107,7 @@ export function shouldSuppressError(
     })
   ) {
     createPlatformVersionError(
-      err.data,
+      err,
       PLATFORM_VERSION_ERROR_TYPES.PLATFORM_VERSION_SPECIFIED_DOES_NOT_EXIST
     );
     return true;


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
The errors for invalid platform versions logs were broken. 

### Before
![Screenshot 2025-05-07 at 12 11 52 PM](https://github.com/user-attachments/assets/4d5d9a5f-1542-4fac-9f2c-f64db27ce6bd)



### After

### Invalid Version
![Screenshot 2025-05-07 at 12 12 23 PM](https://github.com/user-attachments/assets/62ddddc1-cdb7-4c44-bfaa-a8ea3f3173c6)

### Retired version
![Screenshot 2025-05-07 at 12 13 03 PM](https://github.com/user-attachments/assets/eeb2c5ac-9566-42b4-ae5a-b4b4f7fbccc1)


