### PR TITLE
fix: Remove unnecessary `@ts-expect-error`

### DIFF
--- a/commands/upload.ts
+++ b/commands/upload.ts
@@ -104,7 +104,6 @@ async function handler(args: ArgumentsCamelCase<UploadArgs>): Promise<void> {
       projectRoot,
       absoluteSrcPath,
       undefined,
-      // @ts-expect-error - fieldOptions is a string or string[]
       args.fieldOptions
     ).init();
     if (fieldsJs.rejected) return;


### PR DESCRIPTION
## Description and Context
This PR removes an unnecessary `@ts-expect-error` from `/commands/upload`. 

## Screenshots
<!-- Provide images of the before and after functionality -->

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
