### PR TITLE
Fix: Bugs in `account` commands

### DIFF
--- a/commands/account/createOverride.ts
+++ b/commands/account/createOverride.ts
@@ -3,10 +3,7 @@ import path from 'path';
 import { Argv, ArgumentsCamelCase } from 'yargs';
 import { getCwd } from '@hubspot/local-dev-lib/path';
 import { logger } from '@hubspot/local-dev-lib/logger';
-import {
-  DEFAULT_ACCOUNT_OVERRIDE_FILE_NAME,
-  GLOBAL_CONFIG_PATH,
-} from '@hubspot/local-dev-lib/constants/config';
+import { DEFAULT_ACCOUNT_OVERRIDE_FILE_NAME } from '@hubspot/local-dev-lib/constants/config';
 import {
   getCWDAccountOverride,
   getDefaultAccountOverrideFilePath,
@@ -48,7 +45,6 @@ export async function handler(
       i18n(
         'commands.account.subcommands.createOverride.errors.globalConfigNotFound',
         {
-          globalConfigPath: GLOBAL_CONFIG_PATH,
           authCommand: uiCommandReference('hs account auth'),
         }
       )

--- a/commands/account/createOverride.ts
+++ b/commands/account/createOverride.ts
@@ -3,13 +3,17 @@ import path from 'path';
 import { Argv, ArgumentsCamelCase } from 'yargs';
 import { getCwd } from '@hubspot/local-dev-lib/path';
 import { logger } from '@hubspot/local-dev-lib/logger';
-import { DEFAULT_ACCOUNT_OVERRIDE_FILE_NAME } from '@hubspot/local-dev-lib/constants/config';
+import {
+  DEFAULT_ACCOUNT_OVERRIDE_FILE_NAME,
+  GLOBAL_CONFIG_PATH,
+} from '@hubspot/local-dev-lib/constants/config';
 import {
   getCWDAccountOverride,
   getDefaultAccountOverrideFilePath,
   getConfigPath,
   getAccountId,
 } from '@hubspot/local-dev-lib/config';
+import { getGlobalConfig } from '@hubspot/local-dev-lib/config/migrate';
 
 import { i18n } from '../../lib/lang';
 import { promptUser } from '../../lib/prompts/promptUtils';
@@ -18,6 +22,7 @@ import { trackCommandMetadataUsage } from '../../lib/usageTracking';
 import { selectAccountFromConfig } from '../../lib/prompts/accountsPrompt';
 import { logError } from '../../lib/errorHandlers/index';
 import { CommonArgs } from '../../types/Yargs';
+import { uiCommandReference } from '../../lib/ui';
 
 export const describe = i18n(
   'commands.account.subcommands.createOverride.describe',
@@ -36,6 +41,20 @@ export async function handler(
   args: ArgumentsCamelCase<AccountCreateOverrideArgs>
 ): Promise<void> {
   let overrideDefaultAccount = args.account;
+
+  const globalConfig = getGlobalConfig();
+  if (!globalConfig) {
+    logger.error(
+      i18n(
+        'commands.account.subcommands.createOverride.errors.globalConfigNotFound',
+        {
+          globalConfigPath: GLOBAL_CONFIG_PATH,
+          authCommand: uiCommandReference('hs account auth'),
+        }
+      )
+    );
+    process.exit(EXIT_CODES.ERROR);
+  }
 
   const accountOverride = getCWDAccountOverride();
   const overrideFilePath = getDefaultAccountOverrideFilePath();

--- a/commands/account/remove.ts
+++ b/commands/account/remove.ts
@@ -96,7 +96,7 @@ export async function handler(
 
   const accountToRemoveId = getAccountId(accountToRemove);
   let defaultAccountId;
-  if (currentDefaultAccount !== null) {
+  if (currentDefaultAccount) {
     defaultAccountId = getAccountId(currentDefaultAccount);
   }
   if (accountToRemoveId === defaultAccountId) {

--- a/commands/account/remove.ts
+++ b/commands/account/remove.ts
@@ -94,7 +94,12 @@ export async function handler(
   // Get updated version of the config
   loadConfig(getConfigPath()!);
 
-  if (accountToRemove === currentDefaultAccount) {
+  const accountToRemoveId = getAccountId(accountToRemove);
+  let defaultAccountId;
+  if (currentDefaultAccount !== null) {
+    defaultAccountId = getAccountId(currentDefaultAccount);
+  }
+  if (accountToRemoveId === defaultAccountId) {
     logger.log();
     logger.log(
       i18n(`commands.account.subcommands.remove.logs.replaceDefaultAccount`)

--- a/commands/account/removeOverride.ts
+++ b/commands/account/removeOverride.ts
@@ -6,10 +6,7 @@ import {
   getDefaultAccountOverrideFilePath,
   getAccountId,
 } from '@hubspot/local-dev-lib/config';
-import {
-  DEFAULT_ACCOUNT_OVERRIDE_FILE_NAME,
-  GLOBAL_CONFIG_PATH,
-} from '@hubspot/local-dev-lib/constants/config';
+import { DEFAULT_ACCOUNT_OVERRIDE_FILE_NAME } from '@hubspot/local-dev-lib/constants/config';
 import { getGlobalConfig } from '@hubspot/local-dev-lib/config/migrate';
 
 import { i18n } from '../../lib/lang';
@@ -42,7 +39,6 @@ export async function handler(
       i18n(
         'commands.account.subcommands.createOverride.errors.globalConfigNotFound',
         {
-          globalConfigPath: GLOBAL_CONFIG_PATH,
           authCommand: uiCommandReference('hs account auth'),
         }
       )

--- a/commands/account/removeOverride.ts
+++ b/commands/account/removeOverride.ts
@@ -6,7 +6,11 @@ import {
   getDefaultAccountOverrideFilePath,
   getAccountId,
 } from '@hubspot/local-dev-lib/config';
-import { DEFAULT_ACCOUNT_OVERRIDE_FILE_NAME } from '@hubspot/local-dev-lib/constants/config';
+import {
+  DEFAULT_ACCOUNT_OVERRIDE_FILE_NAME,
+  GLOBAL_CONFIG_PATH,
+} from '@hubspot/local-dev-lib/constants/config';
+import { getGlobalConfig } from '@hubspot/local-dev-lib/config/migrate';
 
 import { i18n } from '../../lib/lang';
 import { promptUser } from '../../lib/prompts/promptUtils';
@@ -14,6 +18,7 @@ import { trackCommandMetadataUsage } from '../../lib/usageTracking';
 import { EXIT_CODES } from '../../lib/enums/exitCodes';
 import { logError } from '../../lib/errorHandlers/index';
 import { CommonArgs } from '../../types/Yargs';
+import { uiCommandReference } from '../../lib/ui';
 
 export const describe = i18n(
   'commands.account.subcommands.removeOverride.describe',
@@ -30,6 +35,20 @@ export async function handler(
   args: ArgumentsCamelCase<RemoveOverrideArgs>
 ): Promise<void> {
   const { force } = args;
+
+  const globalConfig = getGlobalConfig();
+  if (!globalConfig) {
+    logger.error(
+      i18n(
+        'commands.account.subcommands.createOverride.errors.globalConfigNotFound',
+        {
+          globalConfigPath: GLOBAL_CONFIG_PATH,
+          authCommand: uiCommandReference('hs account auth'),
+        }
+      )
+    );
+    process.exit(EXIT_CODES.ERROR);
+  }
 
   const accountOverride = getCWDAccountOverride();
   const overrideFilePath = getDefaultAccountOverrideFilePath();

--- a/lang/en.lyaml
+++ b/lang/en.lyaml
@@ -39,7 +39,7 @@ en:
           prompts:
             replaceOverrideFile: "Replace existing account override file?"
           errors:
-            globalConfigNotFound: "A global config file could not be found at {{ globalConfigPath }}, which is required for account overrides. Please run {{ authCommand }} to create one."
+            globalConfigNotFound: "This command is only compatible with our new global config. Run {{ authCommand }} to get started."
             accountNotFound: "The specified account could not be found in the config file {{ configPath }}"
           options:
             account:
@@ -56,7 +56,7 @@ en:
           success: "Removed the default account override file."
           noOverrideFile: "No default account override file found in the current working directory. No action required."
           errors:
-            globalConfigNotFound: "A global config file could not be found at {{ globalConfigPath }}, which is required for account overrides. Please run {{ authCommand }} to create one."
+            globalConfigNotFound: "This command is only compatible with our new global config. Run {{ authCommand }} to get started."
           options:
             force:
               describe: "Skip confirmation prompt when removing the override file"

--- a/lang/en.lyaml
+++ b/lang/en.lyaml
@@ -39,6 +39,7 @@ en:
           prompts:
             replaceOverrideFile: "Replace existing account override file?"
           errors:
+            globalConfigNotFound: "A global config file could not be found at {{ globalConfigPath }}, which is required for account overrides. Please run {{ authCommand }} to create one."
             accountNotFound: "The specified account could not be found in the config file {{ configPath }}"
           options:
             account:
@@ -54,6 +55,8 @@ en:
             deleteOverrideFile: "Delete account override file?"
           success: "Removed the default account override file."
           noOverrideFile: "No default account override file found in the current working directory. No action required."
+          errors:
+            globalConfigNotFound: "A global config file could not be found at {{ globalConfigPath }}, which is required for account overrides. Please run {{ authCommand }} to create one."
           options:
             force:
               describe: "Skip confirmation prompt when removing the override file"


### PR DESCRIPTION
## Description and Context
This PR addresses bugs that I discovered when testing out this LDL [PR](https://github.com/HubSpot/hubspot-local-dev-lib/pull/270), although the two do not rely on one another. 

1) It fixes an issue with `hs account remove`. If your default account were set to the account ID (`1234567`), but you removed the account using its `name` (ie. `hs account remove accountName`), we were not properly prompting users to choose another default account. 

2) Both `hs account create-override` and `hs account remove-override` did not properly warn customers that the commands require a global config file. 

## Screenshots
New error message for `override` commands:

<img width="990" alt="Screenshot 2025-05-12 at 2 59 17 PM" src="https://github.com/user-attachments/assets/413cea17-6d69-489f-af86-32090927b4e5" />

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

- [ ] Address feedback

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@brandenrodgers @camden11 @joe-yeager 
