### PR TITLE
Fix TS build errors with local dev logging

### DIFF
--- a/lib/projects/localDev/LocalDevLogger.ts
+++ b/lib/projects/localDev/LocalDevLogger.ts
@@ -176,7 +176,7 @@ class LocalDevLogger {
   monitorConsoleOutput(): void {
     const originalStdoutWrite = process.stdout.write.bind(process.stdout);
 
-    type StdoutCallback = (err?: Error) => void;
+    type StdoutCallback = (err?: Error | null) => void;
 
     // Need to provide both overloads for process.stdout.write to satisfy TS
     function customStdoutWrite(

--- a/lib/projects/localDev/LocalDevManager.ts
+++ b/lib/projects/localDev/LocalDevManager.ts
@@ -386,7 +386,7 @@ class LocalDevManager {
   monitorConsoleOutput(): void {
     const originalStdoutWrite = process.stdout.write.bind(process.stdout);
 
-    type StdoutCallback = (err?: Error) => void;
+    type StdoutCallback = (err?: Error | null) => void;
 
     // Need to provide both overloads for process.stdout.write to satisfy TS
     function customStdoutWrite(


### PR DESCRIPTION
## Description and Context
Seems we somehow picked up an update to TS types that caused the stdout overriding during local dev to cause type errors

## Who to Notify
@kemmerle @brandenrodgers @joe-yeager 
