### PR TITLE
Fix duplicate local dev watcher calls

### DIFF
--- a/lib/projects/localDev/LocalDevWatcher.ts
+++ b/lib/projects/localDev/LocalDevWatcher.ts
@@ -36,6 +36,7 @@ class LocalDevWatcher {
   start(): void {
     this.watcher = chokidar.watch(this.localDevProcess.projectDir, {
       ignoreInitial: true,
+      ignored: ['**/dist'],
     });
 
     const configPaths = Object.values(this.localDevProcess.projectNodes).map(


### PR DESCRIPTION
## Description and Context
When working on sending websocket messages when project files changed, I noticed that every file change triggered the watcher 3 times. This is because the watcher was also picking up on changes to the compiled apps after the initial file change. This sets up the watcher to ignore the `/dist` directory, which will avoid the duplicate watcher calls and prevent us from, among other things, running the IR 3 times and sending 3 websocket messages for every file change

## Who to Notify
@brandenrodgers @kemmerle @joe-yeager 
