### PR TITLE
Improved local dev state

### DIFF
--- a/commands/project/dev/unifiedFlow.ts
+++ b/commands/project/dev/unifiedFlow.ts
@@ -29,7 +29,7 @@ import {
 } from '../../../lib/accountTypes';
 import { uiCommandReference } from '../../../lib/ui';
 import { i18n } from '../../../lib/lang';
-import LocalDevWebsocketServer from '../../../lib/projects/localDev/LocalDevWebsocketServer';
+// import LocalDevWebsocketServer from '../../../lib/projects/localDev/LocalDevWebsocketServer';
 
 export async function unifiedProjectDevFlow(
   args: ArgumentsCamelCase<ProjectDevArgs>,
@@ -175,15 +175,18 @@ export async function unifiedProjectDevFlow(
   const watcher = new LocalDevWatcher(localDevProcess);
   watcher.start();
 
-  const websocketServer = new LocalDevWebsocketServer(localDevProcess, true);
-  await websocketServer.start();
+  // const websocketServer = new LocalDevWebsocketServer(
+  //   localDevProcess,
+  //   args.debug
+  // );
+  // await websocketServer.start();
 
   handleKeypress(async key => {
     if ((key.ctrl && key.name === 'c') || key.name === 'q') {
       await Promise.all([
         localDevProcess.stop(),
         watcher.stop(),
-        websocketServer.shutdown(),
+        // websocketServer.shutdown(),
       ]);
     }
   });
@@ -191,6 +194,6 @@ export async function unifiedProjectDevFlow(
   handleExit(({ isSIGHUP }) => {
     localDevProcess.stop(!isSIGHUP);
     watcher.stop();
-    websocketServer.shutdown();
+    // websocketServer.shutdown();
   });
 }

--- a/commands/project/dev/unifiedFlow.ts
+++ b/commands/project/dev/unifiedFlow.ts
@@ -29,7 +29,7 @@ import {
 } from '../../../lib/accountTypes';
 import { uiCommandReference } from '../../../lib/ui';
 import { i18n } from '../../../lib/lang';
-// import LocalDevWebsocketServer from '../../../lib/projects/localDev/LocalDevWebsocketServer';
+import LocalDevWebsocketServer from '../../../lib/projects/localDev/LocalDevWebsocketServer';
 
 export async function unifiedProjectDevFlow(
   args: ArgumentsCamelCase<ProjectDevArgs>,
@@ -175,18 +175,15 @@ export async function unifiedProjectDevFlow(
   const watcher = new LocalDevWatcher(localDevProcess);
   watcher.start();
 
-  // const websocketServer = new LocalDevWebsocketServer(
-  //   localDevProcess,
-  //   args.debug
-  // );
-  // await websocketServer.start();
+  const websocketServer = new LocalDevWebsocketServer(localDevProcess, true);
+  await websocketServer.start();
 
   handleKeypress(async key => {
     if ((key.ctrl && key.name === 'c') || key.name === 'q') {
       await Promise.all([
         localDevProcess.stop(),
         watcher.stop(),
-        // websocketServer.shutdown(),
+        websocketServer.shutdown(),
       ]);
     }
   });
@@ -194,6 +191,6 @@ export async function unifiedProjectDevFlow(
   handleExit(({ isSIGHUP }) => {
     localDevProcess.stop(!isSIGHUP);
     watcher.stop();
-    // websocketServer.shutdown();
+    websocketServer.shutdown();
   });
 }

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -94,4 +94,5 @@ export const LOCAL_DEV_UI_WEBSOCKET_MESSAGE_TYPES = {
   UPLOAD: 'upload',
   INSTALL_DEPS: 'installDeps',
   APP_INSTALLED: 'appInstalled',
+  UPDATE_PROJECT_NODES: 'updateProjectNodes',
 } as const;

--- a/lib/projects/localDev/AppDevModeInterface.ts
+++ b/lib/projects/localDev/AppDevModeInterface.ts
@@ -17,7 +17,7 @@ import { confirmPrompt } from '../../prompts/promptUtils';
 import { AppIRNode } from '../../../types/ProjectComponents';
 import { lib } from '../../../lang/en';
 import { uiLogger } from '../../ui/logger';
-import { LocalDevState } from '../../../types/LocalDev';
+import LocalDevState from './LocalDevState';
 import LocalDevLogger from './LocalDevLogger';
 
 type AppDevModeInterfaceConstructorOptions = {

--- a/lib/projects/localDev/DevServerManagerV2.ts
+++ b/lib/projects/localDev/DevServerManagerV2.ts
@@ -12,7 +12,7 @@ import {
 import { getAccountConfig } from '@hubspot/local-dev-lib/config';
 import AppDevModeInterface from './AppDevModeInterface';
 import { lib } from '../../../lang/en';
-import { LocalDevState } from '../../../types/LocalDev';
+import LocalDevState from './LocalDevState';
 import LocalDevLogger from './LocalDevLogger';
 
 type DevServerInterface = {

--- a/lib/projects/localDev/LocalDevLogger.ts
+++ b/lib/projects/localDev/LocalDevLogger.ts
@@ -10,7 +10,7 @@ import {
   uiCommandReference,
 } from '../../ui';
 import { lib } from '../../../lang/en';
-import { LocalDevState } from '../../../types/LocalDev';
+import LocalDevState from './LocalDevState';
 import SpinniesManager from '../../ui/SpinniesManager';
 import { logError } from '../../errorHandlers';
 

--- a/lib/projects/localDev/LocalDevProcess.ts
+++ b/lib/projects/localDev/LocalDevProcess.ts
@@ -1,11 +1,9 @@
 import { IntermediateRepresentationNodeLocalDev } from '@hubspot/project-parsing-lib/src/lib/types';
 import { translateForLocalDev } from '@hubspot/project-parsing-lib';
-import { Build } from '@hubspot/local-dev-lib/types/Build';
-import { Environment } from '@hubspot/local-dev-lib/types/Config';
 import path from 'path';
 
 import { ProjectConfig, ProjectPollResult } from '../../../types/Projects';
-import { LocalDevState } from '../../../types/LocalDev';
+import LocalDevState from './LocalDevState';
 import LocalDevLogger from './LocalDevLogger';
 import DevServerManagerV2 from './DevServerManagerV2';
 import { EXIT_CODES } from '../../enums/exitCodes';
@@ -13,50 +11,14 @@ import { mapToUserFriendlyName } from '@hubspot/project-parsing-lib/src/lib/tran
 import { getProjectConfig } from '../config';
 import { handleProjectUpload } from '../upload';
 import { pollProjectBuildAndDeploy } from '../buildAndDeploy';
-
-type LocalDevProcessConstructorOptions = {
-  targetProjectAccountId: number;
-  targetTestingAccountId: number;
-  projectConfig: ProjectConfig;
-  projectDir: string;
-  projectId: number;
-  debug?: boolean;
-  deployedBuild?: Build;
-  isGithubLinked: boolean;
-  initialProjectNodes: {
-    [key: string]: IntermediateRepresentationNodeLocalDev;
-  };
-  env: Environment;
-};
+import { LocalDevStateConstructorOptions } from '../../../types/LocalDev';
 
 class LocalDevProcess {
   private state: LocalDevState;
   private _logger: LocalDevLogger;
   private devServerManager: DevServerManagerV2;
-  constructor({
-    targetProjectAccountId,
-    targetTestingAccountId,
-    projectConfig,
-    projectDir,
-    projectId,
-    debug,
-    deployedBuild,
-    isGithubLinked,
-    initialProjectNodes,
-    env,
-  }: LocalDevProcessConstructorOptions) {
-    this.state = {
-      targetProjectAccountId,
-      targetTestingAccountId,
-      projectConfig,
-      projectDir,
-      projectId,
-      debug: debug || false,
-      deployedBuild,
-      isGithubLinked,
-      projectNodes: initialProjectNodes,
-      env,
-    };
+  constructor(options: LocalDevStateConstructorOptions) {
+    this.state = new LocalDevState(options);
 
     this._logger = new LocalDevLogger(this.state);
     this.devServerManager = new DevServerManagerV2({

--- a/lib/projects/localDev/LocalDevProcess.ts
+++ b/lib/projects/localDev/LocalDevProcess.ts
@@ -11,7 +11,10 @@ import { mapToUserFriendlyName } from '@hubspot/project-parsing-lib/src/lib/tran
 import { getProjectConfig } from '../config';
 import { handleProjectUpload } from '../upload';
 import { pollProjectBuildAndDeploy } from '../buildAndDeploy';
-import { LocalDevStateConstructorOptions } from '../../../types/LocalDev';
+import {
+  LocalDevStateConstructorOptions,
+  LocalDevStateListener,
+} from '../../../types/LocalDev';
 
 class LocalDevProcess {
   private state: LocalDevState;
@@ -200,6 +203,13 @@ class LocalDevProcess {
       this.logger.uploadSuccess();
       this.logger.clearUploadWarnings();
     }
+  }
+
+  addStateListener<K extends keyof LocalDevState>(
+    key: K,
+    listener: LocalDevStateListener<K>
+  ): void {
+    this.state.addListener(key, listener);
   }
 }
 

--- a/lib/projects/localDev/LocalDevState.ts
+++ b/lib/projects/localDev/LocalDevState.ts
@@ -1,0 +1,123 @@
+import { Build } from '@hubspot/local-dev-lib/types/Build';
+import { IntermediateRepresentationNodeLocalDev } from '@hubspot/project-parsing-lib/src/lib/types';
+import { Environment } from '@hubspot/local-dev-lib/types/Config';
+import { ProjectConfig } from '../../../types/Projects';
+import { LocalDevStateConstructorOptions } from '../../../types/LocalDev';
+
+type LocalDevStateListener<K extends keyof LocalDevState> = (
+  value: LocalDevState[K]
+) => void;
+
+class LocalDevState {
+  private _targetProjectAccountId: number;
+  private _targetTestingAccountId: number;
+  private _projectConfig: ProjectConfig;
+  private _projectDir: string;
+  private _projectId: number;
+  private _debug: boolean;
+  private _deployedBuild?: Build;
+  private _isGithubLinked: boolean;
+  private _projectNodes: {
+    [key: string]: IntermediateRepresentationNodeLocalDev;
+  };
+  private _env: Environment;
+  private _listeners: {
+    [key in keyof LocalDevState]?: LocalDevStateListener<key>[];
+  };
+
+  constructor({
+    targetProjectAccountId,
+    targetTestingAccountId,
+    projectConfig,
+    projectDir,
+    projectId,
+    debug,
+    deployedBuild,
+    isGithubLinked,
+    initialProjectNodes,
+    env,
+  }: LocalDevStateConstructorOptions) {
+    this._targetProjectAccountId = targetProjectAccountId;
+    this._targetTestingAccountId = targetTestingAccountId;
+    this._projectConfig = projectConfig;
+    this._projectDir = projectDir;
+    this._projectId = projectId;
+    this._debug = debug || false;
+    this._deployedBuild = deployedBuild;
+    this._isGithubLinked = isGithubLinked;
+    this._projectNodes = initialProjectNodes;
+    this._env = env;
+
+    this._listeners = {};
+  }
+
+  private setState<K extends keyof LocalDevState>(
+    key: K,
+    value: this[K]
+  ): void {
+    this[key] = value;
+    if (this._listeners[key] && this._listeners[key].length) {
+      this._listeners[key].forEach(listener => listener(value));
+    }
+  }
+
+  get targetProjectAccountId(): number {
+    return this._targetProjectAccountId;
+  }
+
+  get targetTestingAccountId(): number {
+    return this._targetTestingAccountId;
+  }
+
+  get projectConfig(): ProjectConfig {
+    return this._projectConfig;
+  }
+
+  get projectDir(): string {
+    return this._projectDir;
+  }
+
+  get projectId(): number {
+    return this._projectId;
+  }
+
+  get debug(): boolean {
+    return this._debug;
+  }
+
+  get deployedBuild(): Build | undefined {
+    return this._deployedBuild;
+  }
+
+  get isGithubLinked(): boolean {
+    return this._isGithubLinked;
+  }
+
+  get projectNodes(): {
+    [key: string]: IntermediateRepresentationNodeLocalDev;
+  } {
+    return this._projectNodes;
+  }
+
+  set projectNodes(nodes: {
+    [key: string]: IntermediateRepresentationNodeLocalDev;
+  }) {
+    this.setState('projectNodes', nodes);
+  }
+
+  get env(): Environment {
+    return this._env;
+  }
+
+  addListener<K extends keyof LocalDevState>(
+    key: K,
+    listener: LocalDevStateListener<K>
+  ): void {
+    if (!this._listeners[key]) {
+      this._listeners[key] = [];
+    }
+    this._listeners[key].push(listener);
+  }
+}
+
+export default LocalDevState;

--- a/lib/projects/localDev/LocalDevState.ts
+++ b/lib/projects/localDev/LocalDevState.ts
@@ -65,7 +65,9 @@ class LocalDevState {
   }
 
   get projectConfig(): ProjectConfig {
-    return this._projectConfig;
+    return {
+      ...this._projectConfig,
+    };
   }
 
   get projectDir(): string {
@@ -81,7 +83,11 @@ class LocalDevState {
   }
 
   get deployedBuild(): Build | undefined {
-    return this._deployedBuild;
+    return (
+      this._deployedBuild && {
+        ...this._deployedBuild,
+      }
+    );
   }
 
   get isGithubLinked(): boolean {
@@ -91,7 +97,7 @@ class LocalDevState {
   get projectNodes(): {
     [key: string]: IntermediateRepresentationNodeLocalDev;
   } {
-    return this._projectNodes;
+    return { ...this._projectNodes };
   }
 
   set projectNodes(nodes: {

--- a/lib/projects/localDev/LocalDevState.ts
+++ b/lib/projects/localDev/LocalDevState.ts
@@ -50,13 +50,9 @@ class LocalDevState {
     this._listeners = {};
   }
 
-  private setState<K extends keyof LocalDevState>(
-    key: K,
-    value: this[K]
-  ): void {
-    this[key] = value;
+  private runListeners<K extends keyof LocalDevState>(key: K): void {
     if (this._listeners[key] && this._listeners[key].length) {
-      this._listeners[key].forEach(listener => listener(value));
+      this._listeners[key].forEach(listener => listener(this[key]));
     }
   }
 
@@ -101,7 +97,8 @@ class LocalDevState {
   set projectNodes(nodes: {
     [key: string]: IntermediateRepresentationNodeLocalDev;
   }) {
-    this.setState('projectNodes', nodes);
+    this._projectNodes = nodes;
+    this.runListeners('projectNodes');
   }
 
   get env(): Environment {

--- a/lib/projects/localDev/LocalDevState.ts
+++ b/lib/projects/localDev/LocalDevState.ts
@@ -2,11 +2,10 @@ import { Build } from '@hubspot/local-dev-lib/types/Build';
 import { IntermediateRepresentationNodeLocalDev } from '@hubspot/project-parsing-lib/src/lib/types';
 import { Environment } from '@hubspot/local-dev-lib/types/Config';
 import { ProjectConfig } from '../../../types/Projects';
-import { LocalDevStateConstructorOptions } from '../../../types/LocalDev';
-
-type LocalDevStateListener<K extends keyof LocalDevState> = (
-  value: LocalDevState[K]
-) => void;
+import {
+  LocalDevStateConstructorOptions,
+  LocalDevStateListener,
+} from '../../../types/LocalDev';
 
 class LocalDevState {
   private _targetProjectAccountId: number;

--- a/lib/projects/localDev/LocalDevWebsocketServer.ts
+++ b/lib/projects/localDev/LocalDevWebsocketServer.ts
@@ -45,6 +45,10 @@ class LocalDevWebsocketServer {
     }
   }
 
+  private sendMessage(message: LocalDevWebsocketMessage) {
+    this.websocket().send(JSON.stringify(message));
+  }
+
   private setupMessageHandlers() {
     this.websocket().on('message', data => {
       try {
@@ -80,6 +84,15 @@ class LocalDevWebsocketServer {
     });
   }
 
+  private setupStateListeners() {
+    this.localDevProcess.addStateListener('projectNodes', nodes => {
+      this.sendMessage({
+        type: LOCAL_DEV_UI_WEBSOCKET_MESSAGE_TYPES.UPDATE_PROJECT_NODES,
+        data: nodes,
+      });
+    });
+  }
+
   async start() {
     const portManagerIsRunning = await isPortManagerServerRunning();
     if (!portManagerIsRunning) {
@@ -97,6 +110,7 @@ class LocalDevWebsocketServer {
     this.server.on('connection', ws => {
       this._websocket = ws;
       this.setupMessageHandlers();
+      this.setupStateListeners();
     });
   }
 

--- a/types/LocalDev.ts
+++ b/types/LocalDev.ts
@@ -2,6 +2,7 @@ import { IntermediateRepresentationNodeLocalDev } from '@hubspot/project-parsing
 import { Build } from '@hubspot/local-dev-lib/types/Build';
 import { Environment } from '@hubspot/local-dev-lib/types/Config';
 import { ProjectConfig } from './Projects';
+import LocalDevState from '../lib/projects/localDev/LocalDevState';
 
 export type LocalDevStateConstructorOptions = {
   targetProjectAccountId: number;
@@ -22,3 +23,7 @@ export type LocalDevWebsocketMessage = {
   type: string;
   data: unknown;
 };
+
+export type LocalDevStateListener<K extends keyof LocalDevState> = (
+  value: LocalDevState[K]
+) => void;

--- a/types/LocalDev.ts
+++ b/types/LocalDev.ts
@@ -3,16 +3,16 @@ import { Build } from '@hubspot/local-dev-lib/types/Build';
 import { Environment } from '@hubspot/local-dev-lib/types/Config';
 import { ProjectConfig } from './Projects';
 
-export type LocalDevState = {
+export type LocalDevStateConstructorOptions = {
   targetProjectAccountId: number;
   targetTestingAccountId: number;
   projectConfig: ProjectConfig;
   projectDir: string;
   projectId: number;
-  debug: boolean;
+  debug?: boolean;
   deployedBuild?: Build;
   isGithubLinked: boolean;
-  projectNodes: {
+  initialProjectNodes: {
     [key: string]: IntermediateRepresentationNodeLocalDev;
   };
   env: Environment;


### PR DESCRIPTION
## Description and Context
This sets up a new class for `LocalDevState` that makes should make working with `LocalDevState` less error prone.
* All fields are private and only exposed via getters and (when applicable) setters
* Object fields are returned as copy to prevent accidental mutations
* Ability for external classes that interact with the LocalDevProcess (e.g. the dev server and watcher) to listen to and react to state changes
  * As an example, set up a listener to trigger the websocket server to send a message with updated IR object whenever changes are made. This will ensure the Local Dev UI (when it's done) will always have an up to date snapshot of local project state

## TODO
* There's still a fair bit of work to do on the websocket server, including supporting multiple connections and adding some kind of auth. This PR is _only_ to add the state object
* 

## Who to Notify
@brandenrodgers @joe-yeager @kemmerle 
