### PR TITLE
Better errors for hs create

### DIFF
--- a/commands/create.ts
+++ b/commands/create.ts
@@ -10,6 +10,8 @@ import { CreateArgs } from '../types/Cms';
 import { ArgumentsCamelCase, Argv } from 'yargs';
 import { makeYargsBuilder } from '../lib/yargsUtils';
 import { YargsCommandModule } from '../types/Yargs';
+import { EXIT_CODES } from '../lib/enums/exitCodes';
+
 const SUPPORTED_ASSET_TYPES = Object.keys(assets)
   .filter(t => !assets[t].hidden)
   .join(', ');
@@ -68,7 +70,12 @@ async function handler(args: ArgumentsCamelCase<CreateArgs>): Promise<void> {
 
   if (asset.validate && !asset.validate(argsToPass)) return;
 
-  await asset.execute(argsToPass);
+  try {
+    await asset.execute(argsToPass);
+  } catch (e) {
+    logError(e);
+    process.exit(EXIT_CODES.ERROR);
+  }
 }
 
 function createBuilder(yargs: Argv): Argv<CreateArgs> {

--- a/commands/create/app.ts
+++ b/commands/create/app.ts
@@ -5,7 +5,7 @@ const appAssetType: CreatableCmsAsset = {
   hidden: true,
   dest: ({ name, assetType }) => name || assetType,
   execute: async ({ commandArgs, dest, assetType }) => {
-    cloneGithubRepo('HubSpot/crm-card-weather-app', dest, {
+    await cloneGithubRepo('HubSpot/crm-card-weather-app', dest, {
       ...commandArgs,
       type: assetType,
     });

--- a/commands/create/react-app.ts
+++ b/commands/create/react-app.ts
@@ -5,7 +5,7 @@ const reactAppAssetType: CreatableCmsAsset = {
   hidden: false,
   dest: ({ name, assetType }) => name || assetType,
   execute: async ({ commandArgs, dest, assetType }) => {
-    cloneGithubRepo('HubSpot/cms-react-boilerplate', dest, {
+    await cloneGithubRepo('HubSpot/cms-react-boilerplate', dest, {
       ...commandArgs,
       type: assetType,
     });

--- a/commands/create/vue-app.ts
+++ b/commands/create/vue-app.ts
@@ -6,7 +6,7 @@ const vueAppAssetType: CreatableCmsAsset = {
   hidden: false,
   dest: ({ name, assetType }) => name || assetType,
   execute: async ({ commandArgs, dest, assetType }) => {
-    cloneGithubRepo('HubSpot/cms-vue-boilerplate', dest, {
+    await cloneGithubRepo('HubSpot/cms-vue-boilerplate', dest, {
       ...commandArgs,
       type: assetType,
     });

--- a/commands/create/webpack-serverless.ts
+++ b/commands/create/webpack-serverless.ts
@@ -5,7 +5,7 @@ const webpackServerlessAssetType: CreatableCmsAsset = {
   hidden: false,
   dest: ({ name, assetType }) => name || assetType,
   execute: async ({ commandArgs, dest, assetType }) => {
-    cloneGithubRepo('HubSpot/cms-webpack-serverless-boilerplate', dest, {
+    await cloneGithubRepo('HubSpot/cms-webpack-serverless-boilerplate', dest, {
       ...commandArgs,
       type: assetType,
     });

--- a/commands/create/website-theme.ts
+++ b/commands/create/website-theme.ts
@@ -1,6 +1,7 @@
 import { cloneGithubRepo } from '@hubspot/local-dev-lib/github';
 import { getIsInProject } from '../../lib/projects/config';
 import { CreatableCmsAsset } from '../../types/Cms';
+
 const PROJECT_BOILERPLATE_BRANCH = 'cms-boilerplate-developer-projects';
 
 const websiteThemeAssetType: CreatableCmsAsset = {
@@ -12,7 +13,8 @@ const websiteThemeAssetType: CreatableCmsAsset = {
     if (isInProject) {
       commandArgs.branch = PROJECT_BOILERPLATE_BRANCH;
     }
-    cloneGithubRepo('HubSpot/cms-theme-boilerplate', dest, {
+
+    await cloneGithubRepo('HubSpot/cms-theme-boilerplate', dest, {
       ...commandArgs,
       type: assetType,
       sourceDir: 'src',


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->

I noticed we were logging the entire axios response object whenever the clone GH repo request failed. This wraps them all in a try catch and makes sure that we're waiting for the responses.

## Screenshots
<!-- Provide images of the before and after functionality -->

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
