### PR TITLE
Fixing some type issues in deploy tests

### DIFF
--- a/commands/project/__tests__/deploy.test.ts
+++ b/commands/project/__tests__/deploy.test.ts
@@ -3,6 +3,7 @@ import yargs, { Argv, ArgumentsCamelCase } from 'yargs';
 import chalk from 'chalk';
 import * as configUtils from '@hubspot/local-dev-lib/config';
 import { logger } from '@hubspot/local-dev-lib/logger';
+import { Project } from '@hubspot/local-dev-lib/types/Project';
 import * as projectApiUtils from '@hubspot/local-dev-lib/api/projects';
 import * as ui from '../../../lib/ui';
 import {
@@ -161,12 +162,10 @@ describe('commands/project/deploy', () => {
         return text;
       });
       getAccountConfigSpy.mockReturnValue({ accountType, env: 'qa' });
-      fetchProjectSpy.mockResolvedValue(
-        mockHubSpotHttpResponse(exampleProject)
+      fetchProjectSpy.mockReturnValue(
+        mockHubSpotHttpResponse<Project>(exampleProject)
       );
-      deployProjectSpy.mockResolvedValue(
-        mockHubSpotHttpResponse(deployDetails)
-      );
+      deployProjectSpy.mockReturnValue(mockHubSpotHttpResponse(deployDetails));
 
       // Spy on process.exit so our tests don't close when it's called
       // @ts-expect-error Doesn't match the actual signature because then the linter complains about unused variables
@@ -249,7 +248,7 @@ describe('commands/project/deploy', () => {
     });
 
     it('should log an error and exit when latest build is not defined', async () => {
-      fetchProjectSpy.mockResolvedValue(mockHubSpotHttpResponse({}));
+      fetchProjectSpy.mockReturnValue(mockHubSpotHttpResponse({}));
       await projectDeployCommand.handler(args);
       expect(logger.error).toHaveBeenCalledTimes(1);
       expect(logger.error).toHaveBeenCalledWith(

--- a/lib/testUtils.ts
+++ b/lib/testUtils.ts
@@ -1,4 +1,5 @@
-import { AxiosResponse, AxiosHeaders } from 'axios';
+import { AxiosHeaders } from 'axios';
+import { HubSpotPromise } from '@hubspot/local-dev-lib/types/Http';
 import { HubSpotHttpError } from '@hubspot/local-dev-lib/models/HubSpotHttpError';
 
 type MockErrorResponse = {
@@ -12,8 +13,8 @@ type MockErrorResponse = {
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const mockHubSpotHttpResponse = (data: any): AxiosResponse => {
-  return {
+export function mockHubSpotHttpResponse<T>(data?: any): HubSpotPromise<T> {
+  return Promise.resolve({
     data,
     status: 200,
     statusText: 'OK',
@@ -21,14 +22,14 @@ export const mockHubSpotHttpResponse = (data: any): AxiosResponse => {
     config: {
       headers: new AxiosHeaders(),
     },
-  };
-};
+  });
+}
 
-export const mockHubSpotHttpError = (
+export function mockHubSpotHttpError(
   message: string,
   response: MockErrorResponse
-): HubSpotHttpError => {
+): HubSpotHttpError {
   return new HubSpotHttpError(message, {
     cause: { isAxiosError: true, response },
   });
-};
+}


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->

The `fetchProjectSpy` and  `deployProjectSpy` overrides were showing type errors because they're expecting a `HubSpotPromise` as a return type

## Screenshots
<!-- Provide images of the before and after functionality -->

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
