### PR TITLE
Update hs feedback destination

### DIFF
--- a/commands/__tests__/feedback.test.ts
+++ b/commands/__tests__/feedback.test.ts
@@ -1,11 +1,9 @@
 import yargs, { Argv } from 'yargs';
+import * as commonOpts from '../../lib/commonOpts';
 import feedbackCommand from '../feedback';
 
 jest.mock('yargs');
-
-const optionsSpy = jest
-  .spyOn(yargs as Argv, 'options')
-  .mockReturnValue(yargs as Argv);
+jest.mock('../../lib/commonOpts');
 
 describe('commands/feedback', () => {
   describe('command', () => {
@@ -24,11 +22,8 @@ describe('commands/feedback', () => {
     it('should support the correct options', () => {
       feedbackCommand.builder(yargs as Argv);
 
-      expect(optionsSpy).toHaveBeenCalledTimes(1);
-      expect(optionsSpy).toHaveBeenCalledWith({
-        bug: expect.objectContaining({ type: 'boolean' }),
-        general: expect.objectContaining({ type: 'boolean' }),
-      });
+      expect(commonOpts.addGlobalOptions).toHaveBeenCalledTimes(1);
+      expect(commonOpts.addGlobalOptions).toHaveBeenCalledWith(yargs);
     });
   });
 });

--- a/commands/feedback.ts
+++ b/commands/feedback.ts
@@ -20,7 +20,7 @@ async function handler() {
   );
 
   if (!shouldOpen) {
-    logger.error(
+    logger.log(
       i18n(`commands.project.subcommands.feedback.error`, {
         url: uiLink('the developer feedback form', FEEDBACK_URL),
       })

--- a/commands/feedback.ts
+++ b/commands/feedback.ts
@@ -1,77 +1,44 @@
-import { Argv, ArgumentsCamelCase } from 'yargs';
+import { Argv } from 'yargs';
 import open from 'open';
 import { i18n } from '../lib/lang';
 import { logger } from '@hubspot/local-dev-lib/logger';
-import { confirmPrompt, listPrompt } from '../lib/prompts/promptUtils';
+import { confirmPrompt } from '../lib/prompts/promptUtils';
 import { CommonArgs, YargsCommandModule } from '../types/Yargs';
 import { makeYargsBuilder } from '../lib/yargsUtils';
 import { EXIT_CODES } from '../lib/enums/exitCodes';
-
-const FEEDBACK_OPTIONS = {
-  BUG: 'bug',
-  GENERAL: 'general',
-};
-const FEEDBACK_URLS = {
-  BUG: 'https://github.com/HubSpot/hubspot-cli/issues/new',
-  GENERAL:
-    'https://docs.google.com/forms/d/e/1FAIpQLSejZZewYzuH3oKBU01tseX-cSWOUsTHLTr-YsiMGpzwcvgIMg/viewform?usp=sf_link',
-};
+import { uiLink } from '../lib/ui';
+const FEEDBACK_URL = 'https://developers.hubspot.com/feedback';
 
 const command = 'feedback';
 const describe = i18n(`commands.project.subcommands.feedback.describe`);
 
-type FeedbackArgs = CommonArgs & { bug?: boolean; general?: boolean };
+type FeedbackArgs = CommonArgs;
 
-async function handler(args: ArgumentsCamelCase<FeedbackArgs>) {
-  const { bug: bugFlag, general: generalFlag } = args;
-  const usedTypeFlag = bugFlag !== generalFlag;
-
-  await listPrompt(
-    i18n(`commands.project.subcommands.feedback.feedbackType.prompt`),
-    {
-      choices: Object.values(FEEDBACK_OPTIONS).map(option => ({
-        name: i18n(
-          `commands.project.subcommands.feedback.feedbackType.${option}`
-        ),
-        value: option,
-      })),
-      when: !usedTypeFlag,
-    }
-  );
+async function handler() {
   const shouldOpen = await confirmPrompt(
-    i18n(`commands.project.subcommands.feedback.openPrompt`),
-    {
-      when: !usedTypeFlag,
-    }
+    i18n(`commands.project.subcommands.feedback.openPrompt`)
   );
 
-  if (shouldOpen || usedTypeFlag) {
-    // NOTE: for now, all feedback should go to the hubspot-cli repository
-    const url = FEEDBACK_URLS.BUG;
-    open(url, { url: true });
-    logger.success(
-      i18n(`commands.project.subcommands.feedback.success`, { url })
+  if (!shouldOpen) {
+    logger.error(
+      i18n(`commands.project.subcommands.feedback.error`, {
+        url: uiLink('the developer feedback form', FEEDBACK_URL),
+      })
     );
+    process.exit(EXIT_CODES.ERROR);
   }
+
+  open(FEEDBACK_URL, { url: true });
+  logger.success(
+    i18n(`commands.project.subcommands.feedback.success`, {
+      url: uiLink('the developer feedback form', FEEDBACK_URL),
+    })
+  );
+
   process.exit(EXIT_CODES.SUCCESS);
 }
 
 function feedbackBuilder(yargs: Argv): Argv<FeedbackArgs> {
-  yargs.options({
-    bug: {
-      describe: i18n(
-        `commands.project.subcommands.feedback.options.bug.describe`
-      ),
-      type: 'boolean',
-    },
-    general: {
-      describe: i18n(
-        `commands.project.subcommands.feedback.options.general.describe`
-      ),
-      type: 'boolean',
-    },
-  });
-
   return yargs as Argv<FeedbackArgs>;
 }
 

--- a/lang/en.lyaml
+++ b/lang/en.lyaml
@@ -853,18 +853,10 @@ en:
             default: "Opens the projects page for the specified account"
           success: "Successfully opened \"{{ projectName }}\""
         feedback:
-          describe: "Leave feedback on HubSpot projects or file a bug report."
-          feedbackType:
-            prompt: "What type of feedback would you like to leave?"
-            bug: "[--bug] Report a bug"
-            general: "[--general] Tell us about your experience with HubSpot's developer tools"
-          openPrompt: "Create a Github issue in your browser?"
+          describe: "Leave feedback or file a bug report."
+          openPrompt: "Open the feedback form in your browser?"
           success: "We opened {{ url }} in your browser."
-          options:
-            bug:
-              describe: "Open Github issues in your browser to report a bug."
-            general:
-              describe: "Open Github issues in your browser to give feedback."
+          error: "Navigate to {{ url }} to leave feedback."
         installDeps:
           help:
             describe: "Install the dependencies for your project, or add a dependency to a subcomponent of a project."

--- a/lang/en.ts
+++ b/lang/en.ts
@@ -1430,23 +1430,12 @@ export const commands = {
       success: (projectName: string) => `Successfully opened "${projectName}"`,
     },
     feedback: {
-      describe: 'Leave feedback on HubSpot projects or file a bug report.',
-      feedbackType: {
-        prompt: 'What type of feedback would you like to leave?',
-        bug: '[--bug] Report a bug',
-        general:
-          "[--general] Tell us about your experience with HubSpot's developer tools",
-      },
-      openPrompt: 'Create a Github issue in your browser?',
-      success: (url: string) => `We opened ${url} in your browser.`,
-      options: {
-        bug: {
-          describe: 'Open Github issues in your browser to report a bug.',
-        },
-        general: {
-          describe: 'Open Github issues in your browser to give feedback.',
-        },
-      },
+      describe: 'Leave feedback or file a bug report.',
+      openPrompt: 'Open the feedback form in your browser?',
+      success: (url: string) =>
+        `We opened ${uiLink('the developer feedback form', url)} in your browser.`,
+      error: (url: string) =>
+        `Navigate to ${uiLink('the developer feedback form', url)} to leave feedback.`,
     },
     installDeps: {
       help: {


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->

`hs feedback` will now send the user here: https://developers.hubspot.com/feedback

This removes the options, but this isn't a command that would ever be used as a part of an automated workflow. So I don't think this warrants a breaking change.

## Screenshots
<!-- Provide images of the before and after functionality -->

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
