### PR TITLE
Upload projects to test accounts in hs project dev

### DIFF
--- a/commands/project/dev/deprecatedFlow.ts
+++ b/commands/project/dev/deprecatedFlow.ts
@@ -1,7 +1,11 @@
 import { ArgumentsCamelCase } from 'yargs';
 import { logger } from '@hubspot/local-dev-lib/logger';
-import { getConfigAccounts, getEnv } from '@hubspot/local-dev-lib/config';
-import { CLIAccount } from '@hubspot/local-dev-lib/types/Accounts';
+import {
+  getAccountConfig,
+  getConfigAccounts,
+  getEnv,
+} from '@hubspot/local-dev-lib/config';
+
 import { getValidEnv } from '@hubspot/local-dev-lib/environment';
 
 import {
@@ -34,7 +38,7 @@ import { ProjectDevArgs } from '../../../types/Yargs';
 
 export async function deprecatedProjectDevFlow(
   args: ArgumentsCamelCase<ProjectDevArgs>,
-  accountConfig: CLIAccount,
+  accountId: number,
   projectConfig: ProjectConfig,
   projectDir: string
 ): Promise<void> {
@@ -46,6 +50,17 @@ export async function deprecatedProjectDevFlow(
   const componentTypes = getProjectComponentTypes(runnableComponents);
   const hasPrivateApps = !!componentTypes[ComponentTypes.PrivateApp];
   const hasPublicApps = !!componentTypes[ComponentTypes.PublicApp];
+
+  const accountConfig = getAccountConfig(accountId);
+  if (!accountConfig) {
+    logger.error(
+      i18n('commands.project.subcommands.dev.errors.noAccount', {
+        accountId: accountId,
+        authCommand: uiCommandReference('hs auth'),
+      })
+    );
+    process.exit(EXIT_CODES.ERROR);
+  }
 
   if (runnableComponents.length === 0) {
     logger.error(
@@ -126,7 +141,7 @@ export async function deprecatedProjectDevFlow(
       notInConfigAccount,
     } = await suggestRecommendedNestedAccount(
       accounts,
-      accountConfig,
+      accountId,
       hasPublicApps
     );
 

--- a/commands/project/dev/deprecatedFlow.ts
+++ b/commands/project/dev/deprecatedFlow.ts
@@ -36,12 +36,19 @@ import { isSandbox, isDeveloperTestAccount } from '../../../lib/accountTypes';
 import { ensureProjectExists } from '../../../lib/projects/ensureProjectExists';
 import { ProjectDevArgs } from '../../../types/Yargs';
 
-export async function deprecatedProjectDevFlow(
-  args: ArgumentsCamelCase<ProjectDevArgs>,
-  accountId: number,
-  projectConfig: ProjectConfig,
-  projectDir: string
-): Promise<void> {
+type DeprecatedProjectDevFlowArgs = {
+  args: ArgumentsCamelCase<ProjectDevArgs>;
+  accountId: number;
+  projectConfig: ProjectConfig;
+  projectDir: string;
+};
+
+export async function deprecatedProjectDevFlow({
+  args,
+  accountId,
+  projectConfig,
+  projectDir,
+}: DeprecatedProjectDevFlowArgs): Promise<void> {
   const { providedAccountId, derivedAccountId } = args;
   const env = getValidEnv(getEnv(derivedAccountId));
 

--- a/commands/project/dev/index.ts
+++ b/commands/project/dev/index.ts
@@ -31,8 +31,8 @@ async function handler(
   const {
     derivedAccountId,
     providedAccountId,
-    targetTestingAccount,
-    targetProjectAccount,
+    testingAccount,
+    projectAccount,
   } = args;
 
   const { projectConfig, projectDir } = await getProjectConfig();
@@ -47,21 +47,21 @@ async function handler(
 
   // If either targetTestingAccount or targetProjectAccount is provided, the other must be provided
   if (
-    (targetTestingAccount && !targetProjectAccount) ||
-    (targetProjectAccount && !targetTestingAccount)
+    (testingAccount && !projectAccount) ||
+    (projectAccount && !testingAccount)
   ) {
-    uiLogger.error('TODO');
+    uiLogger.error(commands.project.dev.errors.invalidAccountFlags);
     process.exit(EXIT_CODES.ERROR);
   }
 
   // Legacy projects do not support targetTestingAccount and targetProjectAccount
-  if (targetTestingAccount && targetProjectAccount && !useV3) {
-    uiLogger.error('TODO');
+  if (testingAccount && projectAccount && !useV3) {
+    uiLogger.error(commands.project.dev.errors.unsupportedAccountFlags);
     process.exit(EXIT_CODES.ERROR);
   }
 
   let targetProjectAccountId =
-    providedAccountId || getAccountId(targetProjectAccount);
+    providedAccountId || getAccountId(projectAccount);
 
   let profile: HsProfileFile | undefined;
 
@@ -91,7 +91,7 @@ async function handler(
   }
 
   const targetTestingAccountId =
-    getAccountId(targetTestingAccount) || targetProjectAccountId;
+    getAccountId(testingAccount) || targetProjectAccountId;
 
   trackCommandUsage('project-dev', {}, targetProjectAccountId);
 
@@ -100,21 +100,21 @@ async function handler(
   uiLogger.log(commands.project.dev.logs.learnMoreLocalDevServer);
 
   if (useV3) {
-    await unifiedProjectDevFlow(
+    await unifiedProjectDevFlow({
       args,
-      targetProjectAccountId,
-      targetTestingAccountId,
+      initialTargetProjectAccountId: targetProjectAccountId,
+      initialTargetTestingAccountId: targetTestingAccountId,
       projectConfig,
       projectDir,
-      profile
-    );
+      profileConfig: profile,
+    });
   } else {
-    await deprecatedProjectDevFlow(
+    await deprecatedProjectDevFlow({
       args,
-      targetProjectAccountId,
+      accountId: targetProjectAccountId,
       projectConfig,
-      projectDir
-    );
+      projectDir,
+    });
   }
 }
 
@@ -128,14 +128,12 @@ function projectDevBuilder(yargs: Argv): Argv<ProjectDevArgs> {
 
   yargs.options('targetTestingAccount', {
     type: 'string',
-    // TODO: We may want to add messaging that this only works on certain platform versions
     description: commands.project.dev.options.targetTestingAccount,
     hidden: true,
   });
 
   yargs.options('targetProjectAccount', {
     type: 'string',
-    // TODO: We may want to add messaging that this only works on certain platform versions
     description: commands.project.dev.options.targetProjectAccount,
     hidden: true,
   });

--- a/commands/project/dev/index.ts
+++ b/commands/project/dev/index.ts
@@ -61,7 +61,7 @@ async function handler(
   }
 
   let targetProjectAccountId =
-    providedAccountId || getAccountId(projectAccount);
+    providedAccountId || (projectAccount && getAccountId(projectAccount));
 
   let profile: HsProfileFile | undefined;
 
@@ -91,7 +91,7 @@ async function handler(
   }
 
   const targetTestingAccountId =
-    getAccountId(testingAccount) || targetProjectAccountId;
+    (testingAccount && getAccountId(testingAccount)) || targetProjectAccountId;
 
   trackCommandUsage('project-dev', {}, targetProjectAccountId);
 

--- a/commands/project/dev/index.ts
+++ b/commands/project/dev/index.ts
@@ -61,7 +61,8 @@ async function handler(
   }
 
   let targetProjectAccountId =
-    providedAccountId || (projectAccount && getAccountId(projectAccount));
+    (providedAccountId && derivedAccountId) ||
+    (projectAccount && getAccountId(projectAccount));
 
   let profile: HsProfileFile | undefined;
 

--- a/commands/project/dev/index.ts
+++ b/commands/project/dev/index.ts
@@ -20,6 +20,7 @@ import {
   exitIfUsingProfiles,
 } from '../../../lib/projectProfiles';
 import { commands } from '../../../lang/en';
+import { getAccountId } from '@hubspot/local-dev-lib/config';
 
 const command = 'dev';
 const describe = uiBetaTag(commands.project.dev.describe, false);
@@ -59,7 +60,8 @@ async function handler(
     process.exit(EXIT_CODES.ERROR);
   }
 
-  let targetProjectAccountId = providedAccountId || targetProjectAccount;
+  let targetProjectAccountId =
+    providedAccountId || getAccountId(targetProjectAccount);
 
   let profile: HsProfileFile | undefined;
 
@@ -88,7 +90,8 @@ async function handler(
     targetProjectAccountId = derivedAccountId;
   }
 
-  const targetTestingAccountId = targetTestingAccount || targetProjectAccountId;
+  const targetTestingAccountId =
+    getAccountId(targetTestingAccount) || targetProjectAccountId;
 
   trackCommandUsage('project-dev', {}, targetProjectAccountId);
 

--- a/commands/project/dev/unifiedFlow.ts
+++ b/commands/project/dev/unifiedFlow.ts
@@ -72,7 +72,6 @@ export async function unifiedProjectDevFlow(
     return process.exit(EXIT_CODES.ERROR);
   }
 
-  // @TODO Do we need to do more than this or leave it to the dev servers?
   if (!Object.keys(projectNodes).length) {
     logger.error(
       i18n(`commands.project.subcommands.dev.errors.noRunnableComponents`, {
@@ -83,16 +82,14 @@ export async function unifiedProjectDevFlow(
     process.exit(EXIT_CODES.SUCCESS);
   }
 
-  // @TODO Validate component types (i.e. previously you could not have both private and public apps)
-
   const accounts = getConfigAccounts();
 
   // TODO Ideally this should require the user to target a Combined account
   // For now, check if the account is either developer or standard
-  const derivedAccountIsRecommendedType =
+  const derivedAccountIsCompatible =
     isAppDeveloperAccount(accountConfig) || isStandardAccount(accountConfig);
 
-  if (!derivedAccountIsRecommendedType && !profileConfig) {
+  if (!derivedAccountIsCompatible && !profileConfig) {
     logger.error(
       i18n(`commands.project.subcommands.dev.errors.invalidUnifiedAppsAccount`),
       {

--- a/commands/project/dev/unifiedFlow.ts
+++ b/commands/project/dev/unifiedFlow.ts
@@ -31,14 +31,23 @@ import { commands } from '../../../lang/en';
 import { isDeveloperTestAccount, isSandbox } from '../../../lib/accountTypes';
 // import LocalDevWebsocketServer from '../../../lib/projects/localDev/LocalDevWebsocketServer';
 
-export async function unifiedProjectDevFlow(
-  args: ArgumentsCamelCase<ProjectDevArgs>,
-  initialTargetProjectAccountId: number,
-  initialTargetTestingAccountId: number,
-  projectConfig: ProjectConfig,
-  projectDir: string,
-  profileConfig?: HsProfileFile
-): Promise<void> {
+type UnifiedProjectDevFlowArgs = {
+  args: ArgumentsCamelCase<ProjectDevArgs>;
+  initialTargetProjectAccountId: number;
+  initialTargetTestingAccountId: number;
+  projectConfig: ProjectConfig;
+  projectDir: string;
+  profileConfig?: HsProfileFile;
+};
+
+export async function unifiedProjectDevFlow({
+  args,
+  initialTargetProjectAccountId,
+  initialTargetTestingAccountId,
+  projectConfig,
+  projectDir,
+  profileConfig,
+}: UnifiedProjectDevFlowArgs): Promise<void> {
   const env = getValidEnv(getEnv(initialTargetProjectAccountId));
 
   let projectNodes;

--- a/lang/en.ts
+++ b/lang/en.ts
@@ -1011,14 +1011,13 @@ export const commands = {
           `No accounts found in your config. Run ${chalk.bold(authCommand)} to configure a HubSpot account with the CLI.`,
         invalidProjectComponents:
           'Projects cannot contain both private and public apps. Move your apps to separate projects before attempting local development.',
-        noRunnableComponents: (command: string) =>
-          `No supported components were found in this project. Run ${chalk.bold(command)} to see a list of available components and add one to your project.`,
+        noRunnableComponents: `No supported components were found in this project. Run ${uiCommandReference('hs project add')} to see a list of available components and add one to your project.`,
       },
       examples: {
         default: 'Start local dev for the current project',
       },
       options: {
-        targetProjectAccount: 'The id of the account to upload your projec to',
+        targetProjectAccount: 'The id of the account to upload your project to',
         targetTestingAccount:
           'The id of the account to install apps and test on',
         profile: 'The name of the profile to use',

--- a/lang/en.ts
+++ b/lang/en.ts
@@ -997,14 +997,16 @@ export const commands = {
         betaMessage: 'HubSpot projects local development',
         placeholderAccountSelection:
           'Using default account as target account (for now)',
-        learnMoreLocalDevServer:
+        learnMoreLocalDevServer: uiLink(
           'Learn more about the projects local dev server',
+          'https://developers.hubspot.com/docs/platform/project-cli-commands#start-a-local-development-server'
+        ),
       },
       errors: {
         noProjectConfig:
           'No project detected. Please run this command again from a project directory.',
-        noAccount: (accountId: string, authCommand: string) =>
-          `An error occurred while reading account ${accountId} from your config. Run ${chalk.bold(authCommand)} to re-auth this account.`,
+        noAccount: (accountId: number) =>
+          `An error occurred while reading account ${accountId} from your config. Run ${uiCommandReference('hs auth')} to re-auth this account.`,
         noAccountsInConfig: (authCommand: string) =>
           `No accounts found in your config. Run ${chalk.bold(authCommand)} to configure a HubSpot account with the CLI.`,
         invalidProjectComponents:
@@ -1014,6 +1016,12 @@ export const commands = {
       },
       examples: {
         default: 'Start local dev for the current project',
+      },
+      options: {
+        targetProjectAccount: 'The id of the account to upload your projec to',
+        targetTestingAccount:
+          'The id of the account to install apps and test on',
+        profile: 'The name of the profile to use',
       },
     },
     create: {

--- a/lang/en.ts
+++ b/lang/en.ts
@@ -1012,14 +1012,19 @@ export const commands = {
         invalidProjectComponents:
           'Projects cannot contain both private and public apps. Move your apps to separate projects before attempting local development.',
         noRunnableComponents: `No supported components were found in this project. Run ${uiCommandReference('hs project add')} to see a list of available components and add one to your project.`,
+        invalidAccountFlags:
+          'Must specify both --projectAccount and --testingAccount flags. To use the same account for both, use the --account flag.',
+        unsupportedAccountFlags:
+          'The --projectAccount and --testingAccount flags are not supported for projects created with platform versions before 2025.2.',
       },
       examples: {
         default: 'Start local dev for the current project',
       },
       options: {
-        targetProjectAccount: 'The id of the account to upload your project to',
+        targetProjectAccount:
+          'The id of the account to upload your project to. Only compatible with platform versions 2025.2 and above.',
         targetTestingAccount:
-          'The id of the account to install apps and test on',
+          'The id of the account to install apps and test on. Only compatible with platform versions 2025.2 and above.',
         profile: 'The name of the profile to use',
       },
     },

--- a/lib/projects/localDev/helpers.ts
+++ b/lib/projects/localDev/helpers.ts
@@ -163,7 +163,7 @@ export function checkIfAccountFlagIsSupported(
 // If the user isn't using the recommended account type, prompt them to use or create one
 export async function suggestRecommendedNestedAccount(
   accounts: CLIAccount[],
-  accountConfig: CLIAccount,
+  parentAccountId: number,
   hasPublicApps: boolean
 ): Promise<ProjectDevTargetAccountPromptResponse> {
   uiLogger.log('');
@@ -183,7 +183,7 @@ export async function suggestRecommendedNestedAccount(
     ? selectDeveloperTestTargetAccountPrompt
     : selectSandboxTargetAccountPrompt;
 
-  return targetAccountPrompt(accounts, accountConfig);
+  return targetAccountPrompt(accounts, parentAccountId);
 }
 
 // Create a new sandbox and return its accountId

--- a/types/Yargs.ts
+++ b/types/Yargs.ts
@@ -35,8 +35,8 @@ export type ProjectDevArgs = CommonArgs &
   ConfigArgs &
   EnvironmentArgs & {
     profile?: string;
-    targetTestingAccount?: number | string;
-    targetProjectAccount?: number | string;
+    testingAccount?: number | string;
+    projectAccount?: number | string;
   };
 
 export type TestingArgs = {

--- a/types/Yargs.ts
+++ b/types/Yargs.ts
@@ -35,8 +35,8 @@ export type ProjectDevArgs = CommonArgs &
   ConfigArgs &
   EnvironmentArgs & {
     profile?: string;
-    targetTestingAccount?: number;
-    targetProjectAccount?: number;
+    targetTestingAccount?: number | string;
+    targetProjectAccount?: number | string;
   };
 
 export type TestingArgs = {

--- a/types/Yargs.ts
+++ b/types/Yargs.ts
@@ -35,6 +35,8 @@ export type ProjectDevArgs = CommonArgs &
   ConfigArgs &
   EnvironmentArgs & {
     profile?: string;
+    targetTestingAccount?: number;
+    targetProjectAccount?: number;
   };
 
 export type TestingArgs = {


### PR DESCRIPTION
## Description and Context
This uploads the `hs project dev` flow for platform versions `2025.2` and above to default to uploading projects to the developer test account chosen for testing. It also allows users to go through the dev flow with a test account as their default account,  and will skip the account selection prompt in this case.

## Testing
There are unfortunately still a few pain points with this flow, especially when using a new developer test account. Here's what you current need to do to get through the new `hs project dev` flows that this PR enables

#### New developer test account
Also applicable for existing developer test accounts that your project hasn't been uploaded to yet
1. Use a standard account with unified apps beta access as your default account
2. When prompted, create a new developer test account. After the account is created, you'll be prompted to upload your project.
3. Before uploading, ungate your new test account for `Developers:UnifiedApps:PrivateBeta`
4. Proceed with uploading your project. Next, you'll be prompted to install your app
5. Before attempting to install your app, update your backend with the client id and secret from your newly created app
6. Install your app in your test acconut
7. Proceed with local development

#### Separate project account and testing account
You may want to run `hs project dev` and test on an account other than the one where the project lives (similar to the current default flow). To do this, run `hs project dev --targetProjectAccount=[project account id or name] --targetTestingAccount=[testing account id or name]`


## TODO
The next step of this work is supporting sandboxes in the account selection prompt. This will be added in another PR

## Who to Notify
@brandenrodgers @joe-yeager
