### PR TITLE
[WIP] Support dev on dev sandbox accounts if the portal has access

### DIFF
--- a/commands/project/dev/unifiedFlow.ts
+++ b/commands/project/dev/unifiedFlow.ts
@@ -3,6 +3,7 @@ import util from 'util';
 import { ArgumentsCamelCase } from 'yargs';
 import { logger } from '@hubspot/local-dev-lib/logger';
 import { getAccountIdentifier } from '@hubspot/local-dev-lib/config/getAccountIdentifier';
+import { HUBSPOT_ACCOUNT_TYPES } from '@hubspot/local-dev-lib/constants/config';
 import { isTranslationError } from '@hubspot/project-parsing-lib/src/lib/errors';
 import { translateForLocalDev } from '@hubspot/project-parsing-lib';
 import { HsProfileFile } from '@hubspot/project-parsing-lib/src/lib/types';
@@ -19,8 +20,12 @@ import {
   createNewProjectForLocalDev,
   useExistingDevTestAccount,
   createDeveloperTestAccountForLocalDev,
+  selectAccountTypePrompt,
 } from '../../../lib/projects/localDev/helpers';
-import { selectDeveloperTestTargetAccountPrompt } from '../../../lib/prompts/projectDevTargetAccountPrompt';
+import {
+  selectDeveloperTestTargetAccountPrompt,
+  selectSandboxTargetAccountPrompt,
+} from '../../../lib/prompts/projectDevTargetAccountPrompt';
 import SpinniesManager from '../../../lib/ui/SpinniesManager';
 import LocalDevProcess from '../../../lib/projects/localDev/LocalDevProcess';
 import LocalDevWatcher from '../../../lib/projects/localDev/LocalDevWatcher';
@@ -29,7 +34,7 @@ import {
   isAppDeveloperAccount,
   isStandardAccount,
 } from '../../../lib/accountTypes';
-import { uiCommandReference } from '../../../lib/ui';
+import { uiCommandReference, uiLine, uiLink } from '../../../lib/ui';
 import { i18n } from '../../../lib/lang';
 // import LocalDevWebsocketServer from '../../../lib/projects/localDev/LocalDevWebsocketServer';
 
@@ -94,10 +99,12 @@ export async function unifiedProjectDevFlow(
 
   if (!derivedAccountIsRecommendedType && !profileConfig) {
     logger.error(
-      i18n(`commands.project.subcommands.dev.errors.invalidUnifiedAppsAccount`),
-      {
-        authCommand: uiCommandReference('hs auth'),
-      }
+      i18n(
+        `commands.project.subcommands.dev.errors.invalidUnifiedAppsAccount`,
+        {
+          authCommand: uiCommandReference('hs account use'),
+        }
+      )
     );
     process.exit(EXIT_CODES.SUCCESS);
   }
@@ -108,25 +115,53 @@ export async function unifiedProjectDevFlow(
     // Bypass the prompt for the testing account if the user has a profile configured
     targetTestingAccountId = profileConfig.accountId;
   } else {
-    const devAccountPromptResponse =
-      await selectDeveloperTestTargetAccountPrompt(accounts!, accountConfig);
+    logger.log('');
+    uiLine();
+    logger.log(
+      i18n(`commands.project.subcommands.dev.logs.accountTypeInformation`)
+    );
+    logger.log('');
+    logger.log(
+      i18n(`commands.project.subcommands.dev.logs.learnMoreMessage`, {
+        learnMoreLink: uiLink(
+          i18n(`commands.project.subcommands.dev.logs.learnMoreLink`),
+          'https://developers.hubspot.com/docs/getting-started/account-types'
+        ),
+      })
+    );
+    uiLine();
+    logger.log('');
 
-    targetTestingAccountId = devAccountPromptResponse.targetAccountId;
+    const accountType = await selectAccountTypePrompt(accountConfig);
 
-    if (!!devAccountPromptResponse.notInConfigAccount) {
-      // When the developer test account isn't configured in the CLI config yet
-      // Walk the user through adding the account's PAK to the config
-      await useExistingDevTestAccount(
-        env,
-        devAccountPromptResponse.notInConfigAccount
-      );
-    } else if (devAccountPromptResponse.createNestedAccount) {
-      // Create a new developer test account and automatically add it to the CLI config
-      targetTestingAccountId = await createDeveloperTestAccountForLocalDev(
-        targetProjectAccountId,
-        accountConfig,
-        env
-      );
+    if (accountType === HUBSPOT_ACCOUNT_TYPES.DEVELOPER_TEST) {
+      const devAccountPromptResponse =
+        await selectDeveloperTestTargetAccountPrompt(accounts!, accountConfig);
+
+      targetTestingAccountId = devAccountPromptResponse.targetAccountId;
+
+      if (!!devAccountPromptResponse.notInConfigAccount) {
+        // When the developer test account isn't configured in the CLI config yet
+        // Walk the user through adding the account's PAK to the config
+        await useExistingDevTestAccount(
+          env,
+          devAccountPromptResponse.notInConfigAccount
+        );
+      } else if (devAccountPromptResponse.createNestedAccount) {
+        // Create a new developer test account and automatically add it to the CLI config
+        targetTestingAccountId = await createDeveloperTestAccountForLocalDev(
+          targetProjectAccountId,
+          accountConfig,
+          env
+        );
+      }
+    } else if (accountType === HUBSPOT_ACCOUNT_TYPES.DEVELOPMENT_SANDBOX) {
+      const sandboxAccountPromptResponse =
+        await selectSandboxTargetAccountPrompt(accounts!, accountConfig);
+
+      targetTestingAccountId = sandboxAccountPromptResponse.targetAccountId;
+    } else {
+      targetTestingAccountId = targetProjectAccountId;
     }
   }
 

--- a/lang/en.lyaml
+++ b/lang/en.lyaml
@@ -593,6 +593,9 @@ en:
             betaMessage: "HubSpot projects local development"
             placeholderAccountSelection: "Using default account as target account (for now)"
             learnMoreLocalDevServer: "Learn more about the projects local dev server"
+            accountTypeInformation: "Testing in a developer test account is strongly recommended, but you can use a sandbox account if your plan allows you to create one."
+            learnMoreMessage: "Visit our {{ learnMoreLink }} to learn more."
+            learnMoreLink: "docs on Developer Test and Sandbox accounts "
           errors:
             noProjectConfig: "No project detected. Please run this command again from a project directory."
             noAccount: "An error occurred while reading account {{ accountId }} from your config. Run {{ authCommand }} to re-auth this account."
@@ -1349,7 +1352,6 @@ en:
       projectDevTargetAccountPrompt:
         createNewSandboxOption: "<Test on a new development sandbox>"
         createNewDeveloperTestAccountOption: "<Test on a new developer test account>"
-        testOnThisAccountOption: '<Test on this account>'
         chooseDefaultAccountOption: "<{{#bold}}\U00002757{{/bold}} Test on this production account {{#bold}}\U00002757{{/bold}}>"
         promptMessage: "[--account] Choose a {{ accountType }} under {{ accountIdentifier }} to test with:"
         sandboxLimit: "Your account reached the limit of {{ limit }} development sandboxes"

--- a/lang/en.ts
+++ b/lang/en.ts
@@ -981,6 +981,9 @@ export const commands = {
           'Using default account as target account (for now)',
         learnMoreLocalDevServer:
           'Learn more about the projects local dev server',
+        accountTypeInformation:
+          'Testing in a developer test account is strongly recommended, but you can use a sandbox account if your plan allows you to create one.',
+        learnMoreMessage: `Visit our ${uiLink('docs on Developer Test and Sandbox accounts', 'https://developers.hubspot.com/docs/getting-started/account-types')} to learn more.`,
       },
       errors: {
         noProjectConfig:
@@ -2894,6 +2897,14 @@ export const lib = {
           `hs auth --account=${parentAccountId}`
         )} to authenticate the App Developer Account ${parentAccountId} associated with ${accountIdentifier}.`,
     },
+    selectAccountTypePrompt: {
+      message: '[--account] Choose the type of account to test on',
+      developerTestAccountOption: 'Test on a developer test account',
+      sandboxAccountOption: 'Test on a sandbox account',
+      sandboxAccountOptionDisabled:
+        'Disabled - requires access to sandbox accounts',
+      productionAccountOption: `<${chalk.red('!')} Test on this account ${chalk.red('!')}>`,
+    },
   },
   middleware: {
     updateNotification: {
@@ -3207,7 +3218,6 @@ export const lib = {
       createNewSandboxOption: '<Test on a new development sandbox>',
       createNewDeveloperTestAccountOption:
         '<Test on a new developer test account>',
-      testOnThisAccountOption: '<Test on this account>',
       chooseDefaultAccountOption: () =>
         `<${chalk.bold('❗')} Test on this production account ${chalk.bold('❗')}>`,
       promptMessage: (accountType: string, accountIdentifier: string) =>

--- a/lib/prompts/projectDevTargetAccountPrompt.ts
+++ b/lib/prompts/projectDevTargetAccountPrompt.ts
@@ -1,7 +1,3 @@
-import { promptUser } from './promptUtils';
-import { i18n } from '../lang';
-import { uiAccountDescription, uiCommandReference } from '../ui';
-import { isSandbox } from '../accountTypes';
 import { getAccountId } from '@hubspot/local-dev-lib/config';
 import { getSandboxUsageLimits } from '@hubspot/local-dev-lib/api/sandboxHubs';
 import {
@@ -17,10 +13,11 @@ import {
   DeveloperTestAccount,
   FetchDeveloperTestAccountsResponse,
 } from '@hubspot/local-dev-lib/types/developerTestAccounts';
-import {
-  PromptChoices,
-  ProjectDevTargetAccountPromptResponse,
-} from '../../types/Prompts';
+import { promptUser } from './promptUtils';
+import { i18n } from '../lang';
+import { uiAccountDescription, uiCommandReference } from '../ui';
+import { isSandbox } from '../accountTypes';
+import { PromptChoices } from '../../types/Prompts';
 import { EXIT_CODES } from '../enums/exitCodes';
 
 function mapNestedAccount(accountConfig: CLIAccount): {
@@ -49,6 +46,13 @@ function getNonConfigDeveloperTestAccountName(
     HUBSPOT_ACCOUNT_TYPE_STRINGS[HUBSPOT_ACCOUNT_TYPES.DEVELOPER_TEST]
   }] (${account.id})`;
 }
+
+export type ProjectDevTargetAccountPromptResponse = {
+  targetAccountId: number | null;
+  createNestedAccount: boolean;
+  parentAccountId?: number | null;
+  notInConfigAccount?: DeveloperTestAccount | null;
+};
 
 export async function selectSandboxTargetAccountPrompt(
   accounts: CLIAccount[],
@@ -199,15 +203,6 @@ export async function selectDeveloperTestTargetAccountPrompt(
         createNestedAccount: true,
       },
       disabled: disabledMessage,
-    },
-    {
-      name: i18n(
-        `lib.prompts.projectDevTargetAccountPrompt.testOnThisAccountOption`
-      ),
-      value: {
-        targetAccountId: defaultAccountId,
-        createNestedAccount: false,
-      },
     },
   ];
 

--- a/types/Prompts.ts
+++ b/types/Prompts.ts
@@ -1,5 +1,3 @@
-import { DeveloperTestAccount } from '@hubspot/local-dev-lib/types/developerTestAccounts';
-
 export type GenericPromptResponse = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any;
@@ -41,11 +39,4 @@ export type PromptConfig<T extends GenericPromptResponse> = {
   validate?: (answer?: any) => PromptOperand | Promise<PromptOperand>;
   mask?: string;
   filter?: (input: string) => string;
-};
-
-export type ProjectDevTargetAccountPromptResponse = {
-  targetAccountId: number | null;
-  createNestedAccount: boolean;
-  parentAccountId?: number | null;
-  notInConfigAccount?: DeveloperTestAccount | null;
 };


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->

Add support for selecting dev sandbox accounts during the `hs project dev` init flow if the user's account has access to them.

## Screenshots
<!-- Provide images of the before and after functionality -->

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
