### PR TITLE
Don't prompt for static apps that are already installed

### DIFF
--- a/lib/projects/localDev/AppDevModeInterface.ts
+++ b/lib/projects/localDev/AppDevModeInterface.ts
@@ -164,13 +164,6 @@ class AppDevModeInterface {
       return;
     }
 
-    // If the app is static auth, always prompt the user to install the app.
-    // We are currently going this because we have no method to determine if the static auth app
-    // is already installed in the portal
-    if (this.appNode.config.auth.type === APP_AUTH_TYPES.STATIC) {
-      return installAppPrompt(await this.getAppInstallUrl(), false);
-    }
-
     const {
       data: { isInstalledWithScopeGroups, previouslyAuthorizedScopeGroups },
     } = await fetchAppInstallationData(


### PR DESCRIPTION
## Description and Context
`localdevauth/v1/auth/install-info` now supports static auth apps, so we can remove this special case. `hs project dev` will now only open the browser to install your app if it's not already installed.

## Who to Notify
@brandenrodgers @joe-yeager 
