### PR TITLE
Update unified account check to allow all ungated accounts

### DIFF
--- a/lib/accountTypes.ts
+++ b/lib/accountTypes.ts
@@ -50,13 +50,5 @@ export async function isUnifiedAccount(account: CLIAccount): Promise<boolean> {
     return false;
   }
 
-  const isUngatedForUnifiedApps = await hasFeature(
-    accountId,
-    FEATURES.UNIFIED_APPS
-  );
-
-  return (
-    (isStandardAccount(account) || isAppDeveloperAccount(account)) &&
-    isUngatedForUnifiedApps
-  );
+  return hasFeature(accountId, FEATURES.UNIFIED_APPS);
 }


### PR DESCRIPTION
## Description and Context
This updates the `isUnifiedAccount` check to return true for all accounts that are ungated for the unified apps beta. Previously it only returned true for ungated developer and standard accounts, and false for sandbox and dev test accounts.

This was done to make sandboxes and developer test accounts compatible with `hs project dev` in the unified flow, but also affects the other places the check is done:
* `hs project clone-app`
* `hs project migrate-app`
* Legacy `hs project dev` flow for public apps.

In all of these cases, I didn't see a reason why we shouldn't support functionality for sandboxes and dev test accounts, but if anyone disagrees I can update that logic.

## Who to Notify
@brandenrodgers @joe-yeager 
