### PR TITLE
Support projectAccount and testingAccount flags + clean up unified app account logic

### DIFF
--- a/commands/project/dev/deprecatedFlow.ts
+++ b/commands/project/dev/deprecatedFlow.ts
@@ -153,7 +153,7 @@ export async function deprecatedProjectDevFlow({
 
     targetProjectAccountId = hasPublicApps
       ? parentAccountId || null
-      : targetAccountId || null;
+      : targetAccountId;
     targetTestingAccountId = targetAccountId;
 
     // Only used for developer test accounts that are not yet in the config

--- a/commands/project/dev/deprecatedFlow.ts
+++ b/commands/project/dev/deprecatedFlow.ts
@@ -1,7 +1,10 @@
 import { ArgumentsCamelCase } from 'yargs';
 import { logger } from '@hubspot/local-dev-lib/logger';
-import { getConfigAccounts, getEnv } from '@hubspot/local-dev-lib/config';
-import { CLIAccount } from '@hubspot/local-dev-lib/types/Accounts';
+import {
+  getAccountConfig,
+  getConfigAccounts,
+  getEnv,
+} from '@hubspot/local-dev-lib/config';
 import { getValidEnv } from '@hubspot/local-dev-lib/environment';
 
 import {
@@ -32,12 +35,19 @@ import { isSandbox, isDeveloperTestAccount } from '../../../lib/accountTypes';
 import { ensureProjectExists } from '../../../lib/projects/ensureProjectExists';
 import { ProjectDevArgs } from '../../../types/Yargs';
 
-export async function deprecatedProjectDevFlow(
-  args: ArgumentsCamelCase<ProjectDevArgs>,
-  accountConfig: CLIAccount,
-  projectConfig: ProjectConfig,
-  projectDir: string
-): Promise<void> {
+type DeprecatedProjectDevFlowArgs = {
+  args: ArgumentsCamelCase<ProjectDevArgs>;
+  accountId: number;
+  projectConfig: ProjectConfig;
+  projectDir: string;
+};
+
+export async function deprecatedProjectDevFlow({
+  args,
+  accountId,
+  projectConfig,
+  projectDir,
+}: DeprecatedProjectDevFlowArgs): Promise<void> {
   const { providedAccountId, derivedAccountId } = args;
   const env = getValidEnv(getEnv(derivedAccountId));
 
@@ -46,6 +56,17 @@ export async function deprecatedProjectDevFlow(
   const componentTypes = getProjectComponentTypes(runnableComponents);
   const hasPrivateApps = !!componentTypes[ComponentTypes.PrivateApp];
   const hasPublicApps = !!componentTypes[ComponentTypes.PublicApp];
+
+  const accountConfig = getAccountConfig(accountId);
+  if (!accountConfig) {
+    logger.error(
+      i18n('commands.project.subcommands.dev.errors.noAccount', {
+        accountId: accountId,
+        authCommand: uiCommandReference('hs auth'),
+      })
+    );
+    process.exit(EXIT_CODES.ERROR);
+  }
 
   if (runnableComponents.length === 0) {
     logger.error(
@@ -132,7 +153,7 @@ export async function deprecatedProjectDevFlow(
 
     targetProjectAccountId = hasPublicApps
       ? parentAccountId || null
-      : targetAccountId;
+      : targetAccountId || null;
     targetTestingAccountId = targetAccountId;
 
     // Only used for developer test accounts that are not yet in the config

--- a/commands/project/dev/index.ts
+++ b/commands/project/dev/index.ts
@@ -1,7 +1,5 @@
 import { ArgumentsCamelCase, Argv, CommandModule } from 'yargs';
 import { trackCommandUsage } from '../../../lib/usageTracking';
-import { i18n } from '../../../lib/lang';
-import { logger } from '@hubspot/local-dev-lib/logger';
 import { getAccountConfig } from '@hubspot/local-dev-lib/config';
 import { HsProfileFile } from '@hubspot/project-parsing-lib/src/lib/types';
 import {
@@ -9,13 +7,7 @@ import {
   validateProjectConfig,
 } from '../../../lib/projects/config';
 import { EXIT_CODES } from '../../../lib/enums/exitCodes';
-import {
-  uiBetaTag,
-  uiCommandReference,
-  uiLink,
-  uiLine,
-  uiAccountDescription,
-} from '../../../lib/ui';
+import { uiBetaTag, uiLine } from '../../../lib/ui';
 import { ProjectDevArgs } from '../../../types/Yargs';
 import { deprecatedProjectDevFlow } from './deprecatedFlow';
 import { unifiedProjectDevFlow } from './unifiedFlow';
@@ -27,12 +19,11 @@ import {
   logProfileHeader,
   exitIfUsingProfiles,
 } from '../../../lib/projectProfiles';
+import { commands } from '../../../lang/en';
+import { uiLogger } from '../../../lib/ui/logger';
 
 const command = 'dev';
-const describe = uiBetaTag(
-  i18n(`commands.project.subcommands.dev.describe`),
-  false
-);
+const describe = uiBetaTag(commands.project.dev.describe, false);
 
 async function handler(
   args: ArgumentsCamelCase<ProjectDevArgs>
@@ -43,12 +34,7 @@ async function handler(
   validateProjectConfig(projectConfig, projectDir);
 
   if (!projectDir) {
-    logger.error(
-      i18n(`commands.project.subcommands.dev.errors.noProjectConfig`, {
-        accountId: derivedAccountId,
-        authCommand: uiCommandReference('hs auth'),
-      })
-    );
+    uiLogger.error(commands.project.dev.errors.noProjectConfig);
     process.exit(EXIT_CODES.ERROR);
   }
 
@@ -85,22 +71,12 @@ async function handler(
 
   const accountConfig = getAccountConfig(targetAccountId);
 
-  uiBetaTag(i18n(`commands.project.subcommands.dev.logs.betaMessage`));
+  uiBetaTag(commands.project.dev.logs.betaMessage);
 
-  logger.log(
-    uiLink(
-      i18n(`commands.project.subcommands.dev.logs.learnMoreLocalDevServer`),
-      'https://developers.hubspot.com/docs/platform/project-cli-commands#start-a-local-development-server'
-    )
-  );
+  uiLogger.log(commands.project.dev.logs.learnMoreLocalDevServer);
 
   if (!accountConfig) {
-    logger.error(
-      i18n(`commands.project.subcommands.dev.errors.noAccount`, {
-        accountId: uiAccountDescription(targetAccountId),
-        authCommand: uiCommandReference('hs auth'),
-      })
-    );
+    uiLogger.error(commands.project.dev.errors.noAccount(targetAccountId));
     process.exit(EXIT_CODES.ERROR);
   }
 
@@ -126,16 +102,11 @@ function projectDevBuilder(yargs: Argv): Argv<ProjectDevArgs> {
   yargs.option('profile', {
     type: 'string',
     alias: 'p',
-    description: i18n(`commands.project.subcommands.dev.options.profile`),
+    description: commands.project.dev.options.profile,
     hidden: true,
   });
 
-  yargs.example([
-    [
-      '$0 project dev',
-      i18n(`commands.project.subcommands.dev.examples.default`),
-    ],
-  ]);
+  yargs.example([['$0 project dev', commands.project.dev.examples.default]]);
 
   yargs.conflicts('profile', 'account');
 

--- a/commands/project/dev/unifiedFlow.ts
+++ b/commands/project/dev/unifiedFlow.ts
@@ -1,7 +1,6 @@
 import path from 'path';
 import util from 'util';
 import { ArgumentsCamelCase } from 'yargs';
-import { logger } from '@hubspot/local-dev-lib/logger';
 import { getAccountIdentifier } from '@hubspot/local-dev-lib/config/getAccountIdentifier';
 import { HUBSPOT_ACCOUNT_TYPES } from '@hubspot/local-dev-lib/constants/config';
 import { isTranslationError } from '@hubspot/project-parsing-lib/src/lib/errors';
@@ -31,8 +30,10 @@ import LocalDevProcess from '../../../lib/projects/localDev/LocalDevProcess';
 import LocalDevWatcher from '../../../lib/projects/localDev/LocalDevWatcher';
 import { handleExit, handleKeypress } from '../../../lib/process';
 import { isUnifiedAccount } from '../../../lib/accountTypes';
-import { uiCommandReference, uiLine, uiLink } from '../../../lib/ui';
-import { i18n } from '../../../lib/lang';
+import { uiLine } from '../../../lib/ui';
+import { uiLogger } from '../../../lib/ui/logger';
+import { commands } from '../../../lang/en';
+
 // import LocalDevWebsocketServer from '../../../lib/projects/localDev/LocalDevWebsocketServer';
 
 export async function unifiedProjectDevFlow(
@@ -64,10 +65,10 @@ export async function unifiedProjectDevFlow(
 
     projectNodes = intermediateRepresentation.intermediateNodesIndexedByUid;
 
-    logger.debug(util.inspect(projectNodes, false, null, true));
+    uiLogger.debug(util.inspect(projectNodes, false, null, true));
   } catch (e) {
     if (isTranslationError(e)) {
-      logger.error(e.toString());
+      uiLogger.error(e.toString());
     } else {
       logError(e);
     }
@@ -76,12 +77,7 @@ export async function unifiedProjectDevFlow(
 
   // @TODO Do we need to do more than this or leave it to the dev servers?
   if (!Object.keys(projectNodes).length) {
-    logger.error(
-      i18n(`commands.project.subcommands.dev.errors.noRunnableComponents`, {
-        projectDir,
-        command: uiCommandReference('hs project add'),
-      })
-    );
+    uiLogger.error(commands.project.dev.errors.noRunnableComponents);
     process.exit(EXIT_CODES.SUCCESS);
   }
 
@@ -91,12 +87,8 @@ export async function unifiedProjectDevFlow(
   const accountIsCombined = await isUnifiedAccount(accountConfig);
 
   if (!accountIsCombined && !profileConfig) {
-    logger.log('');
-    logger.error(
-      i18n(`commands.project.subcommands.dev.errors.accountNotCombined`, {
-        accountUseCommand: uiCommandReference('hs account use'),
-      })
-    );
+    uiLogger.log('');
+    uiLogger.error(commands.project.dev.errors.accountNotCombined);
     process.exit(EXIT_CODES.ERROR);
   }
 
@@ -109,22 +101,13 @@ export async function unifiedProjectDevFlow(
     // By pass the prompt if the user explicitly provides an --account flag.
     targetTestingAccountId = targetProjectAccountId;
   } else {
-    logger.log('');
+    uiLogger.log('');
     uiLine();
-    logger.log(
-      i18n(`commands.project.subcommands.dev.logs.accountTypeInformation`)
-    );
-    logger.log('');
-    logger.log(
-      i18n(`commands.project.subcommands.dev.logs.learnMoreMessage`, {
-        learnMoreLink: uiLink(
-          i18n(`commands.project.subcommands.dev.logs.learnMoreLink`),
-          'https://developers.hubspot.com/docs/getting-started/account-types'
-        ),
-      })
-    );
+    uiLogger.log(commands.project.dev.logs.accountTypeInformation);
+    uiLogger.log('');
+    uiLogger.log(commands.project.dev.logs.learnMoreMessage);
     uiLine();
-    logger.log('');
+    uiLogger.log('');
 
     const accountType = await selectAccountTypePrompt(accountConfig);
 

--- a/commands/project/dev/unifiedFlow.ts
+++ b/commands/project/dev/unifiedFlow.ts
@@ -129,7 +129,8 @@ export async function unifiedProjectDevFlow({
           targetProjectAccountConfig
         );
 
-      targetTestingAccountId = devAccountPromptResponse.targetAccountId;
+      targetTestingAccountId =
+        devAccountPromptResponse.targetAccountId || undefined;
 
       if (!!devAccountPromptResponse.notInConfigAccount) {
         // When the developer test account isn't configured in the CLI config yet
@@ -153,7 +154,8 @@ export async function unifiedProjectDevFlow({
           targetProjectAccountConfig
         );
 
-      targetTestingAccountId = sandboxAccountPromptResponse.targetAccountId;
+      targetTestingAccountId =
+        sandboxAccountPromptResponse.targetAccountId || undefined;
     } else {
       targetTestingAccountId = targetProjectAccountId;
     }

--- a/lang/en.ts
+++ b/lang/en.ts
@@ -995,8 +995,8 @@ export const commands = {
           `No accounts found in your config. Run ${chalk.bold(authCommand)} to configure a HubSpot account with the CLI.`,
         invalidProjectComponents:
           'Projects cannot contain both private and public apps. Move your apps to separate projects before attempting local development.',
-        noRunnableComponents: (command: string) =>
-          `No supported components were found in this project. Run ${chalk.bold(command)} to see a list of available components and add one to your project.`,
+        noRunnableComponents: `No supported components were found in this project. Run ${uiCommandReference('hs project add')} to see a list of available components and add one to your project.`,
+        accountNotCombined: `Local development of Unified Apps is currently only compatible with accounts that are opted into the unified apps beta. Make sure that this account is opted in or switch accounts using ${uiCommandReference('hs account use')}.`,
       },
       examples: {
         default: 'Start local dev for the current project',

--- a/lang/en.ts
+++ b/lang/en.ts
@@ -989,8 +989,8 @@ export const commands = {
       errors: {
         noProjectConfig:
           'No project detected. Please run this command again from a project directory.',
-        noAccount: (accountId: string, authCommand: string) =>
-          `An error occurred while reading account ${accountId} from your config. Run ${chalk.bold(authCommand)} to re-auth this account.`,
+        noAccount: (accountId: number) =>
+          `An error occurred while reading account ${uiAccountDescription(accountId)} from your config. Run ${uiCommandReference('hs auth')} to re-auth this account.`,
         noAccountsInConfig: (authCommand: string) =>
           `No accounts found in your config. Run ${chalk.bold(authCommand)} to configure a HubSpot account with the CLI.`,
         invalidProjectComponents:
@@ -1000,6 +1000,9 @@ export const commands = {
       },
       examples: {
         default: 'Start local dev for the current project',
+      },
+      options: {
+        profile: 'The profile to target during local dev',
       },
     },
     create: {

--- a/lang/en.ts
+++ b/lang/en.ts
@@ -997,12 +997,22 @@ export const commands = {
           'Projects cannot contain both private and public apps. Move your apps to separate projects before attempting local development.',
         noRunnableComponents: `No supported components were found in this project. Run ${uiCommandReference('hs project add')} to see a list of available components and add one to your project.`,
         accountNotCombined: `Local development of Unified Apps is currently only compatible with accounts that are opted into the unified apps beta. Make sure that this account is opted in or switch accounts using ${uiCommandReference('hs account use')}.`,
+        invalidAccountFlags:
+          'Must specify both --projectAccount and --testingAccount flags. To use the same account for both, use the --account flag.',
+        unsupportedAccountFlagLegacy:
+          'The --projectAccount and --testingAccount flags are not supported for projects with platform versions earlier than 2025.2.',
+        unsupportedAccountFlagV3:
+          'The --account flag is is not supported supported for projects with platform versions 2025.2 and newer. User --testingAccount and --projectAccount flags to specify accounts to use for local dev',
       },
       examples: {
         default: 'Start local dev for the current project',
       },
       options: {
         profile: 'The profile to target during local dev',
+        projectAccount:
+          'The id of the account to upload your project to. Only compatible with platform versions 2025.2 and above.',
+        testingAccount:
+          'The id of the account to install apps and test on. Only compatible with platform versions 2025.2 and above.',
       },
     },
     create: {

--- a/lib/prompts/projectDevTargetAccountPrompt.ts
+++ b/lib/prompts/projectDevTargetAccountPrompt.ts
@@ -48,10 +48,10 @@ function getNonConfigDeveloperTestAccountName(
 }
 
 export type ProjectDevTargetAccountPromptResponse = {
-  targetAccountId: number | null;
+  targetAccountId?: number;
   createNestedAccount: boolean;
-  parentAccountId?: number | null;
-  notInConfigAccount?: DeveloperTestAccount | null;
+  parentAccountId?: number;
+  notInConfigAccount?: DeveloperTestAccount;
 };
 
 export async function selectSandboxTargetAccountPrompt(

--- a/lib/prompts/projectDevTargetAccountPrompt.ts
+++ b/lib/prompts/projectDevTargetAccountPrompt.ts
@@ -48,10 +48,10 @@ function getNonConfigDeveloperTestAccountName(
 }
 
 export type ProjectDevTargetAccountPromptResponse = {
-  targetAccountId?: number;
+  targetAccountId: number | null;
   createNestedAccount: boolean;
-  parentAccountId?: number;
-  notInConfigAccount?: DeveloperTestAccount;
+  parentAccountId?: number | null;
+  notInConfigAccount?: DeveloperTestAccount | null;
 };
 
 export async function selectSandboxTargetAccountPrompt(

--- a/types/Yargs.ts
+++ b/types/Yargs.ts
@@ -35,6 +35,8 @@ export type ProjectDevArgs = CommonArgs &
   ConfigArgs &
   EnvironmentArgs & {
     profile?: string;
+    testingAccount?: string | number;
+    projectAccount?: string | number;
   };
 
 export type TestingArgs = {


### PR DESCRIPTION
## Description and Context
This PR makes many of the changes from #1529 _without_ changing where projects are uploaded to:
* Adds `--projectAccount` and `--testingAccount` flags
* Removes support for `--account` flag from projects with platform version `2025.2` and above
* Converts a few files to use the new lang object
* Cleans up some of the account selection logic in `commands/dev/index` and `unfiedFlow`

### Testing
* Run `hs project dev` with the `--projectAccount` and `--testingAccount` flags and confirm testing account prompt is skipped and accounts are targeted as expected
* Run `hs project dev` without the flags and confirm flow hasn't changed
* Run projects with both old and new platform versions and make sure the correct flags are supported/unsupported

## Who to Notify
@brandenrodgers @joe-yeager 
