### PR TITLE
Rename CMS Hub to Content Hub in contentLevel descriptions

### DIFF
--- a/commands/testAccount/__tests__/create.test.ts
+++ b/commands/testAccount/__tests__/create.test.ts
@@ -103,7 +103,7 @@ describe('commands/testAccount/create', () => {
       expect(yargsMock.option).toHaveBeenCalledWith('content-level', {
         type: 'string',
         description:
-          'CMS Hub tier. Options: FREE, STARTER, PROFESSIONAL, ENTERPRISE',
+          'Content Hub tier. Options: FREE, STARTER, PROFESSIONAL, ENTERPRISE',
         choices: ACCOUNT_LEVEL_CHOICES,
       });
 

--- a/lang/en.ts
+++ b/lang/en.ts
@@ -2983,7 +2983,7 @@ export const commands = {
         salesLevel:
           'Sales Hub tier. Options: FREE, STARTER, PROFESSIONAL, ENTERPRISE',
         contentLevel:
-          'CMS Hub tier. Options: FREE, STARTER, PROFESSIONAL, ENTERPRISE',
+          'Content Hub tier. Options: FREE, STARTER, PROFESSIONAL, ENTERPRISE',
         commerceLevel:
           'Commerce Hub tier. Options: FREE, PROFESSIONAL, ENTERPRISE',
       },

--- a/mcp-server/tools/project/CreateTestAccountTool.ts
+++ b/mcp-server/tools/project/CreateTestAccountTool.ts
@@ -82,7 +82,7 @@ const inputSchema = {
     .enum(ACCOUNT_LEVEL_CHOICES)
     .optional()
     .describe(
-      `CMS Hub tier level. Options: ${ACCOUNT_LEVEL_CHOICES.join(', ')}. Defaults to ENTERPRISE if not specified.`
+      `Content Hub tier level. Options: ${ACCOUNT_LEVEL_CHOICES.join(', ')}. Defaults to ENTERPRISE if not specified.`
     ),
   commerceLevel: z
     .enum(ACCOUNT_LEVEL_CHOICES_WITHOUT_STARTER)


### PR DESCRIPTION
## Summary
- Updates `contentLevel` parameter descriptions from "CMS Hub" to "Content Hub" across the MCP tool, i18n strings, and test, reflecting the product rename.

## Test plan
- [x] Verify `hs account create-test --help` shows "Content Hub tier" for `--content-level`

🤖 Generated with [Claude Code](https://claude.com/claude-code)